### PR TITLE
chore(build): pin CSV createdAt: to stable placeholder, kill the per-PR timestamp conflict class

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,13 +196,25 @@ jobs:
         TAG_NAME: ${{ needs.determine-tag.outputs.tag_name }}
         CLEAN_TAG: ${{ needs.determine-tag.outputs.clean_tag }}
       run: |
-        # Generate OperatorHub bundle/CSV using pre-generated CRDs (SKIP_MANIFESTS=true)
-        make bundle \
+        # Generate OperatorHub bundle/CSV using pre-generated CRDs (SKIP_MANIFESTS=true).
+        # Use `bundle-release` (not `bundle`) so the CSV's createdAt: annotation
+        # gets stamped with the real UTC timestamp before publishing. Plain
+        # `make bundle` writes a stable placeholder so dev/CI PRs don't conflict
+        # on the timestamp — that placeholder must NOT reach OperatorHub.
+        make bundle-release \
           SKIP_MANIFESTS=true \
           VERSION="${CLEAN_TAG}" \
           CHANNELS=alpha \
           DEFAULT_CHANNEL=alpha \
           IMG="${REGISTRY}/${IMAGE_NAME}:${TAG_NAME}"
+
+        # Safety net: fail loudly if the placeholder timestamp survived. The only
+        # way this fires is a future refactor of bundle-release that drops the
+        # restamp step — better to fail the release than ship 2020 to users.
+        if grep -q 'createdAt: "2020-01-01T00:00:00Z"' bundle/manifests/neo4j-kubernetes-operator.clusterserviceversion.yaml; then
+          echo "::error::CSV createdAt: is still the dev placeholder. Refusing to publish bundle to OperatorHub." >&2
+          exit 1
+        fi
 
         mkdir -p release-artifacts
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,7 @@ make install / make uninstall
 # Generators / packaging sync (see ## Generated artifacts below)
 make sync-all                # regenerate every artifact from sources
 make ship-prep               # sync-all + bundle + lint + CSV coverage; pre-release one-shot
+make bundle-release          # bundle + stamp real createdAt: timestamp (run from release workflow)
 make check-drift             # CI gate: fails if any generated file is out of sync
 
 # Operator logs/status
@@ -448,7 +449,7 @@ Two umbrella targets:
 - **`make ship-prep`** — `sync-all` + `bundle` + `helm-lint` + `check-csv-coverage`. Run before tagging a release.
 
 CI gate:
-- **`make check-drift`** — runs `sync-all` + `bundle`, then `git diff --exit-code` (ignoring the `createdAt:` timestamp the operator-sdk stamps). Fails if any committed file is stale. Use this in CI to enforce that whoever changes a source also commits the regenerated output.
+- **`make check-drift`** — runs `sync-all` + `bundle`, then `git diff --exit-code`. Fails if any committed file is stale. Use this in CI to enforce that whoever changes a source also commits the regenerated output. `make bundle` pins the CSV's `createdAt:` annotation to a stable placeholder so concurrent PRs don't conflict on the timestamp; the release flow stamps the real value via `make bundle-release` before publishing to OperatorHub.
 
 53. **Never hand-edit generated files**: edit the source listed above instead. Each generated file carries a `# This file is GENERATED. DO NOT EDIT.` header; check-drift will revert tampering.
 54. **`scripts/helm-sync-artifacthub-crds.sh` requires a description per CRD**: when adding a CRD, also add a `case "$kind" in ... esac` row to the script. The script exits non-zero if a CRD has no mapped description, so you can't forget.

--- a/Makefile
+++ b/Makefile
@@ -373,8 +373,11 @@ ship-prep: sync-all bundle helm-lint check-csv-coverage ## One-stop pre-release:
 .PHONY: check-drift
 check-drift: sync-all bundle ## CI gate: regenerate everything and fail if anything is out of date.
 	@echo "Verifying generated files are committed..."
-	@# operator-sdk stamps createdAt: on every bundle build, so ignore that
-	@# specific line (it's not real drift). Everything else must match HEAD.
+	@# createdAt: is pinned via PINNED_CREATED_AT in the bundle target, so it
+	@# no longer drifts on every regen. The -I filter below is kept as
+	@# belt-and-braces — if someone bypasses `make bundle` and calls
+	@# operator-sdk directly (which restamps with time.Now()), we still
+	@# tolerate the resulting createdAt: diff rather than failing CI.
 	@if ! git diff --exit-code --quiet -I'^    createdAt:' -- \
 	    config/crd config/rbac config/samples config/manifests \
 	    charts/neo4j-operator bundle; then \
@@ -625,6 +628,23 @@ endif
 # identical to what was validated.
 SKIP_MANIFESTS ?= false
 
