### PR TITLE
fix: add trailing newline in BuildMonitoringConfig() to prevent neo4j.conf corruption

### DIFF
--- a/internal/resources/cluster.go
+++ b/internal/resources/cluster.go
@@ -1790,7 +1790,7 @@ func BuildMonitoringConfig(mon *neo4jv1alpha1.MonitoringSpec) string {
 		lines = append(lines, fmt.Sprintf("server.metrics.prefix=%s", mon.MetricsPrefix))
 	}
 
-	return strings.Join(lines, "\n")
+	return strings.Join(lines, "\n") + "\n"
 }
 
 // isNeo4jVersion526OrHigher checks if the Neo4j image is the 5.26.x semver LTS release.

--- a/internal/resources/cluster_test.go
+++ b/internal/resources/cluster_test.go
@@ -2,6 +2,7 @@ package resources_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -1089,5 +1090,25 @@ func TestBuildMonitoringConfig(t *testing.T) {
 
 		assert.NotContains(t, config, "server.metrics.filter")
 		assert.NotContains(t, config, "server.metrics.prefix")
+	})
+
+	t.Run("trailing newline prevents config corruption when metricsFilter is set", func(t *testing.T) {
+		spec := &neo4jv1alpha1.MonitoringSpec{
+			Enabled:       true,
+			MetricsFilter: "*",
+		}
+		config := resources.BuildMonitoringConfig(spec)
+
+		// Config must end with newline so subsequent config entries
+		// (from spec.config) don't concatenate onto the last line.
+		assert.True(t, strings.HasSuffix(config, "\n"),
+			"BuildMonitoringConfig must end with trailing newline, got: %q", config[len(config)-40:])
+
+		// Simulate the concatenation that happens in buildNeo4jConfigForCluster:
+		// config += BuildMonitoringConfig(...)
+		// config += fmt.Sprintf("%s=%s\n", key, value)
+		combined := config + "dbms.default_listen_address=0.0.0.0\n"
+		assert.NotContains(t, combined, "server.metrics.filter=*dbms",
+			"metricsFilter line must not be concatenated with the next config entry")
 	})
 }


### PR DESCRIPTION
## Summary

- Fix `BuildMonitoringConfig()` missing trailing newline that corrupts `neo4j.conf` when `spec.monitoring.metricsFilter` is set alongside `spec.config` entries

Fixes #36

## Root cause

`BuildMonitoringConfig()` uses `strings.Join(lines, "\n")` which does **not** append a trailing newline. When optional fields like `metricsFilter` or `metricsPrefix` are the last appended line, the result ends with e.g. `server.metrics.filter=*` (no `\n`). The caller at `cluster.go:1677` concatenates this directly with `spec.config` entries, producing:

```
server.metrics.filter=*dbms.default_listen_address=0.0.0.0
```

instead of:

```
server.metrics.filter=*
dbms.default_listen_address=0.0.0.0
```

The bug only triggers when `metricsFilter` or `metricsPrefix` is set — when omitted, the last element in the `lines` slice is an empty string `""` which produces a trailing newline after joining.

## Fix

One-line change: append `+ "\n"` to the return value of `BuildMonitoringConfig()`.

## Files changed

- `internal/resources/cluster.go` — the fix (1 line)
- `internal/resources/cluster_test.go` — added regression test that simulates the concatenation bug

## Test plan

- [x] `TestBuildMonitoringConfig` — all 4 cases pass including new regression test
- [x] Pre-commit hooks pass (golangci-lint, staticcheck, go-imports)
- [ ] `make test-integration` — integration tests (requires Kind cluster)

🤖 Generated with [Claude Code](https://claude.com/claude-code)