### PR TITLE
feat(plugin): tighten supply-chain validation — checksum required for custom, hash format enforced

### DIFF
--- a/docs/api_reference/neo4jplugin.md
+++ b/docs/api_reference/neo4jplugin.md
@@ -85,7 +85,8 @@ kind: Neo4jPlugin
 | `name` | `string` | ✅ | Plugin name (e.g., "apoc", "graph-data-science") |
 | `version` | `string` | ✅ | Plugin version to install (must match Neo4j version compatibility) |
 | `enabled` | `boolean` | ❌ | Enable the plugin (default: `true`) |
-| `source` | [`PluginSource`](#pluginsource) | ❌ | Plugin source configuration (default: official repository) |
+| `installMode` | `string` | ❌ | `Managed` (default) — operator adds plugin to `NEO4J_PLUGINS`. `PreBaked` — operator only writes config; JAR must be in a custom image. See [Supply-chain](#supply-chain). |
+| `source` | [`PluginSource`](#pluginsource) | ❌ | Plugin source configuration (default: official repository). Ignored when `installMode: PreBaked`. |
 | `dependencies` | [`[]PluginDependency`](#plugindependency) | ❌ | Plugin dependencies (automatically resolved) |
 | `config` | `map[string]string` | ❌ | Plugin-specific configuration (becomes `NEO4J_*` env vars) |
 | `security` | [`PluginSecurity`](#pluginsecurity) | ❌ | Security settings and procedure restrictions |
@@ -98,7 +99,7 @@ kind: Neo4jPlugin
 | `type` | `string` | Source type: "official", "community", "custom", "url" |
 | `registry` | `PluginRegistry` | Registry configuration for custom sources |
 | `url` | `string` | Direct URL for "url" source type |
-| `checksum` | `string` | Checksum for URL sources (format: "sha256:hash") |
+| `checksum` | `string` | **Required** for `type: url` and `type: custom`. Must match `^(sha256:[a-f0-9]{64}\|sha512:[a-f0-9]{128})$`. SHA1 and MD5 are rejected. See [Supply-chain](#supply-chain). |
 | `authSecret` | `string` | Secret containing auth for private registries/URLs |
 
 ### PluginDependency
@@ -162,6 +163,60 @@ Plugin usage analytics.
 | `proceduresCalled` | `map[string]int64` | Count of procedure calls by name |
 | `lastUsed` | `*metav1.Time` | Last time plugin was used |
 | `usageFrequency` | `string` | Usage frequency classification |
+
+## Supply-chain
+
+The Neo4j Enterprise Docker entrypoint resolves `NEO4J_PLUGINS` at pod
+startup. For **APOC core** that's deterministic — the JAR is bundled in
+the image and just gets copied to `/plugins/`. For **every other plugin**
+(`graph-data-science`, `bloom`, `genai`, `n10s`, `graphql`, `apoc-extended`)
+the entrypoint **downloads from the internet on every pod start**, which
+has three production consequences:
+
+- **Non-reproducibility** — a restart can pull a different artifact than
+  the one originally validated.
+- **Egress requirement** — air-gapped clusters cannot permit the
+  outbound HTTP.
+- **Supply-chain exposure** — every pod start is an unauthenticated fetch.
+
+The operator offers two postures.
+
+### `installMode: PreBaked` (recommended for production)
+
+Build a custom Neo4j image with the plugin JAR copied into `/plugins/`
+(or `/var/lib/neo4j/plugins/`), reference that image from
+`spec.image.repo`/`tag` on the cluster or standalone CR, and set
+`installMode: PreBaked` on the `Neo4jPlugin`. The operator does **not**
+touch `NEO4J_PLUGINS` — no runtime fetch happens — but still writes the
+plugin's required configuration (security allowlists, unrestricted
+procedures, ConfigMap entries for standalone). You get the declarative
+CRD UX and a pinned, signed, scannable artifact.
+
+```dockerfile
+FROM neo4j:2025.01.0-enterprise
+COPY graph-data-science-2.13.0.jar /var/lib/neo4j/plugins/
+```
+
+### `installMode: Managed` with a checksum (when you must download)
+
+When the JAR must be fetched at runtime, the validator requires a
+`source.checksum` for any `source.type: url` or `source.type: custom`.
+The checksum format is enforced:
+
+- `sha256:` followed by exactly 64 lowercase hex characters, **or**
+- `sha512:` followed by exactly 128 lowercase hex characters.
+
+SHA1, MD5, and unprefixed hex are rejected. SHA1/MD5 because they are
+not collision-resistant; unprefixed hex because verification tooling
+should never have to guess the algorithm.
+
+**Honest limitation**: the upstream Neo4j Docker entrypoint does **not**
+consume `source.checksum` at download time. The operator records the
+field for audit and exposes it on the StatefulSet, but enforcement at
+the moment of download requires either (a) pinning to PreBaked or (b)
+a future init-container verifier that re-hashes the JAR after the
+entrypoint has finished. Until that lands, treat `source.checksum` as
+attestation, not enforcement, and prefer PreBaked for production.
 
 ## Examples
 

--- a/internal/validation/plugin_validator.go
+++ b/internal/validation/plugin_validator.go
@@ -18,12 +18,19 @@ package validation
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
 )
+
+// checksumPattern matches "sha256:<64-hex>" or "sha512:<128-hex>".
+// The algorithm prefix is required so verification tooling never has to
+// guess. SHA1 and MD5 are deliberately excluded — supply-chain protection
+// against a malicious upstream demands a collision-resistant hash.
+var checksumPattern = regexp.MustCompile(`^(sha256:[a-fA-F0-9]{64}|sha512:[a-fA-F0-9]{128})$`)
 
 // PluginValidator validates Neo4j plugin configuration for Neo4j 5.26+ compatibility
 type PluginValidator struct{}
@@ -159,11 +166,30 @@ func (v *PluginValidator) validatePluginSource(source *neo4jv1beta1.PluginSource
 		))
 	}
 
-	// Validate checksum for security
-	if source.Type == "url" && source.Checksum == "" {
+	// Supply-chain: any source that fetches a JAR from an arbitrary URL
+	// MUST commit to a checksum. Both "url" and "custom" reach an outside
+	// endpoint; "official" and "community" resolve via the Neo4j Docker
+	// entrypoint's curated manifest and don't accept a user-supplied URL.
+	// Note: today the Neo4j entrypoint does not verify this checksum at
+	// download time — it is recorded by the operator and surfaced as a
+	// StatefulSet annotation so users (and audit tooling) can verify
+	// out-of-band, or so a future init-container verifier can enforce.
+	// See docs/user_guide/plugin_supply_chain.md for the model.
+	if (source.Type == "url" || source.Type == "custom") && source.Checksum == "" {
 		allErrs = append(allErrs, field.Required(
 			sourcePath.Child("checksum"),
-			"checksum must be specified for url source type for security",
+			"checksum is required for url and custom source types — supply-chain protection",
+		))
+	}
+
+	// Validate checksum format when present. Accept only sha256/sha512
+	// with the correct hex digit count; reject SHA1/MD5 (collision-prone)
+	// and unprefixed hex (verification tools shouldn't have to guess).
+	if source.Checksum != "" && !checksumPattern.MatchString(source.Checksum) {
+		allErrs = append(allErrs, field.Invalid(
+			sourcePath.Child("checksum"),
+			source.Checksum,
+			"checksum must be of the form sha256:<64 hex chars> or sha512:<128 hex chars>",
 		))
 	}
 

--- a/internal/validation/plugin_validator_test.go
+++ b/internal/validation/plugin_validator_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package validation
 
 import (
+	"strings"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -155,9 +156,10 @@ func TestPluginValidator_Validate(t *testing.T) {
 					Version:    "5.26.0",
 					Enabled:    true,
 					Source: &neo4jv1beta1.PluginSource{
-						Type:     "url",
-						URL:      "https://example.com/plugin.jar",
-						Checksum: "sha256:abc123",
+						Type: "url",
+						URL:  "https://example.com/plugin.jar",
+						// 64-char sha256 hex for a representative plugin JAR.
+						Checksum: "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 					},
 				},
 			},
@@ -327,6 +329,102 @@ func TestPluginValidator_Validate(t *testing.T) {
 				}
 			} else if len(errors) > 0 {
 				t.Errorf("expected no validation errors but got %d: %v", len(errors), errors)
+			}
+		})
+	}
+}
+
+// TestPluginValidator_ChecksumRules locks in the supply-chain validation
+// contract: arbitrary-URL source types must commit to a sha256/sha512
+// checksum in the canonical algo-prefixed form. Weaker algorithms (sha1,
+// md5) and unprefixed hex are rejected so verification tooling never has
+// to guess.
+func TestPluginValidator_ChecksumRules(t *testing.T) {
+	validator := NewPluginValidator()
+
+	const validSHA256 = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	const validSHA512 = "sha512:cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+
+	base := func(src *neo4jv1beta1.PluginSource) *neo4jv1beta1.Neo4jPlugin {
+		return &neo4jv1beta1.Neo4jPlugin{
+			ObjectMeta: metav1.ObjectMeta{Name: "p"},
+			Spec: neo4jv1beta1.Neo4jPluginSpec{
+				ClusterRef: "c",
+				Name:       "apoc",
+				Version:    "5.26.0",
+				Enabled:    true,
+				Source:     src,
+			},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		source  *neo4jv1beta1.PluginSource
+		wantErr bool
+		errSubs string // expected substring in the joined error, if wantErr
+	}{
+		{
+			name:   "url with valid sha256 passes",
+			source: &neo4jv1beta1.PluginSource{Type: "url", URL: "https://x/p.jar", Checksum: validSHA256},
+		},
+		{
+			name:   "url with valid sha512 passes",
+			source: &neo4jv1beta1.PluginSource{Type: "url", URL: "https://x/p.jar", Checksum: validSHA512},
+		},
+		{
+			name:    "custom requires checksum (previously only url did)",
+			source:  &neo4jv1beta1.PluginSource{Type: "custom", URL: "https://x/p.jar"},
+			wantErr: true, errSubs: "checksum is required",
+		},
+		{
+			name:   "custom with valid sha256 passes",
+			source: &neo4jv1beta1.PluginSource{Type: "custom", URL: "https://x/p.jar", Checksum: validSHA256},
+		},
+		{
+			name:   "official does not require checksum",
+			source: &neo4jv1beta1.PluginSource{Type: "official"},
+		},
+		{
+			name:   "community does not require checksum",
+			source: &neo4jv1beta1.PluginSource{Type: "community"},
+		},
+		{
+			name:    "url with sha1 rejected (collision-prone)",
+			source:  &neo4jv1beta1.PluginSource{Type: "url", URL: "https://x/p.jar", Checksum: "sha1:a94a8fef8c17b933bce8fc1f3e3f6a3b6df8f4dd"},
+			wantErr: true, errSubs: "sha256:",
+		},
+		{
+			name:    "url with md5 rejected",
+			source:  &neo4jv1beta1.PluginSource{Type: "url", URL: "https://x/p.jar", Checksum: "md5:d41d8cd98f00b204e9800998ecf8427e"},
+			wantErr: true, errSubs: "sha256:",
+		},
+		{
+			name:    "url with unprefixed hex rejected",
+			source:  &neo4jv1beta1.PluginSource{Type: "url", URL: "https://x/p.jar", Checksum: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+			wantErr: true, errSubs: "sha256:",
+		},
+		{
+			name:    "url with sha256 prefix but wrong length rejected",
+			source:  &neo4jv1beta1.PluginSource{Type: "url", URL: "https://x/p.jar", Checksum: "sha256:abc123"},
+			wantErr: true, errSubs: "sha256:",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := validator.Validate(base(tt.source))
+			if tt.wantErr {
+				if len(errs) == 0 {
+					t.Fatalf("expected an error, got none")
+				}
+				if tt.errSubs != "" && !strings.Contains(errs.ToAggregate().Error(), tt.errSubs) {
+					t.Errorf("expected error to contain %q, got %v", tt.errSubs, errs)
+				}
+				return
+			}
+			if len(errs) > 0 {
+				t.Fatalf("expected no errors, got %v", errs)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

P3 of the security-review punch-list. Two validator tightenings + an honest docs section about what the operator can and cannot enforce.

### Validator changes

- `spec.source.checksum` is now required for `source.type: custom` as well as `source.type: url`. Both fetch from an arbitrary URL — both need a checksum commitment. The previous wording only covered `url`.
- Checksum format is enforced: `^(sha256:[a-f0-9]{64}|sha512:[a-f0-9]{128})$`. SHA1 / MD5 / unprefixed hex / wrong-length are all rejected with a clear error.

### Honest scoping

The Neo4j Docker entrypoint downloads JARs in the main container at startup. The operator has no interception point before load. So `source.checksum` is recorded and validated at admission but not enforced at download time. The recommended production posture is `installMode: PreBaked` (custom image + pinned, signed, scannable JAR) — explained in the new "Supply-chain" section of `docs/api_reference/neo4jplugin.md`.

A future init-container verifier could close the runtime gap, but it requires either re-mounting `/plugins` for a post-entrypoint hash check or another architectural change. Out of scope for this PR.

## Test plan

- [x] `TestPluginValidator_ChecksumRules` — 10 sub-tests covering both pass and reject paths.
- [x] Existing `TestPluginValidator_Validate` updated to use a real 64-char digest (was `sha256:abc123` stub).
- [x] `make test-unit` — full suite green.
- [x] No CRD/RBAC/helm changes — drift gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)