### PR TITLE
feat(security): harden backup pods, dedup data-plane security contexts, drop unused pods/exec

### DIFF
--- a/bundle/manifests/neo4j-kubernetes-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/neo4j-kubernetes-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: Database
     containerImage: ghcr.io/neo4j-partners/neo4j-kubernetes-operator:latest
-    createdAt: "2026-05-19T10:38:25Z"
+    createdAt: "2026-05-19T11:33:22Z"
     description: Automates Neo4j Enterprise graph database clusters and standalone
       instances on Kubernetes.
     operators.operatorframework.io/builder: operator-sdk-v1.39.1
@@ -214,13 +214,6 @@ spec:
           - get
           - list
           - watch
-        - apiGroups:
-          - ""
-          resources:
-          - pods/exec
-          verbs:
-          - create
-          - get
         - apiGroups:
           - ""
           resources:

--- a/charts/neo4j-operator/templates/clusterrole.yaml
+++ b/charts/neo4j-operator/templates/clusterrole.yaml
@@ -59,13 +59,6 @@ rules:
 - apiGroups:
     - ""
   resources:
-    - pods/exec
-  verbs:
-    - create
-    - get
-- apiGroups:
-    - ""
-  resources:
     - pods/log
   verbs:
     - get

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -48,13 +48,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods/exec
-  verbs:
-  - create
-  - get
-- apiGroups:
-  - ""
-  resources:
   - pods/log
   verbs:
   - get

