### PR TITLE
docs(reports): archive completed backup/restore overhaul plan

### DIFF
--- a/reports/2026-05-19-backup-restore-overhaul-completion.md
+++ b/reports/2026-05-19-backup-restore-overhaul-completion.md
@@ -1,6 +1,37 @@
-# Backup & Restore Overhaul Implementation Plan
+# Backup & Restore Overhaul — Completion Report
 
-> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+**Date completed**: 2026-05-19
+**Original plan**: this file (formerly `docs/plans/2026-02-20-backup-restore-overhaul.md`).
+
+## Status
+
+**Done.** All 15 tasks (24 listed bugs) implemented and committed. Audit performed against `main` at commit `40531ba` plus PR #95 (which retired the obsolete `pods/exec` RBAC marker the old sidecar-exec pattern needed).
+
+| Task | Where it landed |
+|---|---|
+| 1. Version helper — `GetBackupCommand`, `Supports{ParallelDownload,PreferDiffAsParent,RemoteAddressResolution}` | `internal/neo4j/version.go:169` |
+| 2. API types — `ClusterRef`, `PreferDiffAsParent`, `TempPath`, `CredentialsSecretRef` | `api/v1beta1/neo4jbackup_types.go`, `api/v1beta1/neo4jenterprisecluster_types.go:717` |
+| 3. Cluster config — `server.backup.listen_address=0.0.0.0:6362` | `internal/resources/cluster.go:1631` |
+| 4. `BuildBackupFromAddresses` helper | `internal/resources/cluster.go:176` |
+| 5. `isClusterReady` + `getClusterRef` | `internal/controller/neo4jbackup_controller.go:718` |
+| 6. Replace sidecar-exec → direct `neo4j-admin` Job | `createBackupJob` (one-shot) + `createBackupCronJob` (scheduled). `pods/exec` RBAC removed in PR #95. |
+| 7. CronJob + `--prefer-diff-as-parent` | `neo4jbackup_controller.go:462` (version-gated) + command builder |
+| 8. `stopCluster`/`startCluster` STS name | `resolveStatefulSetName` handles cluster + standalone |
+| 9. `validateRestore` source types — backup/s3/gcs/azure/pitr | `neo4jrestore_controller.go:358` |
+| 10. PITR command builder | `buildPITRRestoreCommand` at `:682` |
+| 11. `CREATE DATABASE` post-restore + restore volumes | `createOrStartDatabase` at `:325`, called from `handleRestoreSuccess` |
+| 12. Standalone restore support | `resolveStatefulSetName` PVC + STS fallback to `{name}` |
+| 13. Retention policy artifact cleanup | `cleanupOldBackups` Job + `buildRetentionScript`; cloud delegated to bucket lifecycle rules |
+| 14. Backup stats from Job completion | `updateBackupStats` reads `job.Status.{StartTime,CompletionTime}` |
+| 15. Tests + lint | `make test-unit` green; `make check-drift` green |
+
+## Why this archive
+
+The plan was a working document while implementation was active. Now that all tasks have shipped, it lives in `reports/` as a completion record rather than `docs/plans/` (which is reserved for unfinished work). The detailed task-by-task instructions below are preserved verbatim for historical reference and to document the design decisions that informed each fix.
+
+---
+
+## Original plan content
 
 **Goal:** Fix 24 identified correctness bugs and API design problems in the Neo4j backup/restore system so that backup and restore operations actually work end-to-end for both cluster and standalone deployments.
 


### PR DESCRIPTION
## Summary

P5 of the security-review punch-list, but with a happy result: an audit of `docs/plans/2026-02-20-backup-restore-overhaul.md` against current code shows **every task is already implemented**. No code changes needed — just relocating the plan from `docs/plans/` (reserved for unfinished work) to `reports/` as a completion record.

## What the audit found

All 15 tasks / 24 listed bugs are on `main`. The completion report header maps each task to the code that landed it:

| Task | Where it landed |
|---|---|
| 1–4 | version helper, API types, cluster config, `BuildBackupFromAddresses` |
| 5–7 | backup controller (sidecar-exec retired in PR #95, direct `neo4j-admin` Job, CronJob `--prefer-diff-as-parent`) |
| 8–12 | restore controller (`resolveStatefulSetName`, all source types, PITR, `createOrStartDatabase`, standalone) |
| 13–14 | retention enforcement, stats from Job timestamps |
| 15 | `make test-unit` green |

Full mapping in the report header.

## What this PR does

- Moves the file from `docs/plans/2026-02-20-backup-restore-overhaul.md` to `reports/2026-05-19-backup-restore-overhaul-completion.md`.
- Prepends a completion header that maps each task to its landing-place in the code.
- Preserves the original task-by-task plan content verbatim below the header for historical reference.

No code changes. `make test-unit` still green (run separately, not as part of this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)