+# PINNED_CREATED_AT is the placeholder value the dev/CI bundle target
+# writes into the CSV's createdAt: annotation. The real release timestamp
+# is stamped by `make bundle-release` (called from the release workflow,
+# not from local dev or check-drift).
+#
+# Rationale: operator-sdk re-stamps createdAt: with time.Now() on every
+# `generate bundle` invocation. Without pinning, every PR that touches a
+# generated artifact (CRD, RBAC, sample) gets a unique timestamp value,
+# producing spurious merge conflicts across concurrent PRs. Pinning kills
+# the conflict class entirely. See chore/pin-csv-created-at PR for the
+# full rationale and the failure modes considered.
+#
+# 2020-01-01 is old enough to be obviously a placeholder, recent enough
+# that operator-sdk bundle validate accepts it. Don't change the value
+# casually — anything stricter (1970, etc.) risks tripping validators.
+PINNED_CREATED_AT ?= 2020-01-01T00:00:00Z
+
 ifeq ($(SKIP_MANIFESTS),true)
 .PHONY: bundle
 bundle: kustomize operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
@@ -640,9 +660,25 @@ endif
 	# named "<file>-e"). Use the portable form: pass the in-place flag without the
 	# backup extension and clean up any straggler from older runs.
 	sed -i.bak 's|containerImage: .*|containerImage: $(IMG)|' bundle/manifests/neo4j-kubernetes-operator.clusterserviceversion.yaml
+	# Pin createdAt: to a stable value so concurrent PRs don't conflict on the
+	# timestamp. Release stamps the real time via `make bundle-release`. We use
+	# sed (not yq) because `yq -i` reformats the entire YAML — collapsing
+	# folded scalars, reordering keys — and turns a 1-line timestamp diff into
+	# a thousand-line whole-file rewrite.
+	sed -i.bak 's|createdAt: ".*"|createdAt: "$(PINNED_CREATED_AT)"|' bundle/manifests/neo4j-kubernetes-operator.clusterserviceversion.yaml
 	rm -f bundle/manifests/neo4j-kubernetes-operator.clusterserviceversion.yaml.bak bundle/manifests/neo4j-kubernetes-operator.clusterserviceversion.yaml-e
 	go run ./scripts/update-alm-examples bundle/manifests/neo4j-kubernetes-operator.clusterserviceversion.yaml
 	$(OPERATOR_SDK) bundle validate ./bundle
+
+.PHONY: bundle-release
+bundle-release: bundle ## Pre-release: regenerate the bundle and stamp createdAt: with the real current timestamp. Use this in the release workflow before publishing to OperatorHub.
+	@now=$$(date -u +%Y-%m-%dT%H:%M:%SZ); \
+	echo "Stamping createdAt: $$now"; \
+	sed -i.bak "s|createdAt: \".*\"|createdAt: \"$$now\"|" bundle/manifests/neo4j-kubernetes-operator.clusterserviceversion.yaml; \
+	rm -f bundle/manifests/neo4j-kubernetes-operator.clusterserviceversion.yaml.bak bundle/manifests/neo4j-kubernetes-operator.clusterserviceversion.yaml-e; \
+	$(OPERATOR_SDK) bundle validate ./bundle
+	@echo ""
+	@echo "Release bundle ready. Commit the bundle/ change as part of the release tag."
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.

--- a/bundle/manifests/neo4j-kubernetes-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/neo4j-kubernetes-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: Database
     containerImage: ghcr.io/neo4j-partners/neo4j-kubernetes-operator:latest
-    createdAt: "2026-05-19T11:37:01Z"
+    createdAt: "2020-01-01T00:00:00Z"
     description: Automates Neo4j Enterprise graph database clusters and standalone
       instances on Kubernetes.
     operators.operatorframework.io/builder: operator-sdk-v1.39.1

--- a/docs/developer_guide/makefile_reference.md
+++ b/docs/developer_guide/makefile_reference.md
@@ -43,6 +43,7 @@ make deploy-dev           # Deploy to development namespace
 make sync-all             # Regenerate all artifacts (CRDs, RBAC, helm chart, kustomize lists)
 make ship-prep            # sync-all + bundle + helm lint + CSV coverage check
 make check-drift          # CI gate: fails if any generated file is stale
+make bundle-release       # Bundle + real createdAt: timestamp (release workflow only)
 make install-hooks        # One-time: install pre-commit hooks (runs check-drift before commit)
 ```
 
@@ -135,7 +136,12 @@ Chains: `manifests` → `generate` → `sync-kustomize` → `sync-editor-viewer-
 ### `make check-drift`
 **Description**: Regenerate every artifact and `git diff --exit-code` to fail if anything is stale. Used as a CI gate (`.github/workflows/ci.yml`).
 **Usage**: `make check-drift`
