### PR TITLE
feat(plugin): PreBaked install mode for reproducible production deploys

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,6 +91,31 @@ repos:
         files: \.go$
         pass_filenames: false
 
+      # Drift gate — fires when anything that feeds a generator changes.
+      # Mirrors the CI 'Generated Artifacts In Sync' check so it cannot
+      # surprise you in CI. On failure, regenerated files are left in the
+      # working tree; review, `git add -u`, and recommit.
+      - id: check-drift
+        name: generated artifacts in sync
+        entry: bash
+        args:
+          - -c
+          - |
+            echo "Running make check-drift (regenerates CRDs/RBAC/helm/bundle and diffs)..."
+            if ! make check-drift; then
+              echo ""
+              echo "Generated artifacts were stale. They have been regenerated in your"
+              echo "working tree — review the diff, 'git add -u' the changes, and recommit."
+              exit 1
+            fi
+        language: system
+        pass_filenames: false
+        # Trigger on anything that feeds a generator: kubebuilder type/marker
+        # sources, RBAC markers in controllers, generator scripts, the CSV
+        # source-of-truth, and the generated trees themselves (in case
+        # someone hand-edits a generated file).
+        files: ^(api/v1beta1/.*\.go|internal/controller/.*_controller\.go|scripts/(helm-sync-.*|check-csv-coverage|update-alm-examples).*|config/manifests/bases/.*\.csv\.yaml|config/(crd|rbac|samples|manifests)/.*|charts/neo4j-operator/(crds|templates|Chart\.yaml).*|bundle/.*)$
+
   # Security checks (fast)
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.21.2

--- a/Makefile
+++ b/Makefile
@@ -392,6 +392,19 @@ check-drift: sync-all bundle ## CI gate: regenerate everything and fail if anyth
 helm-lint: ## Lint the Helm chart
 	helm lint charts/neo4j-operator
 
+.PHONY: install-hooks
+install-hooks: ## Install git pre-commit hooks (drift gate, fmt, lint, gitleaks).
+	@command -v pre-commit >/dev/null 2>&1 || { \
+	    echo "ERROR: pre-commit is not installed. Install with: pip install pre-commit  (or  brew install pre-commit)" >&2; \
+	    exit 1; \
+	}
+	pre-commit install
+	pre-commit install --hook-type commit-msg
+	@echo ""
+	@echo "Pre-commit hooks installed. The drift gate will run 'make check-drift'"
+	@echo "whenever you stage files under api/, internal/controller/, scripts/,"
+	@echo "config/, charts/, or bundle/ — same gate CI runs."
+
 .PHONY: helm-template
 helm-template: ## Generate Kubernetes manifests from Helm chart
 	helm template neo4j-operator charts/neo4j-operator \