--- a/internal/controller/neo4jbackup_controller.go
+++ b/internal/controller/neo4jbackup_controller.go
@@ -85,7 +85,11 @@ func GetTestRequeueAfter() time.Duration {
 //+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups="",resources=pods/exec,verbs=create;get
+// Note: pods/exec RBAC was historically declared here for the old
+// sidecar-exec backup architecture. That architecture was replaced by
+// Job-based backups (see docs/plans/2026-02-20-backup-restore-overhaul.md)
+// and no code path uses pods/exec anymore. Removed to reduce blast
+// radius per the November 2025 security review.
 //+kubebuilder:rbac:groups="",resources=pods/log,verbs=get
 
 // Reconcile handles the reconciliation of Neo4jBackup resources
@@ -361,14 +365,16 @@ func (r *Neo4jBackupReconciler) createBackupJob(ctx context.Context, backup *neo
 				Spec: corev1.PodSpec{
 					RestartPolicy:      corev1.RestartPolicyNever,
 					ServiceAccountName: backupServiceAccountName,
+					SecurityContext:    resources.DefaultNeo4jPodSecurityContext(),
 					Containers: []corev1.Container{
 						{
-							Name:         "backup",
-							Image:        image,
-							Command:      []string{"/bin/sh"},
-							Args:         []string{"-c", backupCmd},
-							Env:          r.buildCloudEnvVars(backup),
-							VolumeMounts: r.buildVolumeMounts(backup),
+							Name:            "backup",
+							Image:           image,
+							Command:         []string{"/bin/sh"},
+							Args:            []string{"-c", backupCmd},
+							Env:             r.buildCloudEnvVars(backup),
+							VolumeMounts:    r.buildVolumeMounts(backup),
+							SecurityContext: resources.DefaultNeo4jContainerSecurityContext(),
 						},
 					},
 					Volumes: r.buildVolumes(backup),
@@ -418,14 +424,16 @@ func (r *Neo4jBackupReconciler) createBackupCronJob(ctx context.Context, backup 
 					Spec: corev1.PodSpec{
 						RestartPolicy:      corev1.RestartPolicyNever,
 						ServiceAccountName: backupServiceAccountName,
+						SecurityContext:    resources.DefaultNeo4jPodSecurityContext(),
 						Containers: []corev1.Container{
 							{
-								Name:         "backup",
-								Image:        image,
-								Command:      []string{"/bin/sh"},
-								Args:         []string{"-c", backupCmd},
-								Env:          r.buildCloudEnvVars(backup),
-								VolumeMounts: r.buildVolumeMounts(backup),
+								Name:            "backup",
+								Image:           image,
+								Command:         []string{"/bin/sh"},
+								Args:            []string{"-c", backupCmd},
+								Env:             r.buildCloudEnvVars(backup),
+								VolumeMounts:    r.buildVolumeMounts(backup),
+								SecurityContext: resources.DefaultNeo4jContainerSecurityContext(),
 							},
 						},
 						Volumes: r.buildVolumes(backup),

--- a/internal/controller/neo4jbackup_security_context_test.go
+++ b/internal/controller/neo4jbackup_security_context_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
+)
+
+// newBackupTestReconciler wires a Neo4jBackupReconciler backed by a fake
+// client seeded with the given objects.
+func newBackupTestReconciler(t *testing.T, objs ...runtime.Object) *Neo4jBackupReconciler {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, neo4jv1beta1.AddToScheme(scheme))
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(objs...).
+		Build()
+	return &Neo4jBackupReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(16),
+	}
+}
+
+func minimalClusterForBackup(name, namespace string) *neo4jv1beta1.Neo4jEnterpriseCluster {
+	return &neo4jv1beta1.Neo4jEnterpriseCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: neo4jv1beta1.Neo4jEnterpriseClusterSpec{
+			Image:    neo4jv1beta1.ImageSpec{Repo: "neo4j", Tag: "5.26-enterprise"},
+			Topology: neo4jv1beta1.TopologyConfiguration{Servers: 3},
+		},
+	}
+}
+
+// assertHardenedPodSecurityContext fails the test if the given PodSpec
+// is missing any element of the operator's data-plane hardening contract.
+// Mirrors internal/resources/DefaultNeo4j{Pod,Container}SecurityContext.
+func assertHardenedPodSecurityContext(t *testing.T, ps *corev1.PodSpec) {
+	t.Helper()
+	require.NotNil(t, ps.SecurityContext, "PodSecurityContext must be set")
+	require.NotNil(t, ps.SecurityContext.RunAsNonRoot, "RunAsNonRoot must be set")
+	assert.True(t, *ps.SecurityContext.RunAsNonRoot, "RunAsNonRoot must be true")
+	require.NotNil(t, ps.SecurityContext.RunAsUser, "RunAsUser must be set")
+	assert.Equal(t, int64(7474), *ps.SecurityContext.RunAsUser, "RunAsUser must be 7474 (neo4j)")
+	require.NotNil(t, ps.SecurityContext.SeccompProfile, "SeccompProfile must be set")
+	assert.Equal(t, corev1.SeccompProfileTypeRuntimeDefault, ps.SecurityContext.SeccompProfile.Type)
+
+	require.NotEmpty(t, ps.Containers, "PodSpec must have at least one container")
+	for _, c := range ps.Containers {
+		require.NotNil(t, c.SecurityContext, "container %q must have SecurityContext", c.Name)
+		require.NotNil(t, c.SecurityContext.RunAsNonRoot, "container %q RunAsNonRoot must be set", c.Name)
+		assert.True(t, *c.SecurityContext.RunAsNonRoot)
+		require.NotNil(t, c.SecurityContext.AllowPrivilegeEscalation)
+		assert.False(t, *c.SecurityContext.AllowPrivilegeEscalation, "AllowPrivilegeEscalation must be false")
+		require.NotNil(t, c.SecurityContext.Capabilities, "Capabilities.Drop must be set")
+		assert.Contains(t, c.SecurityContext.Capabilities.Drop, corev1.Capability("ALL"),
+			"container %q must drop ALL capabilities", c.Name)
+	}
+}
+
+// TestBackupJobHasHardenedSecurityContext closes the security gap from the
+// November 2025 review: the one-shot backup Job had no SecurityContext at
+// all. The reviewer's exact concern was that compromised backup pods
+// would run as root.
+func TestBackupJobHasHardenedSecurityContext(t *testing.T) {
+	const ns = "default"
+	const clusterName = "test-cluster"
+	cluster := minimalClusterForBackup(clusterName, ns)
+
+	backup := &neo4jv1beta1.Neo4jBackup{
+		ObjectMeta: metav1.ObjectMeta{Name: "b1", Namespace: ns},
+		Spec: neo4jv1beta1.Neo4jBackupSpec{
+			Target: neo4jv1beta1.BackupTarget{
+				Kind: "Cluster",
+				Name: clusterName,
+			},
+		},
+	}
+	r := newBackupTestReconciler(t, cluster, backup)
+	require.NoError(t, r.Client.Create(context.Background(), &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: backupServiceAccountName, Namespace: ns},
+	}))
+
+	job, err := r.createBackupJob(context.Background(), backup, cluster)
+	require.NoError(t, err)
+	require.NotNil(t, job)
+
+	got := &batchv1.Job{}
+	require.NoError(t, r.Client.Get(context.Background(), types.NamespacedName{Name: job.Name, Namespace: ns}, got))
+	assertHardenedPodSecurityContext(t, &got.Spec.Template.Spec)
+}
+
+// TestBackupCronJobHasHardenedSecurityContext closes the same gap on the
+// scheduled-backup path.
+func TestBackupCronJobHasHardenedSecurityContext(t *testing.T) {
+	const ns = "default"
+	const clusterName = "test-cluster"
+	cluster := minimalClusterForBackup(clusterName, ns)
+
+	backup := &neo4jv1beta1.Neo4jBackup{
+		ObjectMeta: metav1.ObjectMeta{Name: "b1", Namespace: ns},
+		Spec: neo4jv1beta1.Neo4jBackupSpec{
+			Target: neo4jv1beta1.BackupTarget{
+				Kind: "Cluster",
+				Name: clusterName,
+			},
+			Schedule: "0 2 * * *",
+		},
+	}
+	r := newBackupTestReconciler(t, cluster, backup)
+	require.NoError(t, r.Client.Create(context.Background(), &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: backupServiceAccountName, Namespace: ns},
+	}))
+
+	cron, err := r.createBackupCronJob(context.Background(), backup, cluster)
+	require.NoError(t, err)
+	require.NotNil(t, cron)
+
+	got := &batchv1.CronJob{}
+	require.NoError(t, r.Client.Get(context.Background(), types.NamespacedName{Name: cron.Name, Namespace: ns}, got))
+	assertHardenedPodSecurityContext(t, &got.Spec.JobTemplate.Spec.Template.Spec)
+}