-**Notes**: ignores the `createdAt:` timestamp the operator-sdk stamps on every bundle build. If this target fails locally, run `make sync-all bundle` and commit the result. The same check runs as a `pre-commit` hook locally once you've run `make install-hooks` — see below.
+**Notes**: `make bundle` pins the CSV's `createdAt:` to a stable placeholder (see `PINNED_CREATED_AT` in the Makefile), so two consecutive runs produce byte-identical output and concurrent PRs no longer conflict on the timestamp. The `-I '^    createdAt:'` filter is kept as belt-and-braces in case someone bypasses `make bundle` and calls `operator-sdk generate bundle` directly. If `check-drift` fails locally, run `make sync-all bundle` and commit the result. The same check runs as a `pre-commit` hook locally once you've run `make install-hooks` — see below.
+
+### `make bundle-release`
+**Description**: Same as `make bundle`, but stamps the real current UTC timestamp into the CSV's `createdAt:` annotation (overriding the pinned placeholder). Run this from the release workflow before publishing to OperatorHub so the bundle ships with a meaningful `createdAt:` for end-user tooling.
+**Usage**: `make bundle-release`
+**Notes**: only run from release CI — local invocations leave a real timestamp in `bundle/` that will conflict with every other concurrent PR. If you run it by accident, `make bundle` resets it to the placeholder.
 
 ### `make install-hooks`
 **Description**: Install git pre-commit hooks (drift gate, fmt, lint, gitleaks, commitizen). Wraps `pre-commit install` and `pre-commit install --hook-type commit-msg`.


### PR DESCRIPTION
## Summary

`operator-sdk` re-stamps `bundle/manifests/<csv>.yaml`'s `createdAt:` annotation with `time.Now()` on every `generate bundle` invocation. Any two PRs touching a generated artifact get unique timestamps and conflict on that line during rebase — even when the content is byte-identical otherwise. We've hit this on PRs #95, #97, #99, #100 over the past two sessions.

## Fix

- **`Makefile` bundle target** — after `operator-sdk generate bundle`, sed-rewrite `createdAt:` to a stable placeholder (`PINNED_CREATED_AT`, default `2020-01-01T00:00:00Z`).
- **New `make bundle-release` target** — same flow + stamps the real UTC timestamp. Used by `.github/workflows/release.yml` before publishing to OperatorHub.
- **`.github/workflows/release.yml` updated** — swap `make bundle` for `make bundle-release` in the release-artifacts step. Plus a `grep` safety net immediately after: if the placeholder timestamp survives (e.g. future refactor of `bundle-release` drops the restamp), the release fails loudly rather than shipping `createdAt: "2020-01-01..."` to OperatorHub.
- **`check-drift`'s `-I '^    createdAt:'` filter retained** as belt-and-braces against anyone bypassing `make bundle` and calling `operator-sdk` directly.

## Why sed and not yq

First attempt used `yq -i '.metadata.annotations.createdAt = ...'` for formatting robustness — but `yq` reformats the whole YAML (collapses folded scalars, possibly reorders keys), turning a 1-line timestamp diff into a ~900-line whole-file rewrite. `sed` targets only the `createdAt:` line.

## Verification

- `operator-sdk bundle validate` accepts `2020-01-01T00:00:00Z` cleanly.
- Two consecutive `make bundle` invocations produce **byte-identical** output (verified by `diff`).
- `make check-drift` passes cleanly after the pin.
- `make bundle-release` correctly overrides with the real timestamp, then `make bundle` resets to the placeholder.

## Failure modes considered

| Risk | Mitigation |
|---|---|
| Release ships placeholder to OperatorHub | `bundle-release` wired into `release.yml` + `grep` safety net fails release on placeholder survival |
| `operator-sdk bundle validate` rejects placeholder | Tested — accepts |
| Future operator-sdk format change breaks the sed | drift gate would surface the missed rewrite; targeted single-key regex robust against most YAML formatting shifts |
| Loss of "when was this bundle regenerated?" signal | Already misleading — told you when *someone ran the command*, not when *content changed*. Git commit timestamps are the real source of truth. |

## Docs

`CLAUDE.md` and `docs/developer_guide/makefile_reference.md` updated to describe the new flow and the `bundle-release` target's intended use.

## Test plan

- [x] `make bundle` produces deterministic output across runs (byte-identical diff).
- [x] `make check-drift` clean after `make bundle`.
- [x] `make bundle-release` stamps the real timestamp.
- [x] `operator-sdk bundle validate` accepts placeholder.
- [ ] Manual: rebase #95 or #97 on this branch and verify the CSV no longer conflicts.
- [ ] Manual: dry-run the release workflow (workflow_dispatch) and verify the published bundle has a real timestamp + the safety net would catch a placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)