--- a/api/v1beta1/neo4jplugin_types.go
+++ b/api/v1beta1/neo4jplugin_types.go
@@ -38,7 +38,27 @@ type Neo4jPluginSpec struct {
 	// Enable the plugin
 	Enabled bool `json:"enabled,omitempty"`
 
-	// Plugin source configuration
+	// InstallMode selects how the plugin's JAR reaches /plugins.
+	//
+	// "Managed" (default) — operator adds the plugin to NEO4J_PLUGINS so the
+	// upstream Neo4j Docker entrypoint resolves and installs the JAR at pod
+	// startup. For non-bundled plugins (everything except APOC core) this
+	// fetches from the internet on every pod start, which is a poor fit for
+	// air-gapped or regulated environments.
+	//
+	// "PreBaked" — operator does NOT touch NEO4J_PLUGINS. The user is
+	// responsible for delivering the JAR via a custom Neo4j image referenced
+	// from spec.image on the cluster/standalone CR. The operator still
+	// applies the plugin's configuration (security allowlists, unrestricted
+	// procedures, ConfigMap entries) so Neo4j accepts the procedures the
+	// pre-baked JAR exposes.
+	//
+	// +kubebuilder:validation:Enum=Managed;PreBaked
+	// +kubebuilder:default=Managed
+	// +optional
+	InstallMode string `json:"installMode,omitempty"`
+
+	// Plugin source configuration. Ignored when installMode is "PreBaked".
 	Source *PluginSource `json:"source,omitempty"`
 
 	// Plugin configuration

--- a/bundle/manifests/neo4j.neo4j.com_neo4jplugins.yaml
+++ b/bundle/manifests/neo4j.neo4j.com_neo4jplugins.yaml
@@ -93,6 +93,27 @@ spec:
                 default: true
                 description: Enable the plugin
                 type: boolean
+              installMode:
+                default: Managed
+                description: |-
+                  InstallMode selects how the plugin's JAR reaches /plugins.
+
+                  "Managed" (default) — operator adds the plugin to NEO4J_PLUGINS so the
+                  upstream Neo4j Docker entrypoint resolves and installs the JAR at pod
+                  startup. For non-bundled plugins (everything except APOC core) this
+                  fetches from the internet on every pod start, which is a poor fit for
+                  air-gapped or regulated environments.
+
+                  "PreBaked" — operator does NOT touch NEO4J_PLUGINS. The user is
+                  responsible for delivering the JAR via a custom Neo4j image referenced
+                  from spec.image on the cluster/standalone CR. The operator still
+                  applies the plugin's configuration (security allowlists, unrestricted
+                  procedures, ConfigMap entries) so Neo4j accepts the procedures the
+                  pre-baked JAR exposes.
+                enum:
+                - Managed
+                - PreBaked
+                type: string
               name:
                 description: Plugin name
                 type: string
@@ -131,7 +152,8 @@ spec:
                     type: string
                 type: object
               source:
-                description: Plugin source configuration
+                description: Plugin source configuration. Ignored when installMode
+                  is "PreBaked".
                 properties:
                   authSecret:
                     description: Secret containing authentication for private repositories

--- a/charts/neo4j-operator/crds/neo4j.neo4j.com_neo4jplugins.yaml
+++ b/charts/neo4j-operator/crds/neo4j.neo4j.com_neo4jplugins.yaml
@@ -93,6 +93,27 @@ spec:
                 default: true
                 description: Enable the plugin
                 type: boolean
+              installMode:
+                default: Managed
+                description: |-
+                  InstallMode selects how the plugin's JAR reaches /plugins.
+
+                  "Managed" (default) — operator adds the plugin to NEO4J_PLUGINS so the
+                  upstream Neo4j Docker entrypoint resolves and installs the JAR at pod
+                  startup. For non-bundled plugins (everything except APOC core) this
+                  fetches from the internet on every pod start, which is a poor fit for
+                  air-gapped or regulated environments.
+
+                  "PreBaked" — operator does NOT touch NEO4J_PLUGINS. The user is
+                  responsible for delivering the JAR via a custom Neo4j image referenced
+                  from spec.image on the cluster/standalone CR. The operator still
+                  applies the plugin's configuration (security allowlists, unrestricted
+                  procedures, ConfigMap entries) so Neo4j accepts the procedures the
+                  pre-baked JAR exposes.
+                enum:
+                - Managed
+                - PreBaked
+                type: string
               name:
                 description: Plugin name
                 type: string
@@ -131,7 +152,8 @@ spec:
                     type: string
                 type: object
               source:
-                description: Plugin source configuration
+                description: Plugin source configuration. Ignored when installMode
+                  is "PreBaked".
                 properties:
                   authSecret:
                     description: Secret containing authentication for private repositories

--- a/config/crd/bases/neo4j.neo4j.com_neo4jplugins.yaml
+++ b/config/crd/bases/neo4j.neo4j.com_neo4jplugins.yaml
@@ -93,6 +93,27 @@ spec:
                 default: true
                 description: Enable the plugin
                 type: boolean