--- a/internal/controller/neo4jenterprisestandalone_controller.go
+++ b/internal/controller/neo4jenterprisestandalone_controller.go
@@ -36,7 +36,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -66,35 +65,14 @@ func podSecurityContextForStandalone(standalone *neo4jv1beta1.Neo4jEnterpriseSta
 	if standalone.Spec.SecurityContext != nil && standalone.Spec.SecurityContext.PodSecurityContext != nil {
 		return standalone.Spec.SecurityContext.PodSecurityContext
 	}
-
-	uid := int64(7474)
-	return &corev1.PodSecurityContext{
-		RunAsUser:    ptr.To(uid),
-		RunAsGroup:   ptr.To(uid),
-		FSGroup:      ptr.To(uid),
-		RunAsNonRoot: ptr.To(true),
-		SeccompProfile: &corev1.SeccompProfile{
-			Type: corev1.SeccompProfileTypeRuntimeDefault,
-		},
-	}
+	return resources.DefaultNeo4jPodSecurityContext()
 }
 
 func containerSecurityContextForStandalone(standalone *neo4jv1beta1.Neo4jEnterpriseStandalone) *corev1.SecurityContext {
 	if standalone.Spec.SecurityContext != nil && standalone.Spec.SecurityContext.ContainerSecurityContext != nil {
 		return standalone.Spec.SecurityContext.ContainerSecurityContext
 	}
-
-	uid := int64(7474)
-	return &corev1.SecurityContext{
-		RunAsUser:                ptr.To(uid),
-		RunAsGroup:               ptr.To(uid),
-		RunAsNonRoot:             ptr.To(true),
-		AllowPrivilegeEscalation: ptr.To(false),
-		ReadOnlyRootFilesystem:   ptr.To(false),
-		Capabilities: &corev1.Capabilities{
-			Drop: []corev1.Capability{"ALL"},
-		},
-	}
+	return resources.DefaultNeo4jContainerSecurityContext()
 }
 
 // standaloneImagePullSecrets converts the standalone's image pull secret names to []corev1.LocalObjectReference.

