### PR TITLE
chore: replace deprecated k8s + cert-manager API names with canonical forms

### DIFF
--- a/internal/controller/neo4jenterprisestandalone_controller.go
+++ b/internal/controller/neo4jenterprisestandalone_controller.go
@@ -914,7 +914,7 @@ func (r *Neo4jEnterpriseStandaloneReconciler) createService(standalone *neo4jv1b
 
 		// External traffic policy
 		if standalone.Spec.Service.ExternalTrafficPolicy != "" {
-			svc.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyType(standalone.Spec.Service.ExternalTrafficPolicy)
+			svc.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicy(standalone.Spec.Service.ExternalTrafficPolicy)
 		}
 	}
 
@@ -1490,7 +1490,7 @@ func (r *Neo4jEnterpriseStandaloneReconciler) createTLSCertificate(standalone *n
 		},
 		Spec: certmanagerv1.CertificateSpec{
 			SecretName: fmt.Sprintf("%s-tls-secret", standalone.Name),
-			IssuerRef: cmmeta.ObjectReference{
+			IssuerRef: cmmeta.IssuerReference{
 				Name:  standalone.Spec.TLS.IssuerRef.Name,
 				Kind:  standalone.Spec.TLS.IssuerRef.Kind,
 				Group: standalone.Spec.TLS.IssuerRef.Group,

--- a/internal/controller/neo4jenterprisestandalone_controller_test.go
+++ b/internal/controller/neo4jenterprisestandalone_controller_test.go
@@ -502,7 +502,7 @@ var _ = Describe("Neo4jEnterpriseStandalone Controller", func() {
 				// Verify LoadBalancer configuration
 				return service.Spec.Type == corev1.ServiceTypeLoadBalancer &&
 					service.Spec.LoadBalancerIP == "10.0.0.100" &&
-					service.Spec.ExternalTrafficPolicy == corev1.ServiceExternalTrafficPolicyTypeLocal &&
+					service.Spec.ExternalTrafficPolicy == corev1.ServiceExternalTrafficPolicyLocal &&
 					len(service.Spec.LoadBalancerSourceRanges) == 2 &&
 					service.Spec.LoadBalancerSourceRanges[0] == "10.0.0.0/8" &&
 					service.Spec.LoadBalancerSourceRanges[1] == "192.168.0.0/16"

--- a/internal/resources/cluster.go
+++ b/internal/resources/cluster.go
@@ -516,7 +516,7 @@ func BuildClientServiceForEnterprise(cluster *neo4jv1beta1.Neo4jEnterpriseCluste
 
 		// External traffic policy
 		if cluster.Spec.Service.ExternalTrafficPolicy != "" {
-			svc.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyType(cluster.Spec.Service.ExternalTrafficPolicy)
+			svc.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicy(cluster.Spec.Service.ExternalTrafficPolicy)
 		}
 	}
 
@@ -619,7 +619,7 @@ func BuildCertificateForEnterprise(cluster *neo4jv1beta1.Neo4jEnterpriseCluster)
 	// Build certificate spec
 	certSpec := certv1.CertificateSpec{
 		SecretName: fmt.Sprintf("%s-tls-secret", cluster.Name),
-		IssuerRef: cmmeta.ObjectReference{
+		IssuerRef: cmmeta.IssuerReference{
 			Name: cluster.Spec.TLS.IssuerRef.Name,
 			Kind: cluster.Spec.TLS.IssuerRef.Kind,
 		},

--- a/internal/resources/cluster_test.go
+++ b/internal/resources/cluster_test.go
@@ -416,7 +416,7 @@ func TestBuildClientServiceForEnterprise_WithEnhancedFeatures(t *testing.T) {
 			checkFunc: func(t *testing.T, service *corev1.Service) {
 				assert.Equal(t, corev1.ServiceTypeLoadBalancer, service.Spec.Type)
 				assert.Equal(t, "10.0.0.100", service.Spec.LoadBalancerIP)
-				assert.Equal(t, corev1.ServiceExternalTrafficPolicyTypeLocal, service.Spec.ExternalTrafficPolicy)
+				assert.Equal(t, corev1.ServiceExternalTrafficPolicyLocal, service.Spec.ExternalTrafficPolicy)
 				assert.Equal(t, []string{"10.0.0.0/8", "192.168.0.0/16"}, service.Spec.LoadBalancerSourceRanges)
 			},
 		},
@@ -491,7 +491,7 @@ func TestBuildClientServiceForEnterprise_WithEnhancedFeatures(t *testing.T) {
 			},
 			checkFunc: func(t *testing.T, service *corev1.Service) {
 				assert.Equal(t, corev1.ServiceTypeLoadBalancer, service.Spec.Type)
-				assert.Equal(t, corev1.ServiceExternalTrafficPolicyTypeCluster, service.Spec.ExternalTrafficPolicy)
+				assert.Equal(t, corev1.ServiceExternalTrafficPolicyCluster, service.Spec.ExternalTrafficPolicy)
 			},
 		},
 	}

--- a/internal/resources/mcp.go
+++ b/internal/resources/mcp.go
@@ -346,7 +346,7 @@ func buildMCPService(namespace, name string, labels map[string]string, mcp *neo4
 			svc.Spec.LoadBalancerSourceRanges = mcp.HTTP.Service.LoadBalancerSourceRanges
 		}
 		if mcp.HTTP.Service.ExternalTrafficPolicy != "" {
-			svc.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyType(mcp.HTTP.Service.ExternalTrafficPolicy)
+			svc.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicy(mcp.HTTP.Service.ExternalTrafficPolicy)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Two upstream-deprecated identifiers were lighting up gopls' `deprecated` analyzer across several files. Both are pure type-alias renames — **zero behavior change**, just dropping the deprecated names so the warnings stop pulling attention away from real diagnostics.

## Replacements

| Old (deprecated) | New (canonical) | Sites |
|---|---|---|
| `corev1.ServiceExternalTrafficPolicyType` | `corev1.ServiceExternalTrafficPolicy` | `cluster.go`, `mcp.go`, `neo4jenterprisestandalone_controller.go` |
| `corev1.ServiceExternalTrafficPolicyTypeLocal/TypeCluster` | `corev1.ServiceExternalTrafficPolicyLocal/Cluster` | `cluster_test.go`, `neo4jenterprisestandalone_controller_test.go` |
| `cmmeta.ObjectReference` | `cmmeta.IssuerReference` | `cluster.go`, `neo4jenterprisestandalone_controller.go` |

cert-manager 1.20+ defines `type ObjectReference = IssuerReference` so the rename is byte-identical at runtime. Same story for the corev1 alias rename.

## Skipped

The `ptr.To(x)` → `new(x)` suggestions from gopls' modernize analyzer are **false positives** here — `ptr.To` is called with non-zero values throughout (e.g. `ptr.To(int64(7474))`) which can't be replaced by `new(int64)` since `new` returns a pointer to the *zero* value. Not equivalent. Left alone.

## Test plan

- [x] `go build ./...` clean.
- [x] `make test-unit` green (full suite).
- [x] `grep` across `internal/` + `api/` confirms no remaining `ServiceExternalTrafficPolicyType` / `cmmeta.ObjectReference` usages.
- [x] `make check-drift` — no generated artifacts touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)