### PR TITLE
feat(rbac): gate external-secrets.io RBAC behind opt-in helm value (default off)

### DIFF
--- a/charts/neo4j-operator/templates/clusterrole.yaml
+++ b/charts/neo4j-operator/templates/clusterrole.yaml
@@ -110,27 +110,6 @@ rules:
     - list
     - watch
 - apiGroups:
-    - external-secrets.io
-  resources:
-    - clustersecretstores
-    - secretstores
-  verbs:
-    - get
-    - list
-    - watch
-- apiGroups:
-    - external-secrets.io
-  resources:
-    - externalsecrets
-  verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
-- apiGroups:
     - monitoring.coreos.com
   resources:
     - prometheusrules
@@ -244,4 +223,27 @@ rules:
     - get
     - list
     - watch
+{{- if .Values.rbac.externalSecretsIntegration }}
+- apiGroups:
+    - external-secrets.io
+  resources:
+    - clustersecretstores
+    - secretstores
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - external-secrets.io
+  resources:
+    - externalsecrets
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+{{- end }}
 {{- end }}

--- a/charts/neo4j-operator/values.yaml
+++ b/charts/neo4j-operator/values.yaml
@@ -44,6 +44,20 @@ serviceAccount:
 rbac:
   # Specifies whether RBAC resources should be created
   create: true
+  # Grant the operator RBAC for the external-secrets.io integration
+  # (clustersecretstores, secretstores, externalsecrets). Default: off.
+  #
+  # The integration is opt-in per-CR via
+  # spec.tls.externalSecrets.enabled / spec.auth.externalSecrets.enabled on
+  # Neo4jEnterpriseCluster (and standalone). Setting this to true grants
+  # cluster-wide CRUD on ExternalSecret resources — only enable if you
+  # actually use that integration. Per the November 2025 security review
+  # recommendation #1 (reduce RBAC blast radius).
+  #
+  # If left false but a Neo4j CR sets externalSecrets.enabled=true, the
+  # operator will get RBAC-denied when trying to create the ExternalSecret
+  # — clear failure mode, easy to debug.
+  externalSecretsIntegration: false
 
 podAnnotations: {}
 

--- a/docs/user_guide/security.md
+++ b/docs/user_guide/security.md
@@ -786,6 +786,17 @@ spec:
 
 ### External Secrets Integration
 
+> **Helm**: the chart does **not** grant the operator RBAC for the
+> `external-secrets.io` API group by default. To enable the integration,
+> install with `--set rbac.externalSecretsIntegration=true` (or set it in
+> your values file). Without this, any `Neo4jEnterpriseCluster` /
+> `Neo4jEnterpriseStandalone` that sets `spec.tls.externalSecrets.enabled=true`
+> or `spec.auth.externalSecrets.enabled=true` will fail with a clear
+> RBAC-denied error when the operator tries to create the `ExternalSecret`.
+> The default-off posture follows the November 2025 security review's
+> recommendation to keep the operator's RBAC blast radius narrow for
+> deployments that don't actually use the integration.
+
 ```yaml
 # SecretStore for AWS Secrets Manager
 apiVersion: external-secrets.io/v1beta1

--- a/scripts/helm-sync-rbac.sh
+++ b/scripts/helm-sync-rbac.sh
@@ -39,9 +39,21 @@ if [[ "$NAME" != "manager-role" ]]; then
     exit 1
 fi
 
-# Render just the rules array.  yq writes it at zero indent which is the
-# correct YAML form under a `rules:` parent key.
-RULES=$("$YQ" '.rules' "$SRC")
+# Partition the rules into two groups:
+#   1. "core" — rules the operator always needs.
+#   2. "external-secrets" — rules for the optional external-secrets.io
+#      integration. Only emitted when .Values.rbac.externalSecretsIntegration
+#      is true on the helm side, since the integration is opt-in (the
+#      operator only creates ExternalSecret resources when a Neo4j CR sets
+#      spec.{tls,auth}.externalSecrets.enabled=true). Without this split,
+#      the chart's ClusterRole granted external-secrets CRUD verbs
+#      cluster-wide on every install — wide blast radius for a feature
+#      most users don't use. Per the November 2025 security review #1.
+#
+# yq writes each at zero indent which is the correct YAML form under a
+# `rules:` parent key.
+CORE_RULES=$("$YQ" '[.rules[] | select(.apiGroups | contains(["external-secrets.io"]) | not)]' "$SRC")
+EXT_SECRETS_RULES=$("$YQ" '[.rules[] | select(.apiGroups | contains(["external-secrets.io"]))]' "$SRC")
 
 # Helm template wrapper: gated by .Values.rbac.create AND the chart's helper
 # that decides whether to emit ClusterRole vs Role (cluster-wide vs single-
@@ -65,7 +77,10 @@ metadata:
   labels:
     {{- include "neo4j-operator.labels" . | nindent 4 }}
 rules:
-${RULES}
+${CORE_RULES}
+{{- if .Values.rbac.externalSecretsIntegration }}
+${EXT_SECRETS_RULES}
+{{- end }}
 {{- end }}
 EOF
 


### PR DESCRIPTION
## Summary

P2 of the security-review punch-list. Closes the November 2025 security review's recommendation **#1 (reduce RBAC blast radius)** for the external-secrets.io integration.

## What was wrong

The operator's `+kubebuilder:rbac:` markers declare CRUD on the `external-secrets.io` API group (`clustersecretstores`, `secretstores`, `externalsecrets`). The helm chart's ClusterRole emitted those rules **unconditionally**, so every chart install — even ones that don't use the integration — granted the operator cluster-wide CRUD on `ExternalSecret` resources.

The integration itself is opt-in per-CR (`spec.{tls,auth}.externalSecrets.enabled`), so the RBAC should be too.

## Changes

- **`scripts/helm-sync-rbac.sh`** — partition kubebuilder-generated rules via `yq`. Rules with `apiGroups` containing `external-secrets.io` go into a separate gated block. Core rules emit unconditionally; external-secrets rules emit only when `.Values.rbac.externalSecretsIntegration` is true.
- **`charts/neo4j-operator/values.yaml`** — new `rbac.externalSecretsIntegration` (default **false**) with inline docs explaining the trade-off.
- **`charts/neo4j-operator/templates/clusterrole.yaml`** — regenerated via `make helm-sync-rbac`.
- **`docs/user_guide/security.md`** — prominent callout in the External Secrets Integration section pointing at the helm value.

## Failure mode

If a user installs the chart with the default (gate off) and then creates a Neo4j CR with `externalSecrets.enabled=true`, the operator gets RBAC-denied when trying to create the `ExternalSecret`. Clear, easy to debug, points at the correct fix (set the helm value, redeploy).

## Test plan

- [x] `helm template` (default): zero references to `external-secrets.io` in the rendered manifest.
- [x] `helm template --set rbac.externalSecretsIntegration=true`: two RBAC rule blocks restored (read on `{cluster,}secretstores`, CRUD on `externalsecrets`).
- [x] `helm lint`: clean.
- [x] `make check-drift`: clean.
- [x] `make test-unit`: green.
- [ ] Manual: chart install with gate=false, create a CR with `externalSecrets.enabled=true`, confirm operator logs an RBAC error rather than silently succeeding.
- [ ] Manual: chart install with `--set rbac.externalSecretsIntegration=true`, same CR, confirm the ExternalSecret is created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)