--- a/internal/controller/neo4jrestore_controller.go
+++ b/internal/controller/neo4jrestore_controller.go
@@ -70,31 +70,14 @@ type Neo4jRestoreReconciler struct {
 	RequeueAfter            time.Duration
 }
 
+// Pod hardening for restore Jobs delegates to the single source of truth
+// in internal/resources/security_context.go.
 func hardenedRestorePodSecurityContext() *corev1.PodSecurityContext {
-	uid := int64(7474)
-	return &corev1.PodSecurityContext{
-		RunAsUser:    ptr.To(uid),
-		RunAsGroup:   ptr.To(uid),
-		FSGroup:      ptr.To(uid),
-		RunAsNonRoot: ptr.To(true),
-		SeccompProfile: &corev1.SeccompProfile{
-			Type: corev1.SeccompProfileTypeRuntimeDefault,
-		},
-	}
+	return resources.DefaultNeo4jPodSecurityContext()
 }
 
 func hardenedRestoreContainerSecurityContext() *corev1.SecurityContext {
-	uid := int64(7474)
-	return &corev1.SecurityContext{
-		RunAsUser:                ptr.To(uid),
-		RunAsGroup:               ptr.To(uid),
-		RunAsNonRoot:             ptr.To(true),
-		AllowPrivilegeEscalation: ptr.To(false),
-		ReadOnlyRootFilesystem:   ptr.To(false),
-		Capabilities: &corev1.Capabilities{
-			Drop: []corev1.Capability{"ALL"},
-		},
-	}
+	return resources.DefaultNeo4jContainerSecurityContext()
 }
 
 const (

--- a/internal/controller/plugin_controller.go
+++ b/internal/controller/plugin_controller.go
@@ -36,10 +36,10 @@ import (
 
 	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
 	neo4jclient "github.com/neo4j-partners/neo4j-kubernetes-operator/internal/neo4j"
+	"github.com/neo4j-partners/neo4j-kubernetes-operator/internal/resources"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/ptr"
 )
 
 const (
@@ -472,31 +472,15 @@ func (r *Neo4jPluginReconciler) applySecurityConfiguration(ctx context.Context, 
 	return nil
 }
 
+// Pod hardening for plugin install/remove Jobs delegates to the single
+// source of truth in internal/resources/security_context.go so it can't
+// drift from the cluster/standalone/backup/restore pods.
 func hardenedPluginPodSecurityContext() *corev1.PodSecurityContext {
-	uid := int64(7474)
-	return &corev1.PodSecurityContext{
-		RunAsUser:    ptr.To(uid),
-		RunAsGroup:   ptr.To(uid),
-		FSGroup:      ptr.To(uid),
-		RunAsNonRoot: ptr.To(true),
-		SeccompProfile: &corev1.SeccompProfile{
-			Type: corev1.SeccompProfileTypeRuntimeDefault,
-		},
-	}
+	return resources.DefaultNeo4jPodSecurityContext()
 }
 
 func hardenedPluginContainerSecurityContext() *corev1.SecurityContext {
-	uid := int64(7474)
-	return &corev1.SecurityContext{
-		RunAsUser:                ptr.To(uid),
-		RunAsGroup:               ptr.To(uid),
-		RunAsNonRoot:             ptr.To(true),
-		AllowPrivilegeEscalation: ptr.To(false),
-		ReadOnlyRootFilesystem:   ptr.To(false),
-		Capabilities: &corev1.Capabilities{
-			Drop: []corev1.Capability{"ALL"},
-		},
-	}
+	return resources.DefaultNeo4jContainerSecurityContext()
 }
 
 func (r *Neo4jPluginReconciler) uninstallPlugin(ctx context.Context, plugin *neo4jv1beta1.Neo4jPlugin) error {

--- a/internal/resources/cluster.go
+++ b/internal/resources/cluster.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/ptr"
 
 	certv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
@@ -92,35 +91,13 @@ const (
 	CertManagerMode = "cert-manager"
 
 	// Default non-root UID/GID for Neo4j containers
-	defaultNeo4jUID int64 = 7474
-
 	// operatorVersionEnv is the environment variable that holds the operator version
 	operatorVersionEnv = "OPERATOR_VERSION"
 )
 
-var (
-	defaultPodSecurityContext = &corev1.PodSecurityContext{
-		RunAsUser:    ptr.To(defaultNeo4jUID),
-		RunAsGroup:   ptr.To(defaultNeo4jUID),
-		FSGroup:      ptr.To(defaultNeo4jUID),
-		RunAsNonRoot: ptr.To(true),
-		SeccompProfile: &corev1.SeccompProfile{
-			Type: corev1.SeccompProfileTypeRuntimeDefault,
-		},
-	}
-
-	defaultContainerSecurityContext = &corev1.SecurityContext{
-		RunAsUser:                ptr.To(defaultNeo4jUID),
-		RunAsGroup:               ptr.To(defaultNeo4jUID),
-		RunAsNonRoot:             ptr.To(true),
-		AllowPrivilegeEscalation: ptr.To(false),
-		// Neo4j requires writable root for scripts/tmp; keep root FS writable but drop capabilities.
-		ReadOnlyRootFilesystem: ptr.To(false),
-		Capabilities: &corev1.Capabilities{
-			Drop: []corev1.Capability{"ALL"},
-		},
-	}
-)
+// Pod hardening defaults live in security_context.go as the single source
+// of truth. The two wrappers below keep the CR-override semantics that
+// only the cluster CR exposes.
 
 // OperatorUDCPackagingValue returns the value for the NEO4J_UDC_PACKAGING environment variable.
 // It reads the OPERATOR_VERSION env var and returns "k8s-<version>", or "k8s-development" if unset.
@@ -135,14 +112,14 @@ func podSecurityContextForCluster(cluster *neo4jv1beta1.Neo4jEnterpriseCluster) 
 	if cluster.Spec.SecurityContext != nil && cluster.Spec.SecurityContext.PodSecurityContext != nil {
 		return cluster.Spec.SecurityContext.PodSecurityContext
 	}
-	return defaultPodSecurityContext
+	return DefaultNeo4jPodSecurityContext()
 }
 
 func containerSecurityContextForCluster(cluster *neo4jv1beta1.Neo4jEnterpriseCluster) *corev1.SecurityContext {
 	if cluster.Spec.SecurityContext != nil && cluster.Spec.SecurityContext.ContainerSecurityContext != nil {
 		return cluster.Spec.SecurityContext.ContainerSecurityContext
 	}
-	return defaultContainerSecurityContext
+	return DefaultNeo4jContainerSecurityContext()
 }
 
 // BuildServerStatefulSetForEnterprise creates a single StatefulSet for all Neo4j servers

--- a/internal/resources/security_context.go
+++ b/internal/resources/security_context.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package resources
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+)
+
+// Neo4jPodUID is the UID/GID Neo4j runs as inside the Enterprise image.
+const Neo4jPodUID int64 = 7474
+
+// DefaultNeo4jPodSecurityContext returns the hardened PodSecurityContext
+// applied by default to every operator-managed pod that runs Neo4j or
+// touches the Neo4j data volume (cluster servers, standalone, backup,
+// restore, plugin jobs). Callers MAY override on a per-CR basis where
+// the CRD exposes a spec.securityContext field; if unset, this default
+// is enforced.
+//
+// Single source of truth — do not inline this elsewhere. The cluster,
+// standalone, backup, restore, and plugin controllers all delegate
+// here so that pod hardening cannot regress in one place while
+// staying correct in another.
+func DefaultNeo4jPodSecurityContext() *corev1.PodSecurityContext {
+	return &corev1.PodSecurityContext{
+		RunAsUser:    ptr.To(Neo4jPodUID),
+		RunAsGroup:   ptr.To(Neo4jPodUID),
+		FSGroup:      ptr.To(Neo4jPodUID),
+		RunAsNonRoot: ptr.To(true),
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+}
+
+// DefaultNeo4jContainerSecurityContext returns the hardened container
+// SecurityContext for the same set of pods. Drops all Linux capabilities,
+// disables privilege escalation, runs as the non-root Neo4j UID.
+//
+// ReadOnlyRootFilesystem is intentionally false: the Neo4j Docker
+// entrypoint writes to several locations under the root filesystem
+// (notably /var/lib/neo4j/conf for plugin config wiring, /tmp for
+// startup scripts). A read-only root would break the entrypoint and
+// the plugin/extension loaders. The data path itself is on a separate
+// PV and is unaffected.
+func DefaultNeo4jContainerSecurityContext() *corev1.SecurityContext {
+	return &corev1.SecurityContext{
+		RunAsUser:                ptr.To(Neo4jPodUID),
+		RunAsGroup:               ptr.To(Neo4jPodUID),
+		RunAsNonRoot:             ptr.To(true),
+		AllowPrivilegeEscalation: ptr.To(false),
+		ReadOnlyRootFilesystem:   ptr.To(false),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+	}
+}


### PR DESCRIPTION
## Summary

P1 of the security-review punch-list. Closes the **data-plane pod hardening** finding for backup pods (cluster/standalone/plugin/restore were already hardened; backup was the outlier) and removes one stale RBAC verb.

## What was missing

`internal/controller/neo4jbackup_controller.go` built bare `PodSpec`s for both the one-shot backup Job and the scheduled backup CronJob. No `RunAsNonRoot`, no capability drops, no seccomp. Backup pods ran as root with full Linux capabilities — wide blast radius for a compromised backup container, which has write access to the data PV.

The four existing hardened-context implementations (cluster.go, standalone, plugin, restore controllers) were near-identical copy/paste. Easy for one to drift from the others.

## Changes

- New `internal/resources/security_context.go` — `DefaultNeo4jPodSecurityContext()` + `DefaultNeo4jContainerSecurityContext()` as the single source of truth.
- `neo4jbackup_controller.go` — apply hardened contexts to Job + CronJob.
- Deduped cluster/standalone/plugin/restore controllers; CR override semantics (cluster + standalone `spec.securityContext`) preserved.
- Removed unused `pods/exec` RBAC marker — stale from the old sidecar-exec backup arch; no current code path uses it. RBAC role + bundle CSV both shrink by one rule.
- **Pre-commit hook fixes** (the drift gate I added in PR #91 could not commit its own output):
  - Drift hook now restores the bundle CSV `createdAt:` churn on the no-drift path so pre-commit's auto-fix detector doesn't roll back the commit.
  - `go-imports` hook excludes `zz_generated*.go` — `controller-gen` and `goimports` disagree on import-alias style for single-use imports and fight every CRD-touching commit.

## Test plan

- [x] `TestBackupJobHasHardenedSecurityContext` — Job pod + container assert RunAsNonRoot=true, UID=7474, seccomp default, no privilege escalation, drop ALL caps.
- [x] `TestBackupCronJobHasHardenedSecurityContext` — same on JobTemplate.
- [x] `make test-unit` — full suite green.
- [x] `make build` — green.
- [x] `make sync-all bundle` + drift hook end-to-end on this commit.
- [ ] Manual: deploy a Neo4jBackup CR to Kind, confirm `kubectl describe pod` shows the hardened context.

## Carried over to next PR

- ExternalSecrets RBAC gating via helm values (P2 continuation)
- Plugin checksum verification (P3)
- Default NetworkPolicies (P4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)