### PR TITLE
docs: install instructions for the new Helm chart repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,62 +48,44 @@ The Operator deploys Neo4j EE v5.26+.  It supports both clustered and standalone
 
 ### Installation
 
-Installation requires cloning from source:
+1. **Install the operator** using Helm. Three supported paths:
 
-1. **Clone the repository** and checkout the latest tag:
-
+   **Helm chart repository (recommended, available from v1.8.0 onwards)**:
    ```bash
-   # Clone the repository
-   git clone https://github.com/neo4j-partners/neo4j-kubernetes-operator.git
-   cd neo4j-kubernetes-operator
-
-   # Checkout the latest release tag
-   LATEST_TAG=$(git describe --tags --abbrev=0)
-   git checkout $LATEST_TAG
-   ```
-
-2. **Install the operator** using Helm (recommended) or make targets:
-
-   **Helm Installation (Recommended)**:
-   ```bash
-   # Install using Helm chart (automatically handles RBAC)
-   helm install neo4j-operator ./charts/neo4j-operator \
+   helm repo add neo4j https://neo4j-partners.github.io/neo4j-kubernetes-operator/charts
+   helm repo update
+   helm install neo4j-operator neo4j/neo4j-operator \
      --namespace neo4j-operator-system \
      --create-namespace
    ```
+
+   **OCI registry (all releases)**:
    ```bash
-   # Install from GHCR OCI registry
    helm install neo4j-operator oci://ghcr.io/neo4j-partners/charts/neo4j-operator \
      --version <release-version> \
      --namespace neo4j-operator-system \
      --create-namespace
    ```
-   Note: use the chart version without the `v` prefix (for example, `0.2.0`).
+   Use the chart version without the `v` prefix (for example, `1.8.0`).
 
-   **Make Targets**:
+   **From a cloned repository** (testing an unreleased commit, or customising the chart locally):
    ```bash
-   # Install CRDs into your cluster
-   make install
+   git clone https://github.com/neo4j-partners/neo4j-kubernetes-operator.git
+   cd neo4j-kubernetes-operator
+   LATEST_TAG=$(git describe --tags --abbrev=0)
+   git checkout $LATEST_TAG    # or omit to install from main
 
-   # Deploy the operator (choose based on your environment)
-   make deploy-prod        # Production deployment (uses local neo4j-operator:latest image)
-   make deploy-dev         # Development deployment (uses local neo4j-operator:dev image)
-
-   # Registry-based deployment (requires cluster-admin permissions)
-   make deploy-prod-registry  # Deploy from Docker Hub registry (auto-checks RBAC)
-   make deploy-dev-registry   # Deploy dev overlay with registry image (auto-checks RBAC)
-
-   # For users without cluster-admin permissions
-   make deploy-namespace-scoped  # Deploy with namespace-only permissions (limited functionality)
+   helm install neo4j-operator ./charts/neo4j-operator \
+     --namespace neo4j-operator-system \
+     --create-namespace
    ```
 