+              installMode:
+                default: Managed
+                description: |-
+                  InstallMode selects how the plugin's JAR reaches /plugins.
+
+                  "Managed" (default) — operator adds the plugin to NEO4J_PLUGINS so the
+                  upstream Neo4j Docker entrypoint resolves and installs the JAR at pod
+                  startup. For non-bundled plugins (everything except APOC core) this
+                  fetches from the internet on every pod start, which is a poor fit for
+                  air-gapped or regulated environments.
+
+                  "PreBaked" — operator does NOT touch NEO4J_PLUGINS. The user is
+                  responsible for delivering the JAR via a custom Neo4j image referenced
+                  from spec.image on the cluster/standalone CR. The operator still
+                  applies the plugin's configuration (security allowlists, unrestricted
+                  procedures, ConfigMap entries) so Neo4j accepts the procedures the
+                  pre-baked JAR exposes.
+                enum:
+                - Managed
+                - PreBaked
+                type: string
               name:
                 description: Plugin name
                 type: string
@@ -131,7 +152,8 @@ spec:
                     type: string
                 type: object
               source:
-                description: Plugin source configuration
+                description: Plugin source configuration. Ignored when installMode
+                  is "PreBaked".
                 properties:
                   authSecret:
                     description: Secret containing authentication for private repositories

--- a/docs/developer_guide/contributing.md
+++ b/docs/developer_guide/contributing.md
@@ -378,7 +378,7 @@ When adding new Custom Resource Definitions:
     - Integration tests in `test/integration/` (one Ginkgo file per CRD; mirror `test/integration/neo4juser_test.go`).
     - Add cleanup logic to `cleanupCustomResourcesInNamespace` in `test/integration/integration_suite_test.go`.
 
-CI's `check-drift` job runs `make sync-all bundle` and fails the PR if anything is out of date — this enforces step 8.
+CI's `check-drift` job runs `make sync-all bundle` and fails the PR if anything is out of date — this enforces step 8. To catch drift locally before pushing, run `make install-hooks` once; the pre-commit `check-drift` hook fires whenever you stage files under `api/`, `internal/controller/`, `scripts/`, `config/`, `charts/`, or `bundle/`, runs the same gate, and leaves regenerated artifacts in your working tree if anything was stale.
 
 ### Performance Considerations
 

--- a/docs/developer_guide/development.md
+++ b/docs/developer_guide/development.md
@@ -95,7 +95,12 @@ cd neo4j-kubernetes-operator
 
 # Add upstream remote for pulling updates
 git remote add upstream https://github.com/neo4j-partners/neo4j-kubernetes-operator.git
+
+# One-time: install pre-commit hooks (drift gate, fmt, lint, gitleaks)
+make install-hooks
 ```
+
+The drift hook runs `make check-drift` whenever you stage files under `api/`, `internal/controller/`, `scripts/`, `config/`, `charts/`, or `bundle/` — the same gate CI's "Generated Artifacts In Sync" job runs. It fires before the commit lands, so you can't ship a CRD or RBAC change that forgot to regenerate the helm chart or OperatorHub bundle. Requires `pre-commit` (`pip install pre-commit` or `brew install pre-commit`).
 
 ### 2. Generate Code and Manifests
 

--- a/docs/developer_guide/makefile_reference.md
+++ b/docs/developer_guide/makefile_reference.md
@@ -43,6 +43,7 @@ make deploy-dev           # Deploy to development namespace
 make sync-all             # Regenerate all artifacts (CRDs, RBAC, helm chart, kustomize lists)
 make ship-prep            # sync-all + bundle + helm lint + CSV coverage check
 make check-drift          # CI gate: fails if any generated file is stale
+make install-hooks        # One-time: install pre-commit hooks (runs check-drift before commit)
 ```
 
 ## Target Categories
