### PR TITLE
feat(backup,restore): propagate cluster imagePullSecrets to Job pods + archive observability/gitops plan

### DIFF
--- a/internal/controller/neo4jbackup_controller.go
+++ b/internal/controller/neo4jbackup_controller.go
@@ -366,6 +366,13 @@ func (r *Neo4jBackupReconciler) createBackupJob(ctx context.Context, backup *neo
 					RestartPolicy:      corev1.RestartPolicyNever,
 					ServiceAccountName: backupServiceAccountName,
 					SecurityContext:    resources.DefaultNeo4jPodSecurityContext(),
+					// Propagate the cluster's image pull secrets so backup
+					// pods can pull the SAME Neo4j Enterprise image from
+					// private registries — without this, a cluster running
+					// fine on a private image fails its backups with
+					// ImagePullBackOff because the backup namespace's default
+					// SA has no creds.
+					ImagePullSecrets: resources.ImagePullSecretsFromNames(cluster.Spec.Image.PullSecrets),
 					Containers: []corev1.Container{
 						{
 							Name:            "backup",
@@ -425,6 +432,10 @@ func (r *Neo4jBackupReconciler) createBackupCronJob(ctx context.Context, backup 
 						RestartPolicy:      corev1.RestartPolicyNever,
 						ServiceAccountName: backupServiceAccountName,
 						SecurityContext:    resources.DefaultNeo4jPodSecurityContext(),
+						// Same rationale as createBackupJob — scheduled
+						// backups need the same pull secrets as the cluster
+						// they're backing up.
+						ImagePullSecrets: resources.ImagePullSecretsFromNames(cluster.Spec.Image.PullSecrets),
 						Containers: []corev1.Container{
 							{
 								Name:            "backup",

--- a/internal/controller/neo4jbackup_security_context_test.go
+++ b/internal/controller/neo4jbackup_security_context_test.go
@@ -141,3 +141,69 @@ func TestBackupCronJobHasHardenedSecurityContext(t *testing.T) {
 	require.NoError(t, r.Client.Get(context.Background(), types.NamespacedName{Name: cron.Name, Namespace: ns}, got))
 	assertHardenedPodSecurityContext(t, &got.Spec.JobTemplate.Spec.Template.Spec)
 }
+
+// TestBackupJobPropagatesImagePullSecrets locks in the contract that a
+// backup Job inherits the cluster's image pull secrets. Without this,
+// private-registry clusters fail their backups with ImagePullBackOff
+// because the backup pod can't pull the same Neo4j Enterprise image
+// the cluster uses.
+func TestBackupJobPropagatesImagePullSecrets(t *testing.T) {
+	const ns = "default"
+	const clusterName = "test-cluster"
+	cluster := minimalClusterForBackup(clusterName, ns)
+	cluster.Spec.Image.PullSecrets = []string{"ghcr-creds", "internal-mirror"}
+
+	backup := &neo4jv1beta1.Neo4jBackup{
+		ObjectMeta: metav1.ObjectMeta{Name: "b1", Namespace: ns},
+		Spec: neo4jv1beta1.Neo4jBackupSpec{
+			Target: neo4jv1beta1.BackupTarget{Kind: "Cluster", Name: clusterName},
+		},
+	}
+	r := newBackupTestReconciler(t, cluster, backup)
+	require.NoError(t, r.Client.Create(context.Background(), &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: backupServiceAccountName, Namespace: ns},
+	}))
+
+	job, err := r.createBackupJob(context.Background(), backup, cluster)
+	require.NoError(t, err)
+	got := &batchv1.Job{}
+	require.NoError(t, r.Client.Get(context.Background(), types.NamespacedName{Name: job.Name, Namespace: ns}, got))
+
+	want := []corev1.LocalObjectReference{
+		{Name: "ghcr-creds"},
+		{Name: "internal-mirror"},
+	}
+	assert.Equal(t, want, got.Spec.Template.Spec.ImagePullSecrets,
+		"backup Job must carry the cluster's image pull secrets")
+}
+
+// TestBackupCronJobPropagatesImagePullSecrets — same contract on the
+// scheduled-backup path.
+func TestBackupCronJobPropagatesImagePullSecrets(t *testing.T) {
+	const ns = "default"
+	const clusterName = "test-cluster"
+	cluster := minimalClusterForBackup(clusterName, ns)
+	cluster.Spec.Image.PullSecrets = []string{"ghcr-creds"}
+
+	backup := &neo4jv1beta1.Neo4jBackup{
+		ObjectMeta: metav1.ObjectMeta{Name: "b1", Namespace: ns},
+		Spec: neo4jv1beta1.Neo4jBackupSpec{
+			Target:   neo4jv1beta1.BackupTarget{Kind: "Cluster", Name: clusterName},
+			Schedule: "0 2 * * *",
+		},
+	}
+	r := newBackupTestReconciler(t, cluster, backup)
+	require.NoError(t, r.Client.Create(context.Background(), &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: backupServiceAccountName, Namespace: ns},
+	}))
+
+	cron, err := r.createBackupCronJob(context.Background(), backup, cluster)
+	require.NoError(t, err)
+	got := &batchv1.CronJob{}
+	require.NoError(t, r.Client.Get(context.Background(), types.NamespacedName{Name: cron.Name, Namespace: ns}, got))
+
+	assert.Equal(t,
+		[]corev1.LocalObjectReference{{Name: "ghcr-creds"}},
+		got.Spec.JobTemplate.Spec.Template.Spec.ImagePullSecrets,
+		"backup CronJob must carry the cluster's image pull secrets")
+}

--- a/internal/controller/neo4jrestore_controller.go
+++ b/internal/controller/neo4jrestore_controller.go
@@ -469,6 +469,11 @@ func (r *Neo4jRestoreReconciler) createRestoreJob(ctx context.Context, restore *
 				Spec: corev1.PodSpec{
 					RestartPolicy:   corev1.RestartPolicyNever,
 					SecurityContext: hardenedRestorePodSecurityContext(),
+					// Restore pod uses the cluster's Neo4j image; propagate
+					// pull secrets so private-registry clusters can restore.
+					// Without this, a private-image cluster restore fails
+					// with ImagePullBackOff before any neo4j-admin runs.
+					ImagePullSecrets: resources.ImagePullSecretsFromNames(cluster.Spec.Image.PullSecrets),
 					Containers: []corev1.Container{
 						{
 							Name:            "neo4j-restore",

--- a/internal/resources/cluster.go
+++ b/internal/resources/cluster.go
@@ -1527,11 +1527,26 @@ func BuildPodSpecForEnterprise(cluster *neo4jv1beta1.Neo4jEnterpriseCluster, ser
 
 // clusterImagePullSecrets converts the cluster's image pull secret names to []corev1.LocalObjectReference.
 func clusterImagePullSecrets(cluster *neo4jv1beta1.Neo4jEnterpriseCluster) []corev1.LocalObjectReference {
-	if len(cluster.Spec.Image.PullSecrets) == 0 {
+	return ImagePullSecretsFromNames(cluster.Spec.Image.PullSecrets)
+}
+
+// ImagePullSecretsFromNames is the exported variant of the cluster/standalone
+// pull-secret accessor: given a slice of Secret names, return the
+// LocalObjectReference list that goes into a PodSpec's
+// ImagePullSecrets field. Returns nil for empty/all-blank input so the
+// caller can drop the field entirely on PodSpec.
+//
+// Lives at the resources/ layer so the backup, restore, plugin, and
+// other Job-spawning controllers can all pull the same shape without
+// reaching into typed cluster/standalone helpers. Empty strings are
+// skipped — they'd be invalid Secret names anyway and silently break
+// kubelet's image-pull resolution.
+func ImagePullSecretsFromNames(names []string) []corev1.LocalObjectReference {
+	if len(names) == 0 {
 		return nil
 	}
-	refs := make([]corev1.LocalObjectReference, 0, len(cluster.Spec.Image.PullSecrets))
-	for _, name := range cluster.Spec.Image.PullSecrets {
+	refs := make([]corev1.LocalObjectReference, 0, len(names))
+	for _, name := range names {
 		if name == "" {
 			continue
 		}

--- a/reports/2026-05-19-observability-gitops-completion.md
+++ b/reports/2026-05-19-observability-gitops-completion.md
@@ -1,6 +1,30 @@
-# Observability & GitOps Improvements Implementation Plan
+# Observability & GitOps Improvements — Completion Report
 
-> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+**Date completed**: 2026-05-19
+**Original plan**: this file (formerly `docs/plans/2026-02-21-observability-gitops-improvements.md`).
+
+## Status
+
+**Done.** All five tasks implemented and on `main`. The accompanying PR also closes one remaining gap (image pull secrets on backup + restore Job pods) that this audit surfaced and that the plan's Task 5 did not explicitly cover.
+
+| Task | Where it landed |
+|---|---|
+| 1. Event reason constants (typed enum, replaces string literals) | `internal/controller/events.go` |
+| 2. Wire Prometheus metrics into controllers | `internal/controller/neo4jenterprisecluster_controller.go` (RecordReconcile, RecordClusterPhase, RecordClusterHealth, RecordClusterReplicas), `internal/controller/neo4jbackup_controller.go` (RecordBackup) |
+| 2 (continued). Split-brain counter metric | `internal/metrics/metrics.go:104` (`splitBrainDetectedTotal`) + call site in `neo4jenterprisecluster_controller.go:1438` |
+| 3. ArgoCD & Flux health checks | `docs/gitops/argocd-health-checks.yaml` + `docs/gitops/README.md` |
+| 4. Status condition constants (Ready type for Flux auto-detection) | `internal/controller/conditions.go` (`ConditionTypeReady`, `ConditionReasonReady`, `SetReadyCondition`) |
+| 5. imagePullSecrets on Neo4j StatefulSet | `internal/resources/cluster.go:1517` (cluster), `internal/controller/neo4jenterprisestandalone_controller.go:1037` (standalone) |
+| Bonus. Helm chart appVersion bump at release | `.github/workflows/release.yml:152-153` |
+| Bonus. imagePullSecrets on backup + restore Jobs | NEW — extracted `ImagePullSecretsFromNames` helper in `internal/resources/cluster.go`; backup Job, backup CronJob, restore Job now propagate `cluster.Spec.Image.PullSecrets`. Without this, private-registry clusters fail their backups/restores with `ImagePullBackOff` because the auxiliary Job pods can't pull the same Neo4j Enterprise image as the StatefulSet. |
+
+## Why this archive
+
+The plan was a working document while implementation was active. With every task landed, it lives in `reports/` as a completion record rather than `docs/plans/` (which is reserved for unfinished work). The detailed task-by-task content is preserved verbatim below for historical reference and to document the per-task design decisions.
+
+---
+
+## Original plan content
 
 **Goal:** Wire up structured Kubernetes Events, activate existing Prometheus metrics, add ArgoCD/Flux health checks, standardize status conditions, and fix image pull secret and Helm chart versioning gaps.
 


### PR DESCRIPTION
## Summary

P6 of the security-review punch-list — observability/GitOps polish. Audit of the plan in `docs/plans/2026-02-21-observability-gitops-improvements.md` found **every task already on `main`**:

| Plan task | Where it landed |
|---|---|
| Event reason constants | `internal/controller/events.go` |
| Wire Prometheus metrics | `neo4jenterprisecluster_controller.go` (RecordReconcile/Phase/Health/Replicas) + `neo4jbackup_controller.go` (RecordBackup) |
| Split-brain counter metric | `metrics.go:104` + call site in cluster controller |
| ArgoCD/Flux health checks | `docs/gitops/argocd-health-checks.yaml` |
| Status condition constants | `internal/controller/conditions.go` |
| imagePullSecrets on Neo4j STS | `cluster.go:1517` + `neo4jenterprisestandalone_controller.go:1037` |
| Helm appVersion at release | `.github/workflows/release.yml:152-153` |

## The one gap this PR closes

The backup + restore controllers spawn Jobs that pull the **same** Neo4j Enterprise image as the cluster's StatefulSet, but their PodSpecs did **not** carry the cluster's `imagePullSecrets`. A private-registry cluster running fine would silently fail its backups + restores with `ImagePullBackOff` because the auxiliary Job pods couldn't auth to the registry.

### Changes

- **`internal/resources/cluster.go`** — extracted `ImagePullSecretsFromNames([]string) → []corev1.LocalObjectReference` as an exported helper. Existing `clusterImagePullSecrets` now delegates to it.
- **`internal/controller/neo4jbackup_controller.go`** — backup Job + CronJob PodSpecs now set `ImagePullSecrets` from `cluster.Spec.Image.PullSecrets`.
- **`internal/controller/neo4jrestore_controller.go`** — restore Job PodSpec same. Hook-image Job left alone — that uses a user-supplied image with its own pull-secret concern.
- **`internal/controller/neo4jbackup_security_context_test.go`** — two new regression tests assert backup Job + CronJob carry the cluster's pull secrets.

## Plan archive

Same pattern as PR #98 for the backup-restore plan:

- `docs/plans/2026-02-21-observability-gitops-improvements.md` → `reports/2026-05-19-observability-gitops-completion.md`
- Completion header at the top maps each task to landed code; the original plan content is preserved verbatim below for historical reference.

## Test plan

- [x] `TestBackupJobPropagatesImagePullSecrets` — Job carries `[ghcr-creds, internal-mirror]`.
- [x] `TestBackupCronJobPropagatesImagePullSecrets` — CronJob's JobTemplate carries `[ghcr-creds]`.
- [x] `TestBackupJobHasHardenedSecurityContext` + cron variant — still green (no regression).
- [x] `make test-unit` — full suite green.
- [x] `make check-drift` — clean.
- [ ] Manual: deploy a Neo4j cluster from a private registry with `spec.image.pullSecrets` set, run a `Neo4jBackup` CR, confirm the backup Job pod pulls the image successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)