-   **Note**:
-   - **Helm chart** automatically creates all necessary RBAC permissions
-   - **Registry deployments** automatically check and help set up RBAC permissions
-   - If you encounter permission errors, the operator will guide you through the setup process
-   - **RBAC scope**: `operatorMode=cluster` and `operatorMode=namespaces` install ClusterRole/ClusterRoleBinding; `operatorMode=namespace` installs Role/RoleBinding in a single namespace (details: docs/user_guide/operator-modes.md)
+   **Notes**:
+   - The Helm chart automatically creates all necessary RBAC permissions.
+   - **RBAC scope**: `operatorMode=cluster` and `operatorMode=namespaces` install ClusterRole/ClusterRoleBinding; `operatorMode=namespace` installs Role/RoleBinding in a single namespace (details: [docs/user_guide/operator-modes.md](docs/user_guide/operator-modes.md)).
+   - For `make`-driven installation (operator development workflow with locally built images), see [Development Installation](#development-installation) below.
 
-3. **Create admin credentials** (Required for authentication):
+2. **Create admin credentials** (Required for authentication):
 
    ```bash
    kubectl create secret generic neo4j-admin-secret \
@@ -113,7 +95,7 @@ Installation requires cloning from source:
 
    **Important**: The operator manages authentication through Kubernetes secrets. Do not set NEO4J_AUTH directly in environment variables.
 
-4. **Deploy your first Neo4j instance**:
+3. **Deploy your first Neo4j instance**:
 
    **For single-node development** (non-clustered):
 
@@ -127,7 +109,7 @@ Installation requires cloning from source:
    kubectl apply -f examples/clusters/minimal-cluster.yaml
    ```
 
-5. **Access your Neo4j instance**:
+4. **Access your Neo4j instance**:
 
    ```bash
    # For standalone deployment
@@ -139,7 +121,7 @@ Installation requires cloning from source:
 
    Open <http://localhost:7474> in your browser.
 
-6. **Verify your installation** (Optional):
+5. **Verify your installation** (Optional):
 
    ```bash
    # Run unit tests (fast, no cluster required)
@@ -457,24 +439,25 @@ make uninstall
 
 ### Development Installation
 
-For development work with locally built images:
+For contributors building the operator from source and deploying locally built images:
 
 ```bash
 # Create development cluster
 make dev-cluster
 
 # Deploy operator (uses local images by default)
-make deploy-dev   # Deploy to dev namespace with local neo4j-operator:dev image
+make deploy-dev    # Deploy with local neo4j-operator:dev image
 # or
-make deploy-prod  # Deploy to prod namespace with local neo4j-operator:latest image
+make deploy-prod   # Deploy with local neo4j-operator:latest image
 
-# Alternative: Use automated setup (detects available clusters)
+# Alternative: automated setup (detects available clusters)
 make operator-setup
 
-# Note: Production deployment now uses local images by default
+# For users without cluster-admin permissions
+make deploy-namespace-scoped
 ```
 
-For additional deployment options, see the Installation section above.
+If `make deploy-*` reports RBAC errors, the target prints the exact commands needed to grant the missing permissions. For installing the chart from a cloned repository without local image builds, see the third path under [Installation](#installation) above.
 
 ## 💡 Examples
 

--- a/charts/neo4j-operator/README.md
+++ b/charts/neo4j-operator/README.md
@@ -12,21 +12,34 @@ This Helm chart deploys the Neo4j Enterprise Operator for Kubernetes, which mana
 
 ## Installation
 
-### Add Helm Repository (when published)
+### From the Helm chart repository (recommended, available from v1.8.0 onwards)
 
 ```bash
-helm repo add neo4j-operator https://neo4j-partners.github.io/neo4j-kubernetes-operator
+helm repo add neo4j https://neo4j-partners.github.io/neo4j-kubernetes-operator/charts
 helm repo update
+
+helm install neo4j-operator neo4j/neo4j-operator \
+  --namespace neo4j-operator-system \
+  --create-namespace
 ```
 
-### Install from Source
+### From the OCI registry (all releases)
 
 ```bash
-# Clone the repository
+helm install neo4j-operator oci://ghcr.io/neo4j-partners/charts/neo4j-operator \
+  --version 1.8.0 \
+  --namespace neo4j-operator-system \
+  --create-namespace
+```
+
+Use the chart version without the `v` prefix.
+
+### From Source
+
+```bash
 git clone https://github.com/neo4j-partners/neo4j-kubernetes-operator.git
 cd neo4j-kubernetes-operator
 
-# Install the chart (automatically creates ClusterRole and RBAC permissions)
 helm install neo4j-operator ./charts/neo4j-operator \
   --namespace neo4j-operator-system \
   --create-namespace

--- a/docs/user_guide/installation.md
+++ b/docs/user_guide/installation.md
@@ -4,22 +4,80 @@ This guide provides detailed instructions for installing the Neo4j Enterprise Op
 
 ## Quick Installation
 
-### Method 1: Quick Install from GitHub Release (Recommended)
+### Method 1: Helm Chart Repository (Recommended)
 
-The fastest way to install the operator for production use is directly from a GitHub release:
+> Available from v1.8.0 onwards. The chart repository is hosted at
+> `https://neo4j-partners.github.io/neo4j-kubernetes-operator/charts` and is
+> updated automatically on every operator release.
 
 ```bash
-# Install the latest release (includes CRDs and operator)
-RELEASE_VERSION=v1.0.0  # Replace with desired version
+helm repo add neo4j https://neo4j-partners.github.io/neo4j-kubernetes-operator/charts
+helm repo update
+
+helm install neo4j-operator neo4j/neo4j-operator \
+  --namespace neo4j-operator-system \
+  --create-namespace
+```
+
+**Pin to a specific version**:
+```bash
+helm install neo4j-operator neo4j/neo4j-operator \
+  --version 1.8.0 \
+  --namespace neo4j-operator-system \
+  --create-namespace
+```
+
+**Customise installation values**:
+```bash
+# View available configuration options
+helm show values neo4j/neo4j-operator
+
+helm install neo4j-operator neo4j/neo4j-operator \
+  --namespace neo4j-operator-system \
+  --create-namespace \
+  --set resources.limits.memory=512Mi
+```
+
+**Upgrade**:
+```bash
+helm repo update
+helm upgrade neo4j-operator neo4j/neo4j-operator \
+  --namespace neo4j-operator-system
+```
+
+**Uninstall**:
+```bash
+helm uninstall neo4j-operator --namespace neo4j-operator-system
+```
+
+### Method 2: OCI Registry
+
+Available for all releases (including pre-v1.8.0). Helm 3.8 or later is required for OCI support.
+
+```bash
+helm install neo4j-operator oci://ghcr.io/neo4j-partners/charts/neo4j-operator \
+  --version 1.8.0 \
+  --namespace neo4j-operator-system \
+  --create-namespace
+```
+
+Use the chart version without the `v` prefix (for example, `1.8.0`).
+
+### Method 3: Quick Install from GitHub Release
+
+For environments where running `helm` is inconvenient, every release also publishes a single kubectl-applyable YAML bundle:
+
+```bash
+RELEASE_VERSION=v1.8.0  # Replace with desired version
 
 kubectl apply -f https://github.com/neo4j-partners/neo4j-kubernetes-operator/releases/download/${RELEASE_VERSION}/neo4j-kubernetes-operator-complete.yaml
 ```
 
 **What this installs**:
 - Custom Resource Definitions (CRDs)
-- Operator Deployment (using multi-arch images from ghcr.io)
+- Operator Deployment (multi-arch images from ghcr.io)
 - All required RBAC permissions (ClusterRole, ClusterRoleBinding, ServiceAccount)
-- Deployed to `neo4j-operator-system` namespace
+- Deployed to the `neo4j-operator-system` namespace
 
 **To find available releases**:
 ```bash
@@ -28,59 +86,30 @@ kubectl apply -f https://github.com/neo4j-partners/neo4j-kubernetes-operator/rel
 gh release list --repo neo4j-partners/neo4j-kubernetes-operator
 ```
 
-**CRDs Only Installation** (if you want to manage the operator deployment separately):
+**CRDs only** (manage the operator deployment separately):
 ```bash
 kubectl apply -f https://github.com/neo4j-partners/neo4j-kubernetes-operator/releases/download/${RELEASE_VERSION}/neo4j-kubernetes-operator.yaml
 ```
 
-**Supported Architectures**: linux/amd64, linux/arm64
+**Supported architectures**: linux/amd64, linux/arm64
 
-### Method 2: Helm Installation (from cloned repository)
+### Method 4: Helm from Cloned Repository
 
-Install using Helm for simplified configuration management:
-
-> **Note**: Helm charts are not yet published to a Helm repository. You must clone the repository to use this installation method. We plan to publish Helm charts to an OCI registry (e.g., ghcr.io) in a future release.
+Useful for testing an unreleased commit or customising the chart locally.
 
 ```bash
-# Clone the repository
 git clone https://github.com/neo4j-partners/neo4j-kubernetes-operator.git
 cd neo4j-kubernetes-operator
 
-# Checkout the latest release tag
 LATEST_TAG=$(git describe --tags --abbrev=0)
-git checkout $LATEST_TAG
+git checkout $LATEST_TAG    # or omit to test main
 
-# Install using Helm (automatically handles RBAC)
 helm install neo4j-operator ./charts/neo4j-operator \
   --namespace neo4j-operator-system \
   --create-namespace
 ```
 
-**Helm Installation Benefits**:
-- Simplified configuration through values.yaml
-- Easy upgrades with `helm upgrade`
-- Automatic RBAC setup
-- Customizable installation parameters
-
-**Customize Helm installation**:
-```bash
-# View available configuration options
-helm show values ./charts/neo4j-operator
-
-# Install with custom values
-helm install neo4j-operator ./charts/neo4j-operator \
-  --namespace neo4j-operator-system \
-  --create-namespace \
-  --set image.tag=v1.0.0 \
-  --set resources.limits.memory=512Mi
-```
-
-**Uninstall via Helm**:
-```bash
-helm uninstall neo4j-operator --namespace neo4j-operator-system
-```
-
-### Method 3: Git Clone with Make Targets
+### Method 5: Git Clone with Make Targets
 
 For development, customization, or when you need to build from source:
 
@@ -302,23 +331,9 @@ kubectl port-forward svc/standalone-neo4j-service 7474:7474
 
 ## Uninstalling the Operator
 
-### Quick Install Uninstallation
-
-If you installed using Method 1 (GitHub Release):
-
-```bash
-# Get the release version you installed
-RELEASE_VERSION=v1.0.0  # Replace with your installed version
-
-# Delete the operator and CRDs
-kubectl delete -f https://github.com/neo4j-partners/neo4j-kubernetes-operator/releases/download/${RELEASE_VERSION}/neo4j-kubernetes-operator-complete.yaml
-```
-
-**Warning**: Deleting CRDs will also delete all Neo4j instances managed by the operator.
-
 ### Helm Uninstallation
 
-If you installed using Method 2 (Helm):
+If you installed via Helm (Methods 1, 2, or 4):
 
 ```bash
 # Uninstall the Helm release
@@ -335,11 +350,29 @@ kubectl delete crd neo4jenterpriseclusters.neo4j.neo4j.com
 kubectl delete crd neo4jenterprisestandalones.neo4j.neo4j.com
 kubectl delete crd neo4jplugins.neo4j.neo4j.com
 kubectl delete crd neo4jrestores.neo4j.neo4j.com
+kubectl delete crd neo4jroles.neo4j.neo4j.com
+kubectl delete crd neo4jrolebindings.neo4j.neo4j.com
+kubectl delete crd neo4jusers.neo4j.neo4j.com
+kubectl delete crd neo4jshardeddatabases.neo4j.neo4j.com
 ```
+
+### Quick Install Uninstallation
+
+If you installed using Method 3 (kubectl apply from a GitHub release):
+
+```bash
+# Get the release version you installed
+RELEASE_VERSION=v1.8.0  # Replace with your installed version
+
+# Delete the operator and CRDs
+kubectl delete -f https://github.com/neo4j-partners/neo4j-kubernetes-operator/releases/download/${RELEASE_VERSION}/neo4j-kubernetes-operator-complete.yaml
+```
+
+**Warning**: Deleting CRDs will also delete all Neo4j instances managed by the operator.
 
 ### Make Targets Uninstallation
 
-If you installed using Method 3 (Git Clone with Make):
+If you installed using Method 5 (Git Clone with Make):
 
 ```bash
 # From the cloned repository directory

--- a/docs/user_guide/operator-modes.md
+++ b/docs/user_guide/operator-modes.md
@@ -38,20 +38,25 @@ Choose both explicitly so your deployment matches your environment and security 
 
 **2) Install with Helm (recommended)**
 
+The examples below use the Helm chart repository (available from v1.8.0 onwards). For pre-v1.8.0 releases, substitute `neo4j/neo4j-operator` with `oci://ghcr.io/neo4j-partners/charts/neo4j-operator`.
+
 ```bash
+helm repo add neo4j https://neo4j-partners.github.io/neo4j-kubernetes-operator/charts
+helm repo update
+
 # Cluster scope (default)
-helm install neo4j-operator oci://ghcr.io/neo4j-partners/charts/neo4j-operator \
+helm install neo4j-operator neo4j/neo4j-operator \
   --namespace neo4j-operator-system \
   --create-namespace
 
 # Namespace scope
-helm install neo4j-operator oci://ghcr.io/neo4j-partners/charts/neo4j-operator \
+helm install neo4j-operator neo4j/neo4j-operator \
   --namespace team-a \
   --create-namespace \
   --set operatorMode=namespace
 
 # Multi-namespace scope
-helm install neo4j-operator oci://ghcr.io/neo4j-partners/charts/neo4j-operator \
+helm install neo4j-operator neo4j/neo4j-operator \
   --namespace neo4j-operator-system \
   --create-namespace \
   --set operatorMode=namespaces \
@@ -193,14 +198,14 @@ Examples:
 
 ```bash
 # Development mode + cluster scope
-helm upgrade --install neo4j-operator oci://ghcr.io/neo4j-partners/charts/neo4j-operator \
+helm upgrade --install neo4j-operator neo4j/neo4j-operator \
   --namespace neo4j-operator-dev \
   --create-namespace \
   --set developmentMode=true \
   --set logLevel=debug
 
 # Multi-namespace scope
-helm upgrade --install neo4j-operator oci://ghcr.io/neo4j-partners/charts/neo4j-operator \
+helm upgrade --install neo4j-operator neo4j/neo4j-operator \
   --namespace neo4j-operator-system \
   --create-namespace \
   --set operatorMode=namespaces \


### PR DESCRIPTION
## Summary

PR #76 added a GitHub-Pages-hosted Helm chart repository. This PR propagates the new install method through every place that documents installing the chart, presented alongside the existing methods (OCI registry, source clone, kubectl-apply bundle) rather than replacing them.

The new method is gated behind a clear "available from v1.8.0 onwards" note since the chart repo only starts populating after the next release tag.

## Changes per file

- **`README.md`** — Quick Start now offers three Helm install paths in one place: Helm chart repository (recommended, from v1.8.0), OCI registry (all releases), and cloned repository (testing unreleased commits). The "Development Installation" section stays focused on the `make`-driven contributor workflow.

- **`docs/user_guide/installation.md`** — Renumbered to 5 methods: helm repo, OCI, kubectl-apply bundle, cloned helm, make targets. Dropped the stale *"we plan to publish charts"* note. Updated the uninstall section to map onto the new method numbers, and refreshed the CRD cleanup list to include `Neo4jUser`/`Role`/`RoleBinding`/`ShardedDatabase`.

- **`docs/user_guide/operator-modes.md`** — Three examples now use `neo4j/neo4j-operator` from the chart repository, with a note pointing at OCI for pre-v1.8.0 releases.

- **`charts/neo4j-operator/README.md`** — Replaced the placeholder *"when published"* repo section with the live URL; added an OCI section; kept the source-install path.

## Test plan

- [x] `mkdocs build --strict` passes (no new broken links)
- [x] Pre-commit hooks pass
- [ ] Render check on the published Pages site once this lands and the docs workflow rebuilds `dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)