### PR TITLE
ci(setup-k8s): fail loudly on transient kind/kubectl download errors

### DIFF
--- a/.github/actions/setup-k8s/action.yml
+++ b/.github/actions/setup-k8s/action.yml
@@ -16,7 +16,22 @@ runs:
     - name: Install Kind
       shell: bash
       run: |
-        curl -Lo ./kind https://kind.sigs.k8s.io/dl/${{ inputs.kind-version }}/kind-linux-amd64
+        # --fail makes curl exit non-zero on HTTP errors. Without it, a
+        # transient redirect/asset failure silently writes a tiny error
+        # body to ./kind which then gets "executed" later as a shell
+        # command (line 1: Error: command not found). --retry-all-errors
+        # rides over flaky GitHub release-assets responses. file(1) is a
+        # final sanity check in case --fail still misses (e.g. an HTML
+        # 200 from a misconfigured proxy).
+        curl --fail --location --retry 5 --retry-delay 5 --retry-all-errors \
+            -o ./kind \
+            "https://kind.sigs.k8s.io/dl/${{ inputs.kind-version }}/kind-linux-amd64"
+        file ./kind | grep -q 'ELF.*executable' || {
+            echo "ERROR: downloaded kind is not an ELF binary:" >&2
+            file ./kind >&2
+            head -c 512 ./kind >&2
+            exit 1
+        }
         chmod +x ./kind
         sudo mv ./kind /usr/local/bin/kind
         kind version
@@ -24,7 +39,16 @@ runs:
     - name: Install kubectl
       shell: bash
       run: |
-        curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+        STABLE=$(curl --fail --location --retry 5 --retry-delay 5 --retry-all-errors -sS https://dl.k8s.io/release/stable.txt)
+        curl --fail --location --retry 5 --retry-delay 5 --retry-all-errors \
+            -o kubectl \
+            "https://dl.k8s.io/release/${STABLE}/bin/linux/amd64/kubectl"
+        file kubectl | grep -q 'ELF.*executable' || {
+            echo "ERROR: downloaded kubectl is not an ELF binary:" >&2
+            file kubectl >&2
+            head -c 512 kubectl >&2
+            exit 1
+        }
         chmod +x kubectl
         sudo mv kubectl /usr/local/bin/
         kubectl version --client


### PR DESCRIPTION
The integration test workflow on PR #90 failed with:

  /usr/local/bin/kind: line 1: Error: command not found

Root cause: 'curl -Lo' silently writes the HTTP error body to the output file when the upstream returns non-2xx. A transient GitHub release-assets hiccup returned a 46-byte text body starting with 'Error: ...', which got saved as /usr/local/bin/kind and 'executed' as a shell script on the next step. The kind/kubectl URLs themselves are fine.

Fixes:

- Add --fail so curl exits non-zero on HTTP errors instead of writing the error body to the binary output path.
- Add --retry 5 --retry-delay 5 --retry-all-errors so transient blips on GitHub release-assets / dl.k8s.io don't fail the job.
- Sanity-check with file(1) that the downloaded artifact is an ELF executable; print head(-c 512) and abort if not. Belt-and-braces in case --fail is bypassed (e.g. proxy returning HTML with HTTP 200).

Applies to both the kind and kubectl installation steps.