### PR TITLE
chore: address AI review findings (restore test + metrics test + backup controller + demo.sh)

### DIFF
--- a/internal/controller/neo4jbackup_controller.go
+++ b/internal/controller/neo4jbackup_controller.go
@@ -341,7 +341,7 @@ func (r *Neo4jBackupReconciler) createBackupJob(ctx context.Context, backup *neo
 	jobName := backup.Name + "-backup"
 	logger := log.FromContext(ctx)
 
-	backupCmd, err := r.buildBackupCommand(backup, cluster)
+	backupCmd, err := r.buildBackupCommand(ctx, backup, cluster)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build backup command: %w", err)
 	}
@@ -395,7 +395,7 @@ func (r *Neo4jBackupReconciler) createBackupJob(ctx context.Context, backup *neo
 func (r *Neo4jBackupReconciler) createBackupCronJob(ctx context.Context, backup *neo4jv1beta1.Neo4jBackup, cluster *neo4jv1beta1.Neo4jEnterpriseCluster) (*batchv1.CronJob, error) {
 	cronJobName := backup.Name + "-backup-cron"
 
-	backupCmd, err := r.buildBackupCommand(backup, cluster)
+	backupCmd, err := r.buildBackupCommand(ctx, backup, cluster)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build backup command: %w", err)
 	}
@@ -449,10 +449,19 @@ func (r *Neo4jBackupReconciler) createBackupCronJob(ctx context.Context, backup 
 	return cronJob, nil
 }
 
-func (r *Neo4jBackupReconciler) buildBackupCommand(backup *neo4jv1beta1.Neo4jBackup, cluster *neo4jv1beta1.Neo4jEnterpriseCluster) (string, error) {
+func (r *Neo4jBackupReconciler) buildBackupCommand(ctx context.Context, backup *neo4jv1beta1.Neo4jBackup, cluster *neo4jv1beta1.Neo4jEnterpriseCluster) (string, error) {
 	imageTag := fmt.Sprintf("%s:%s", cluster.Spec.Image.Repo, cluster.Spec.Image.Tag)
 	version, err := neo4j.GetImageVersion(imageTag)
 	if err != nil {
+		// Silent fallback used to mask exotic / misconfigured image tags —
+		// version-gated flags (--parallel-download, --prefer-diff-as-parent,
+		// --remote-address-resolution) would then silently degrade to the
+		// 5.26 defaults with no signal to the operator. Log the fallback so
+		// the diagnostic is visible without forcing the backup to fail.
+		log.FromContext(ctx).Info("Failed to parse Neo4j image version, falling back to 5.26.0 defaults",
+			"imageTag", imageTag,
+			"error", err.Error(),
+			"clusterName", cluster.Name)
 		version = &neo4j.Version{Major: 5, Minor: 26, Patch: 0}
 	}
 
@@ -873,9 +882,16 @@ echo "Found $FILE_COUNT backup directories"
 if [ "$FILE_COUNT" -gt "$MAX_COUNT" ]; then
     TO_DELETE=$((FILE_COUNT - MAX_COUNT))
     echo "Deleting $TO_DELETE oldest backups (keeping $MAX_COUNT)"
-    find "$BACKUP_DIR" -maxdepth 1 -mindepth 1 -type d | \
-        sort | \
+    # Sort by filesystem mtime, not by directory name. The directory name
+    # happens to encode a YYYYMMDD-HHMMSS timestamp today, but coupling
+    # retention's "oldest first" semantics to that naming convention is
+    # fragile — anyone who renames the timestamp format silently breaks
+    # retention. GNU find's -printf is available because the backup
+    # container is Linux-only.
+    find "$BACKUP_DIR" -maxdepth 1 -mindepth 1 -type d -printf '%%T@ %%p\n' | \
+        sort -n | \
         head -n "$TO_DELETE" | \
+        cut -d' ' -f2- | \
         xargs -r rm -rf
     echo "Deleted $TO_DELETE old backup directories"
 fi

--- a/internal/controller/neo4jrestore_controller_test.go
+++ b/internal/controller/neo4jrestore_controller_test.go
@@ -113,10 +113,7 @@ var _ = Describe("Neo4jRestore Controller", func() {
 				"NEO4J_AUTH": []byte("neo4j/testpassword123"),
 			},
 		}
-		err := k8sClient.Create(ctx, secret)
-		if err != nil && !errors.IsAlreadyExists(err) {
-			Expect(err).NotTo(HaveOccurred())
-		}
+		Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
 
 		// Patch cluster status to Ready so restore controller proceeds
 		patch := client.MergeFrom(cluster.DeepCopy())
@@ -183,18 +180,22 @@ var _ = Describe("Neo4jRestore Controller", func() {
 		// Clean up resources. Cleanup-warning output goes through GinkgoWriter
 		// so Ginkgo can attribute it to the spec that produced it (and respect
 		// verbosity flags) — fmt.Printf to stdout would be unattributed noise.
+		//
+		// NotFound is filtered out so finalizer cascades and tests that
+		// delete-as-they-go don't produce noise on already-gone resources.
+		// Matches the sibling pattern in neo4jbackup_controller_test.go.
 		if restore != nil {
-			if err := k8sClient.Delete(ctx, restore, client.PropagationPolicy(metav1.DeletePropagationForeground)); err != nil {
+			if err := k8sClient.Delete(ctx, restore, client.PropagationPolicy(metav1.DeletePropagationForeground)); err != nil && !errors.IsNotFound(err) {
 				fmt.Fprintf(GinkgoWriter, "Warning: Failed to delete restore during cleanup: %v\n", err)
 			}
 		}
 		if backup != nil {
-			if err := k8sClient.Delete(ctx, backup, client.PropagationPolicy(metav1.DeletePropagationForeground)); err != nil {
+			if err := k8sClient.Delete(ctx, backup, client.PropagationPolicy(metav1.DeletePropagationForeground)); err != nil && !errors.IsNotFound(err) {
 				fmt.Fprintf(GinkgoWriter, "Warning: Failed to delete backup during cleanup: %v\n", err)
 			}
 		}
 		if cluster != nil {
-			if err := k8sClient.Delete(ctx, cluster, client.PropagationPolicy(metav1.DeletePropagationForeground)); err != nil {
+			if err := k8sClient.Delete(ctx, cluster, client.PropagationPolicy(metav1.DeletePropagationForeground)); err != nil && !errors.IsNotFound(err) {
 				fmt.Fprintf(GinkgoWriter, "Warning: Failed to delete cluster during cleanup: %v\n", err)
 			}
 		}
@@ -205,7 +206,7 @@ var _ = Describe("Neo4jRestore Controller", func() {
 				Namespace: namespaceName,
 			},
 		}
-		if err := k8sClient.Delete(ctx, secret); err != nil {
+		if err := k8sClient.Delete(ctx, secret); err != nil && !errors.IsNotFound(err) {
 			fmt.Fprintf(GinkgoWriter, "Warning: Failed to delete admin secret during cleanup: %v\n", err)
 		}
 	})

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -75,9 +75,13 @@ func TestReconcileMetrics_StartReconcileSpan(t *testing.T) {
 
 	require.NotNil(t, newCtx)
 	require.NotNil(t, span)
-
-	// Verify span exists (may not be recording in test environment without tracer setup)
-	assert.NotNil(t, span)
+	// Verify the returned context actually carries the same span — this is
+	// the contract callers rely on (downstream code reads the active span
+	// from ctx, not from the explicit span return). Works against the
+	// global noop tracer too because tracer.Start always puts the
+	// returned span into the returned context via WithValue.
+	require.Equal(t, span, trace.SpanFromContext(newCtx),
+		"newCtx must carry the returned span")
 
 	// Clean up
 	span.End()
@@ -619,9 +623,10 @@ func TestSpanTracing(t *testing.T) {
 
 			require.NotNil(t, newCtx)
 			require.NotNil(t, span)
-
-			// Verify span exists (may not be recording in test environment without tracer setup)
-			assert.NotNil(t, span)
+			// Same rationale as TestReconcileMetrics_StartReconcileSpan:
+			// verify the returned context actually carries the same span.
+			require.Equal(t, span, trace.SpanFromContext(newCtx),
+				"newCtx must carry the returned span")
 
 			// Clean up
 			span.End()

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -57,9 +57,10 @@ esac
 
 # ── Display functions ──────────────────────────────────────────────────────
 
-# Full-width separator
+# Full-width separator. Bash brace expansion avoids the per-call subshell
+# + seq fork — the script is #!/bin/bash so {1..N} is portable here.
 separator() {
-    echo -e "${DIM}$(printf '━%.0s' $(seq 1 78))${NC}"
+    echo -e "${DIM}$(printf '━%.0s' {1..78})${NC}"
 }
 
 # Part header with step counter and emoji
@@ -79,11 +80,17 @@ log_header() {
     SECTION_START_TIME=$(date +%s)
 }
 
-# Section header within a part
+# Section header within a part. Brace expansion can't be used here
+# ({1..${#1}} doesn't work — Bash expands braces before variables), so
+# build an N-space pad with `%*s` and substitute spaces for the dash
+# character. Still subshell-free, unlike the prior $(seq ...) call.
 log_section() {
+    local underline
+    printf -v underline '%*s' "${#1}" ''
+    underline=${underline// /─}
     echo
     echo -e "  ${YELLOW}${BOLD}▸ $1${NC}"
-    echo -e "  ${DIM}$(printf '─%.0s' $(seq 1 ${#1}))${NC}"
+    echo -e "  ${DIM}${underline}${NC}"
 }
 
 log_info() {
@@ -1090,7 +1097,7 @@ EOF
     local timeout=120
     local elapsed=0
 
-    while [ $elapsed -lt $timeout ]; do
+    while [[ $elapsed -lt $timeout ]]; do
         if kubectl get neo4jdatabase orders-database -n "${DEMO_NAMESPACE}" -o jsonpath='{.status.phase}' 2>/dev/null | grep -q "Ready"; then
             break
         fi


### PR DESCRIPTION
## Summary

Bundle of small, defensible cleanups across four files flagged by the GitHub security-and-quality AI review. Each finding was audited against live code before applying — false positives (Copilot reading docs in isolation) are explicitly skipped.

## Changes by file

### `internal/controller/neo4jrestore_controller_test.go` (PR's original scope)

- **`BeforeEach`** — dropped the dead `IsAlreadyExists`-tolerant Create. The secret name uses `time.Now().UnixNano()` so collisions are impossible; the same BeforeEach creates `cluster`/`backup`/`restore` with the standard pattern. Replaced with `Expect(...).Should(Succeed())`.
- **`AfterEach`** — added `&& !errors.IsNotFound(err)` to all four Delete-then-warn blocks for parity with the convention in `neo4jbackup_controller_test.go`. Stops noise on finalizer cascades.

### `internal/metrics/metrics_test.go`

- Two test sites had `require.NotNil(t, span)` followed by a dead `assert.NotNil(t, span)`. Replaced the redundant assertion with a real contract check: `require.Equal(t, span, trace.SpanFromContext(newCtx))` — verifies the function actually embeds the returned span into the returned context (which downstream code reads). Works against the global noop tracer.

### `internal/controller/neo4jbackup_controller.go`

- **`buildBackupCommand`** — silent fallback to Neo4j 5.26.0 on `GetImageVersion` parse failure used to mask exotic / typo'd image tags. The version-gated flags (`SupportsParallelDownload`, `SupportsPreferDiffAsParent`, `SupportsRemoteAddressResolution`) would silently evaluate against 5.26 with no signal. Added `log.FromContext(ctx).Info(...)` at the fallback point. Threaded `ctx` through `buildBackupCommand`.
- **`buildRetentionScript` `MaxCount` block** — was sorting backup directories by name. Only "happens to work" because today's naming embeds `YYYYMMDD-HHMMSS`; coupling retention semantics to that convention silently breaks if the timestamp format ever changes. Switched to filesystem mtime via `find ... -printf '%T@ %p\n' | sort -n | head | cut -d' ' -f2-`. GNU find is fine — backup container is Linux only.

### `scripts/demo.sh`

- `separator()` — `printf '━%.0s' {1..78}` replaces `$(seq 1 78)` (no subshell, no seq fork).
- `log_section()` — build the underline via `printf -v` + `%*s` + space-to-dash substitution. Can't use brace expansion here (`{1..${#1}}` doesn't expand; Bash processes braces before variables).
- One `while [ ... ]` switched to `while [[ ... ]]` for consistency with the other four loops in the file.

## Skipped from the Copilot review

- **"BackupPort undefined"** — false positive; the constant is defined in `internal/resources/cluster.go:60`. Copilot reviewed the markdown snippet in the archived plan without scope.
- **"MaxAge shell parsing fragile"** — false positive; live code does this in Go via `parseFindTimeArg` with proper validation, not the shell snippet Copilot found in the plan doc.
- **demo.sh `awk | wc -l` pipeline** — valid concern but ~10 lines of new code for a non-critical demo script. Defer to a follow-up if we want the jsonpath migration.

## Test plan

- [x] `go test ./internal/controller -run TestControllers -ginkgo.focus="Neo4jRestore Controller"` — green.
- [x] `go test ./internal/metrics` — green (including the upgraded span/context check).
- [x] `go test ./internal/controller -run TestBackup` — green.
- [x] `make test-unit` — full suite green.
- [x] `make check-drift` — clean.
- [x] `bash -n scripts/demo.sh` — syntax OK; rendered `separator` + `log_section "Hello World"` standalone and confirmed identical visual output to pre-change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)