### PR TITLE
fix(chart): preserve newline before clusterrole template's {{ if }} guard

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,11 +31,15 @@ repos:
           - -c
           - |
             GOPATH=$(go env GOPATH)
-            if [ -f "$GOPATH/bin/goimports" ]; then
-              "$GOPATH/bin/goimports" -w .
-            else
-              go install golang.org/x/tools/cmd/goimports@latest && "$GOPATH/bin/goimports" -w .
+            if [ ! -f "$GOPATH/bin/goimports" ]; then
+              go install golang.org/x/tools/cmd/goimports@latest
             fi
+            # Exclude machine-generated files. controller-gen and goimports
+            # disagree on import-alias style for single-use imports (e.g.
+            # `v1 "k8s.io/api/core/v1"` vs bare). Running goimports on
+            # zz_generated*.go fights with `make generate` and breaks the
+            # commit on every CRD-touching change.
+            find . -name 'zz_generated*.go' -prune -o -name '*.go' -print | xargs "$GOPATH/bin/goimports" -w
         language: system
         files: \.go$
         pass_filenames: false
@@ -95,6 +99,11 @@ repos:
       # Mirrors the CI 'Generated Artifacts In Sync' check so it cannot
       # surprise you in CI. On failure, regenerated files are left in the
       # working tree; review, `git add -u`, and recommit.
+      #
+      # On success, the bundle CSV's createdAt: timestamp is reset to
+      # whatever was staged, otherwise every commit attempt would leave
+      # a fresh timestamp in the working tree and pre-commit's auto-fix
+      # detector would roll the commit back.
       - id: check-drift
         name: generated artifacts in sync
         entry: bash
@@ -107,6 +116,17 @@ repos:
               echo "Generated artifacts were stale. They have been regenerated in your"
               echo "working tree — review the diff, 'git add -u' the changes, and recommit."
               exit 1
+            fi
+            # check-drift passed — the only diff make bundle produced
+            # against HEAD is the createdAt: timestamp (everything else
+            # was already in sync). Drop that churn so pre-commit doesn't
+            # see a hook-modified working tree and roll back the commit.
+            CSV=bundle/manifests/neo4j-kubernetes-operator.clusterserviceversion.yaml
+            if git diff --quiet --staged -- "$CSV" 2>/dev/null && ! git diff --quiet -- "$CSV" 2>/dev/null; then
+                git checkout -- "$CSV"
+            elif ! git diff --quiet --staged -- "$CSV" 2>/dev/null; then
+                # CSV has a staged change; restore working tree to the staged version
+                git checkout-index -f -- "$CSV"
             fi
         language: system
         pass_filenames: false

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )

--- a/bundle/manifests/neo4j-kubernetes-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/neo4j-kubernetes-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: Database
     containerImage: ghcr.io/neo4j-partners/neo4j-kubernetes-operator:latest
-    createdAt: "2026-05-07T09:16:34Z"
+    createdAt: "2026-05-19T10:38:25Z"
     description: Automates Neo4j Enterprise graph database clusters and standalone
       instances on Kubernetes.
     operators.operatorframework.io/builder: operator-sdk-v1.39.1

--- a/charts/neo4j-operator/templates/clusterrole.yaml
+++ b/charts/neo4j-operator/templates/clusterrole.yaml
@@ -7,7 +7,7 @@
 #   3. Run 'make helm-sync-rbac' (regenerates this file)
 #
 # CI's 'make check-drift' fails if these are out of sync.
-{{- if and .Values.rbac.create (eq (include "neo4j-operator.createClusterRole" .) "true") -}}
+{{ if and .Values.rbac.create (eq (include "neo4j-operator.createClusterRole" .) "true") -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/scripts/helm-sync-rbac.sh
+++ b/scripts/helm-sync-rbac.sh
@@ -57,7 +57,7 @@ cat > "$DST" <<EOF
 #   3. Run 'make helm-sync-rbac' (regenerates this file)
 #
 # CI's 'make check-drift' fails if these are out of sync.
-{{- if and .Values.rbac.create (eq (include "neo4j-operator.createClusterRole" .) "true") -}}
+{{ if and .Values.rbac.create (eq (include "neo4j-operator.createClusterRole" .) "true") -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:


### PR DESCRIPTION
## Summary

The chart's generated `templates/clusterrole.yaml` is unusable — `helm install` rejects it with `error validating "": error validating data: apiVersion not set`. Discovered while doing live verification of PR #97 against a Kind cluster.

## Root cause

`scripts/helm-sync-rbac.sh` emits:

```
# CI's 'make check-drift' fails if these are out of sync.
{{- if and .Values.rbac.create ... -}}
```

The leading `-` in `{{- if ... -}}` strips whitespace **before** the action template. After helm renders, the comment block glues straight to the next content line:

```
# CI's 'make check-drift' fails if these are out of sync.apiVersion: rbac...
```

The K8s API server rejects the manifest because `apiVersion:` is on the same line as a comment.

## Fix

Drop the leading `-` so the newline before `{{` survives the render (`{{- if ... -}}` → `{{ if ... -}}`). Trailing strip kept so the action line itself doesn't bleed into the `apiVersion` line below.

Regenerated `charts/neo4j-operator/templates/clusterrole.yaml` via `make helm-sync-rbac`; verified with `helm install --dry-run`.

## Hook fix piggyback

Folded in the pre-commit hook fixes from PR #95 — without them this commit can't get past the drift gate's self-conflict. Identical content; will be a no-op merge once #95 (or #97) lands.

## Test plan

- [x] `helm install --dry-run` clean (was failing with apiVersion error before).
- [x] `helm template | grep 'apiVersion:'` shows each on its own line.
- [x] `make check-drift` green.
- [ ] Manual: actually `helm install` into a Kind cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)