### PR TITLE
fix(rbac): add monitoring.coreos.com rules for ServiceMonitor and PrometheusRule

### DIFF
--- a/charts/neo4j-operator/templates/clusterrole.yaml
+++ b/charts/neo4j-operator/templates/clusterrole.yaml
@@ -206,6 +206,19 @@ rules:
   - update
   - watch
 - apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - prometheusrules
+  - servicemonitors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - route.openshift.io
   resources:
   - routes

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -127,6 +127,19 @@ rules:
   - update
   - watch
 - apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - prometheusrules
+  - servicemonitors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - neo4j.neo4j.com
   resources:
   - neo4jbackups

--- a/internal/controller/neo4jenterprisecluster_controller.go
+++ b/internal/controller/neo4jenterprisecluster_controller.go
@@ -97,6 +97,7 @@ const (
 //+kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=get;list;watch
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors;prometheusrules,verbs=get;list;watch;create;update;patch;delete
 
 func (r *Neo4jEnterpriseClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)


### PR DESCRIPTION
## Summary

- Add missing RBAC rules for `monitoring.coreos.com` API group (`servicemonitors`, `prometheusrules`)
- Fixes silent failure where ServiceMonitor and PrometheusRule resources were never created when `spec.monitoring.enabled: true`

Fixes #35

## Root cause

The operator creates `ServiceMonitor` and `PrometheusRule` resources (from `monitoring.coreos.com/v1`) when monitoring is enabled and Prometheus Operator CRDs are present. However, the ClusterRole had no rules for the `monitoring.coreos.com` API group. The Kubernetes API server returned `403 Forbidden`, and the operator silently swallowed the error — the resources simply never appeared.

The CRD availability check works (the operator correctly detects Prometheus Operator is installed), but the subsequent create/update calls fail due to missing RBAC permissions.

## Fix

Added RBAC rules in three places:

| File | Change |
|------|--------|
| `internal/controller/neo4jenterprisecluster_controller.go` | Added `+kubebuilder:rbac` marker for `monitoring.coreos.com` |
| `config/rbac/role.yaml` | Regenerated via `make manifests` |
| `charts/neo4j-operator/templates/clusterrole.yaml` | Added matching rule to Helm chart |

New RBAC rule:
```yaml
- apiGroups: ["monitoring.coreos.com"]
  resources: ["servicemonitors", "prometheusrules"]
  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
```

This mirrors the existing patterns for `cert-manager.io`, `external-secrets.io`, and `route.openshift.io` — all optional CRD-based integrations that the operator manages when available.

## Test plan

- [x] `go build ./...` — compiles
- [x] `go vet ./...` — clean
- [x] Pre-commit hooks pass
- [ ] Deploy operator with Prometheus Operator installed, verify ServiceMonitor and PrometheusRule are created when `spec.monitoring.enabled: true`
- [ ] Deploy operator **without** Prometheus Operator, verify operator gracefully skips monitoring resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)