### PR TITLE
fix: correct database name validation to match Neo4j naming rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -339,7 +339,7 @@ kubectl logs -n neo4j-operator-system deployment/neo4j-operator-controller-manag
 27. **TLS CA Auto-Discovery**: `buildTLSConfig()` in `internal/neo4j/client.go` loads CA from cert-manager Secret (`{name}-tls-secret`) automatically; `TrustedCASecret` is an override; `InsecureSkipVerify` is fallback only
 28. **All Client Functions Must Handle TLS**: `NewClientForEnterprise`, `NewClientForEnterpriseStandalone`, AND `NewClientForPod` all call `buildTLSConfig()`; split-brain detector uses dynamic `bolt+s://` scheme
 29. **ObservedGeneration**: Set `status.observedGeneration = latest.Generation` on every status update in both cluster and standalone controllers
-30. **Name Length Validation**: Cluster names max 56 chars (DNS label 63 minus `-server` suffix); standalone max 63 chars; database names max 65 chars, must match `^[a-zA-Z_][a-zA-Z0-9_.]*$`
+30. **Name Length Validation**: Cluster names max 56 chars (DNS label 63 minus `-server` suffix); standalone max 63 chars; database names max 65 chars, must match `^[a-zA-Z][a-zA-Z0-9.\-]*$`
 31. **serverRoles Validation**: Index must be in `[0, servers-1]`, no duplicates, cannot set ALL to SECONDARY
 32. **Standalone Diagnostics**: `collectStandaloneDiagnostics()` runs `SHOW DATABASES` when monitoring enabled and phase Ready; non-fatal like cluster diagnostics
 33. **Standalone UpgradeStrategy**: Pre-upgrade health check via `VerifyConnectivity`; `autoPauseOnFailure` blocks upgrade if health check fails; STS update strategy set from spec

--- a/internal/validation/database_validator.go
+++ b/internal/validation/database_validator.go
@@ -50,9 +50,10 @@ type DatabaseValidationResult struct {
 	Warnings []string
 }
 
-// neo4jDatabaseNamePattern matches valid Neo4j database names: starts with letter or underscore,
-// followed by alphanumeric characters, underscores, or dots.
-var neo4jDatabaseNamePattern = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_.]*$`)
+// neo4jDatabaseNamePattern matches valid Neo4j database names: starts with a letter,
+// followed by letters, digits, dots, or dashes.
+// See: https://neo4j.com/docs/operations-manual/5/database-administration/standard-databases/naming-databases/
+var neo4jDatabaseNamePattern = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9.\-]*$`)
 
 const maxDatabaseNameLength = 65
 
@@ -73,7 +74,7 @@ func validateDatabaseName(name string, fldPath *field.Path) (field.ErrorList, []
 
 	if !neo4jDatabaseNamePattern.MatchString(name) {
 		allErrs = append(allErrs, field.Invalid(fldPath, name,
-			"must start with a letter or underscore and contain only alphanumeric characters, underscores, or dots"))
+			"must start with a letter and contain only letters, digits, dots, or dashes"))
 	}
 
 	if strings.EqualFold(name, "system") {

--- a/internal/validation/database_validator_test.go
+++ b/internal/validation/database_validator_test.go
@@ -960,14 +960,31 @@ func TestValidateDatabaseName(t *testing.T) {
 			wantErrors: 0,
 		},
 		{
-			name:       "valid name with underscore prefix",
-			dbName:     "_internal",
+			name:       "valid name with dashes",
+			dbName:     "my-database",
 			wantErrors: 0,
 		},
 		{
 			name:       "valid name with dots",
 			dbName:     "my.database.v2",
 			wantErrors: 0,
+		},
+		{
+			name:       "valid name with dots and dashes",
+			dbName:     "my-db.v2",
+			wantErrors: 0,
+		},
+		{
+			name:       "invalid name with underscore",
+			dbName:     "my_database",
+			wantErrors: 1,
+			wantMsg:    "must start with a letter",
+		},
+		{
+			name:       "invalid name starts with underscore",
+			dbName:     "_internal",
+			wantErrors: 1,
+			wantMsg:    "must start with a letter",
 		},
 		{
 			name:       "empty name",
@@ -979,13 +996,13 @@ func TestValidateDatabaseName(t *testing.T) {
 			name:       "starts with number",
 			dbName:     "1badname",
 			wantErrors: 1,
-			wantMsg:    "must start with a letter or underscore",
+			wantMsg:    "must start with a letter",
 		},
 		{
-			name:       "contains hyphen",
-			dbName:     "bad-name",
+			name:       "starts with dash",
+			dbName:     "-badname",
 			wantErrors: 1,
-			wantMsg:    "must start with a letter or underscore",
+			wantMsg:    "must start with a letter",
 		},
 		{
 			name:       "reserved name system",


### PR DESCRIPTION
## Summary

- Fix database name validation regex to match [Neo4j naming conventions](https://neo4j.com/docs/operations-manual/5/database-administration/standard-databases/naming-databases/)
- **Allow dashes** (`-`) in database names — previously rejected despite being valid
- **Reject underscores** (`_`) in database names — previously allowed despite Neo4j server rejecting them

Regex changed from `^[a-zA-Z_][a-zA-Z0-9_.]*$` to `^[a-zA-Z][a-zA-Z0-9.\-]*$`

Fixes #37

## What changed

| | Old (broken) | New (correct) |
|--|---|---|
| `my-db` | Rejected | **Allowed** |
| `my_db` | Allowed | **Rejected** |
| `_internal` | Allowed | **Rejected** |
| `my.db.v2` | Allowed | Allowed |
| `mydb` | Allowed | Allowed |

**Files:**
- `internal/validation/database_validator.go` — regex + error message
- `internal/validation/database_validator_test.go` — updated/added test cases
- `CLAUDE.md` — updated documented pattern

## Test plan

- [x] `TestValidateDatabaseName` — all 12 cases pass (including new cases for dashes, underscores, dots+dashes)
- [x] Pre-commit hooks pass
- [ ] `make test-integration` — integration tests (requires Kind cluster)

🤖 Generated with [Claude Code](https://claude.com/claude-code)