@@ -134,7 +135,13 @@ Chains: `manifests` → `generate` → `sync-kustomize` → `sync-editor-viewer-
 ### `make check-drift`
 **Description**: Regenerate every artifact and `git diff --exit-code` to fail if anything is stale. Used as a CI gate (`.github/workflows/ci.yml`).
 **Usage**: `make check-drift`
-**Notes**: ignores the `createdAt:` timestamp the operator-sdk stamps on every bundle build. If this target fails locally, run `make sync-all bundle` and commit the result.
+**Notes**: ignores the `createdAt:` timestamp the operator-sdk stamps on every bundle build. If this target fails locally, run `make sync-all bundle` and commit the result. The same check runs as a `pre-commit` hook locally once you've run `make install-hooks` — see below.
+
+### `make install-hooks`
+**Description**: Install git pre-commit hooks (drift gate, fmt, lint, gitleaks, commitizen). Wraps `pre-commit install` and `pre-commit install --hook-type commit-msg`.
+**Usage**: `make install-hooks` (one-time per clone)
+**Prerequisite**: `pre-commit` on your `PATH` (`pip install pre-commit` or `brew install pre-commit`).
+**What the drift hook does**: when staged files match `api/v1beta1/*.go`, `internal/controller/*_controller.go`, `scripts/{helm-sync-*,check-csv-coverage,update-alm-examples}*`, `config/manifests/bases/*.csv.yaml`, `config/{crd,rbac,samples,manifests}/`, `charts/neo4j-operator/`, or `bundle/`, the hook runs `make check-drift`. On stale artifacts the regenerated files are left in your working tree; `git add -u` and recommit.
 
 ### `make helm-sync-crds`
 **Description**: Copy the kubebuilder-generated CRDs from `config/crd/bases/` into `charts/neo4j-operator/crds/` so the Helm install picks them up.

--- a/internal/controller/plugin_controller.go
+++ b/internal/controller/plugin_controller.go
@@ -45,7 +45,24 @@ import (
 const (
 	// DefaultAdminSecretNamePlugin is the default name for admin credentials secret
 	DefaultAdminSecretNamePlugin = "neo4j-admin-secret"
+
+	// PluginInstallModeManaged is the default — operator adds the plugin to
+	// NEO4J_PLUGINS so the Neo4j Docker entrypoint resolves and installs the
+	// JAR at pod startup.
+	PluginInstallModeManaged = "Managed"
+
+	// PluginInstallModePreBaked — operator does not touch NEO4J_PLUGINS. The
+	// JAR must already be in /plugins (baked into a custom Neo4j image).
+	// Operator still applies plugin configuration (security allowlists,
+	// unrestricted procedures, ConfigMap entries).
+	PluginInstallModePreBaked = "PreBaked"
 )
+
+// isPreBakedInstallMode reports whether the operator should skip the
+// NEO4J_PLUGINS env mutation for this plugin and only apply configuration.
+func isPreBakedInstallMode(plugin *neo4jv1beta1.Neo4jPlugin) bool {
+	return plugin.Spec.InstallMode == PluginInstallModePreBaked
+}
 
 // getAdminSecretName safely extracts the admin secret name from cluster spec with fallback to default
 func getClusterAdminSecretName(cluster *neo4jv1beta1.Neo4jEnterpriseCluster) string {
@@ -493,6 +510,17 @@ func (r *Neo4jPluginReconciler) uninstallPlugin(ctx context.Context, plugin *neo
 		return nil
 	}
 
+	// PreBaked installs are JARs the operator did not deliver — never run the
+	// jar-removal Job against them. The user-supplied custom image owns
+	// /plugins/*; touching it could orphan files the operator did not put
+	// there. Only configuration (env vars, ConfigMap entries) was operator-
+	// owned, and that is removed when the StatefulSet/ConfigMap is reconciled
+	// after the CR is deleted.
+	if isPreBakedInstallMode(plugin) {
+		logger.Info("Skipping JAR removal for PreBaked plugin", "plugin", plugin.Spec.Name)
+		return nil
+	}
+
 	// Remove plugin from deployment
 	if err := r.removePluginFromDeployment(ctx, plugin, deployment); err != nil {
 		return fmt.Errorf("failed to remove plugin from deployment: %w", err)
@@ -594,7 +622,12 @@ func (r *Neo4jPluginReconciler) updatePluginStatus(ctx context.Context, plugin *
 // This is the recommended approach by Neo4j for Docker plugin installation
 func (r *Neo4jPluginReconciler) installPluginViaEnvironment(ctx context.Context, plugin *neo4jv1beta1.Neo4jPlugin, deployment *DeploymentInfo) error {
 	logger := log.FromContext(ctx)
-	logger.Info("Installing plugin via NEO4J_PLUGINS environment variable", "plugin", plugin.Spec.Name)
+	preBaked := isPreBakedInstallMode(plugin)
+	if preBaked {
+		logger.Info("Configuring plugin in PreBaked mode — skipping NEO4J_PLUGINS mutation", "plugin", plugin.Spec.Name)
+	} else {
+		logger.Info("Installing plugin via NEO4J_PLUGINS environment variable", "plugin", plugin.Spec.Name)
+	}
 
 	// Get the StatefulSet for the deployment
 	sts := &appsv1.StatefulSet{}
@@ -630,36 +663,38 @@ func (r *Neo4jPluginReconciler) installPluginViaEnvironment(ctx context.Context,
 		pluginsToInstall = append(pluginsToInstall, depName)
 	}
 
-	// Find existing NEO4J_PLUGINS environment variable or create new one
-	var pluginsEnvVar *corev1.EnvVar
-	for i := range neo4jContainer.Env {
-		if neo4jContainer.Env[i].Name == "NEO4J_PLUGINS" {
-			pluginsEnvVar = &neo4jContainer.Env[i]
-			break
-		}
-	}
-
-	if pluginsEnvVar == nil {
-		// Add new NEO4J_PLUGINS environment variable with all plugins
-		var quotedPlugins []string
-		for _, plugin := range pluginsToInstall {
-			quotedPlugins = append(quotedPlugins, fmt.Sprintf("\"%s\"", plugin))
-		}
-		neo4jContainer.Env = append(neo4jContainer.Env, corev1.EnvVar{
-			Name:  "NEO4J_PLUGINS",
-			Value: fmt.Sprintf("[%s]", strings.Join(quotedPlugins, ",")),
-		})
-	} else {
-		// Update existing NEO4J_PLUGINS - parse and add all new plugins
-		currentValue := pluginsEnvVar.Value
-		for _, plugin := range pluginsToInstall {
-			updatedPlugins, err := r.addPluginToList(currentValue, plugin)
-			if err != nil {
-				return fmt.Errorf("failed to update plugin list: %w", err)
+	if !preBaked {
+		// Find existing NEO4J_PLUGINS environment variable or create new one
+		var pluginsEnvVar *corev1.EnvVar
+		for i := range neo4jContainer.Env {
+			if neo4jContainer.Env[i].Name == "NEO4J_PLUGINS" {
+				pluginsEnvVar = &neo4jContainer.Env[i]
+				break
 			}
-			currentValue = updatedPlugins
 		}
-		pluginsEnvVar.Value = currentValue
+
+		if pluginsEnvVar == nil {
+			// Add new NEO4J_PLUGINS environment variable with all plugins
+			var quotedPlugins []string
+			for _, plugin := range pluginsToInstall {
+				quotedPlugins = append(quotedPlugins, fmt.Sprintf("\"%s\"", plugin))
+			}
+			neo4jContainer.Env = append(neo4jContainer.Env, corev1.EnvVar{
+				Name:  "NEO4J_PLUGINS",
+				Value: fmt.Sprintf("[%s]", strings.Join(quotedPlugins, ",")),
+			})
+		} else {
+			// Update existing NEO4J_PLUGINS - parse and add all new plugins
+			currentValue := pluginsEnvVar.Value
+			for _, plugin := range pluginsToInstall {
+				updatedPlugins, err := r.addPluginToList(currentValue, plugin)
+				if err != nil {
+					return fmt.Errorf("failed to update plugin list: %w", err)
+				}
+				currentValue = updatedPlugins
+			}
+			pluginsEnvVar.Value = currentValue
+		}
 	}
 
 	// Add plugin configuration as environment variables
@@ -733,41 +768,43 @@ func (r *Neo4jPluginReconciler) installPluginViaEnvironment(ctx context.Context,
 			pluginsToInstall = append(pluginsToInstall, depName)
 		}
 
-		// Find existing NEO4J_PLUGINS environment variable or create new one
-		var pluginsEnvVar *corev1.EnvVar
-		for i := range currentNeo4jContainer.Env {
-			if currentNeo4jContainer.Env[i].Name == "NEO4J_PLUGINS" {
-				pluginsEnvVar = &currentNeo4jContainer.Env[i]
-				break
-			}
-		}
-		if pluginsEnvVar == nil {
-			// Add new NEO4J_PLUGINS environment variable with all plugins
-			var quotedPlugins []string
-			for _, plugin := range pluginsToInstall {
-				quotedPlugins = append(quotedPlugins, fmt.Sprintf("\"%s\"", plugin))
-			}
-			currentNeo4jContainer.Env = append(currentNeo4jContainer.Env, corev1.EnvVar{
-				Name:  "NEO4J_PLUGINS",
-				Value: fmt.Sprintf("[%s]", strings.Join(quotedPlugins, ",")),
-			})
-		} else {
-			// Update existing NEO4J_PLUGINS — delegate to the same helper used
-			// in the outer block (above) so the merge is JSON-aware,
-			// idempotent, and bug-free. The previous inline implementation
-			// here read `currentValue` once but then mutated only
-			// `pluginsEnvVar.Value`, leaving `currentValue` stale across
-			// loop iterations — only the first plugin in pluginsToInstall
-			// would actually land in the env var.
-			currentValue := pluginsEnvVar.Value
-			for _, plugin := range pluginsToInstall {
-				updated, err := r.addPluginToList(currentValue, plugin)
-				if err != nil {
-					return fmt.Errorf("failed to update plugin list: %w", err)
+		if !preBaked {
+			// Find existing NEO4J_PLUGINS environment variable or create new one
+			var pluginsEnvVar *corev1.EnvVar
+			for i := range currentNeo4jContainer.Env {
+				if currentNeo4jContainer.Env[i].Name == "NEO4J_PLUGINS" {
+					pluginsEnvVar = &currentNeo4jContainer.Env[i]
+					break
 				}
-				currentValue = updated
 			}
-			pluginsEnvVar.Value = currentValue
+			if pluginsEnvVar == nil {
+				// Add new NEO4J_PLUGINS environment variable with all plugins
+				var quotedPlugins []string
+				for _, plugin := range pluginsToInstall {
+					quotedPlugins = append(quotedPlugins, fmt.Sprintf("\"%s\"", plugin))
+				}
+				currentNeo4jContainer.Env = append(currentNeo4jContainer.Env, corev1.EnvVar{
+					Name:  "NEO4J_PLUGINS",
+					Value: fmt.Sprintf("[%s]", strings.Join(quotedPlugins, ",")),
+				})
+			} else {
+				// Update existing NEO4J_PLUGINS — delegate to the same helper used
+				// in the outer block (above) so the merge is JSON-aware,
+				// idempotent, and bug-free. The previous inline implementation
+				// here read `currentValue` once but then mutated only
+				// `pluginsEnvVar.Value`, leaving `currentValue` stale across
+				// loop iterations — only the first plugin in pluginsToInstall
+				// would actually land in the env var.
+				currentValue := pluginsEnvVar.Value
+				for _, plugin := range pluginsToInstall {
+					updated, err := r.addPluginToList(currentValue, plugin)
+					if err != nil {
+						return fmt.Errorf("failed to update plugin list: %w", err)
+					}
+					currentValue = updated
+				}
+				pluginsEnvVar.Value = currentValue
+			}
 		}
 
 		// Add plugin-specific configuration as environment variables

--- a/internal/controller/plugin_install_mode_test.go
+++ b/internal/controller/plugin_install_mode_test.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
+)
+
+// newPluginTestReconciler builds a Neo4jPluginReconciler backed by a fake
+// client seeded with the given objects.
+func newPluginTestReconciler(t *testing.T, objs ...runtime.Object) *Neo4jPluginReconciler {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, neo4jv1beta1.AddToScheme(scheme))
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(objs...).
+		Build()
+	return &Neo4jPluginReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(16),
+	}
+}
+
+// pluginTestSTS returns a minimal cluster StatefulSet shaped like what the
+// cluster controller emits — name "<cluster>-server", a single "neo4j"
+// container, no pre-existing NEO4J_PLUGINS env var.
+func pluginTestSTS(clusterName, namespace string) *appsv1.StatefulSet {
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterName + "-server",
+			Namespace: namespace,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "neo4j"},
+					},
+				},
+			},
+		},
+	}
+}
+
+// findEnv returns (value, true) if name is present on the container, else "", false.
+func findEnv(c *corev1.Container, name string) (string, bool) {
+	for _, e := range c.Env {
+		if e.Name == name {
+			return e.Value, true
+		}
+	}
+	return "", false
+}
+
+// TestInstallPluginViaEnvironment_Managed asserts the default-mode behaviour
+// is unchanged: NEO4J_PLUGINS is added AND security env vars are written.
+func TestInstallPluginViaEnvironment_Managed(t *testing.T) {
+	const ns = "default"
+	const clusterName = "managed-c"
+
+	sts := pluginTestSTS(clusterName, ns)
+	r := newPluginTestReconciler(t, sts)
+
+	plugin := &neo4jv1beta1.Neo4jPlugin{
+		ObjectMeta: metav1.ObjectMeta{Name: "gds", Namespace: ns},
+		Spec: neo4jv1beta1.Neo4jPluginSpec{
+			ClusterRef: clusterName,
+			Name:       "graph-data-science",
+			Version:    "2.13.0",
+			// InstallMode left empty — defaults to "Managed".
+		},
+	}
+	deployment := &DeploymentInfo{Type: "cluster", Name: clusterName, Namespace: ns}
+
+	require.NoError(t, r.installPluginViaEnvironment(context.Background(), plugin, deployment))
+
+	got := &appsv1.StatefulSet{}
+	require.NoError(t, r.Get(context.Background(), types.NamespacedName{Name: clusterName + "-server", Namespace: ns}, got))
+	c := &got.Spec.Template.Spec.Containers[0]
+
+	pluginsVal, hasPlugins := findEnv(c, "NEO4J_PLUGINS")
+	require.True(t, hasPlugins, "Managed mode must add NEO4J_PLUGINS")
+	assert.Contains(t, pluginsVal, "graph-data-science")
+
+	// GDS triggers automatic security settings — verify one landed.
+	unrestricted, ok := findEnv(c, "NEO4J_DBMS_SECURITY_PROCEDURES_UNRESTRICTED")
+	require.True(t, ok, "Managed mode must write the GDS unrestricted security env var")
+	assert.Contains(t, unrestricted, "gds.*")
+}
+
+// TestInstallPluginViaEnvironment_PreBaked asserts that PreBaked skips the
+// NEO4J_PLUGINS mutation but still writes the plugin's security configuration
+// — the whole point of the mode.
+func TestInstallPluginViaEnvironment_PreBaked(t *testing.T) {
+	const ns = "default"
+	const clusterName = "prebaked-c"
+
+	sts := pluginTestSTS(clusterName, ns)
+	r := newPluginTestReconciler(t, sts)
+
+	plugin := &neo4jv1beta1.Neo4jPlugin{
+		ObjectMeta: metav1.ObjectMeta{Name: "gds", Namespace: ns},
+		Spec: neo4jv1beta1.Neo4jPluginSpec{
+			ClusterRef:  clusterName,
+			Name:        "graph-data-science",
+			Version:     "2.13.0",
+			InstallMode: PluginInstallModePreBaked,
+		},
+	}
+	deployment := &DeploymentInfo{Type: "cluster", Name: clusterName, Namespace: ns}
+
+	require.NoError(t, r.installPluginViaEnvironment(context.Background(), plugin, deployment))
+
+	got := &appsv1.StatefulSet{}
+	require.NoError(t, r.Get(context.Background(), types.NamespacedName{Name: clusterName + "-server", Namespace: ns}, got))
+	c := &got.Spec.Template.Spec.Containers[0]
+
+	_, hasPlugins := findEnv(c, "NEO4J_PLUGINS")
+	assert.False(t, hasPlugins, "PreBaked mode must NOT add NEO4J_PLUGINS")
+
+	// Configuration path must still run — security env vars are why a user
+	// keeps the CR around when they bake the JAR into the image.
+	unrestricted, ok := findEnv(c, "NEO4J_DBMS_SECURITY_PROCEDURES_UNRESTRICTED")
+	require.True(t, ok, "PreBaked mode must still write the GDS unrestricted security env var")
+	assert.Contains(t, unrestricted, "gds.*")
+}
+
+// TestInstallPluginViaEnvironment_PreBaked_PreservesExistingPluginsEnv asserts
+// that if NEO4J_PLUGINS is already present (e.g. set by the user on the
+// cluster CR for APOC core), PreBaked does not mutate it.
+func TestInstallPluginViaEnvironment_PreBaked_PreservesExistingPluginsEnv(t *testing.T) {
+	const ns = "default"
+	const clusterName = "prebaked-preserve-c"
+
+	sts := pluginTestSTS(clusterName, ns)
+	sts.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{
+		{Name: "NEO4J_PLUGINS", Value: `["apoc"]`},
+	}
+	r := newPluginTestReconciler(t, sts)
+
+	plugin := &neo4jv1beta1.Neo4jPlugin{
+		ObjectMeta: metav1.ObjectMeta{Name: "gds", Namespace: ns},
+		Spec: neo4jv1beta1.Neo4jPluginSpec{
+			ClusterRef:  clusterName,
+			Name:        "graph-data-science",
+			Version:     "2.13.0",
+			InstallMode: PluginInstallModePreBaked,
+		},
+	}
+	deployment := &DeploymentInfo{Type: "cluster", Name: clusterName, Namespace: ns}
+
+	require.NoError(t, r.installPluginViaEnvironment(context.Background(), plugin, deployment))
+
+	got := &appsv1.StatefulSet{}
+	require.NoError(t, r.Get(context.Background(), types.NamespacedName{Name: clusterName + "-server", Namespace: ns}, got))
+
+	pluginsVal, _ := findEnv(&got.Spec.Template.Spec.Containers[0], "NEO4J_PLUGINS")
+	assert.Equal(t, `["apoc"]`, pluginsVal, "PreBaked must not append GDS to a pre-existing NEO4J_PLUGINS")
+}


### PR DESCRIPTION
## Summary

- Add `spec.installMode` to `Neo4jPlugin` (`Managed` default, `PreBaked` opt-in).
- Under `PreBaked`, the operator **does not** mutate `NEO4J_PLUGINS` but **does** still apply the plugin's security/config env vars (and ConfigMap entries on the standalone path). The JAR is expected to be baked into a custom Neo4j image referenced from `spec.image` on the cluster/standalone CR.
- Uninstall under `PreBaked` skips the JAR-removal Job — the operator never delivered the JAR and must not touch user-owned content under `/plugins`.

Closes #89.

## Why

The upstream Neo4j Docker entrypoint, when it sees `NEO4J_PLUGINS`, **downloads** non-bundled plugin JARs (everything except APOC core) from the internet at pod start. That fails the air-gapped test, fails the reproducibility test (a pod restart can pull a different artifact than the one originally validated), and fails the supply-chain test (every pod start is an unauthenticated outbound fetch). `PreBaked` lets users pin everything in a custom image while keeping the declarative wiring of plugin security / allowlist / extension settings.

Backwards-compatible: `installMode` defaults to `Managed`. Existing CRs are byte-identical in behaviour.

## Test plan

- [x] `go test ./internal/controller -run TestInstallPluginViaEnvironment -v` — three new tests all pass
- [x] `make test-unit` — full suite green
- [x] `make build` — green
- [x] `make sync-all` — CRD bases, helm CRDs, deepcopy in sync
- [ ] CRD enum is enforced by API server (manual: `kubectl apply` of `installMode: bogus` rejected)
- [ ] Manual smoke on Kind: plugin CR with `installMode: PreBaked` configured against a Neo4j image with GDS pre-baked — verify `NEO4J_PLUGINS` not present, security env vars present, GDS procedures usable

🤖 Generated with [Claude Code](https://claude.com/claude-code)