### PR TITLE
feat(plugin): VerifiedDownload install mode — init container downloads + SHA verifies before Neo4j starts

### DIFF
--- a/api/v1beta1/neo4jplugin_types.go
+++ b/api/v1beta1/neo4jplugin_types.go
@@ -44,7 +44,8 @@ type Neo4jPluginSpec struct {
 	// upstream Neo4j Docker entrypoint resolves and installs the JAR at pod
 	// startup. For non-bundled plugins (everything except APOC core) this
 	// fetches from the internet on every pod start, which is a poor fit for
-	// air-gapped or regulated environments.
+	// air-gapped or regulated environments. source.checksum is recorded for
+	// attestation but the upstream entrypoint does not verify it.
 	//
 	// "PreBaked" — operator does NOT touch NEO4J_PLUGINS. The user is
 	// responsible for delivering the JAR via a custom Neo4j image referenced
@@ -53,12 +54,24 @@ type Neo4jPluginSpec struct {
 	// procedures, ConfigMap entries) so Neo4j accepts the procedures the
 	// pre-baked JAR exposes.
 	//
-	// +kubebuilder:validation:Enum=Managed;PreBaked
+	// "VerifiedDownload" — the operator injects an init container into the
+	// target StatefulSet's pod template. The init container downloads
+	// source.url, verifies the SHA256/SHA512 against source.checksum,
+	// and drops the JAR into the shared /plugins emptyDir BEFORE the
+	// Neo4j entrypoint runs. NEO4J_PLUGINS is NOT mutated (preventing
+	// the entrypoint's own download from racing the verified JAR).
+	// Authenticated mirrors are supported via source.authSecret;
+	// internal CAs are supported via the cluster's spec.trustedCASecrets.
+	// On checksum mismatch the init container exits non-zero, the pod
+	// stays Pending, and Neo4jPlugin.status surfaces the failure.
+	//
+	// +kubebuilder:validation:Enum=Managed;PreBaked;VerifiedDownload
 	// +kubebuilder:default=Managed
 	// +optional
 	InstallMode string `json:"installMode,omitempty"`
 
-	// Plugin source configuration. Ignored when installMode is "PreBaked".
+	// Plugin source configuration. Required when installMode is
+	// "VerifiedDownload". Ignored when installMode is "PreBaked".
 	Source *PluginSource `json:"source,omitempty"`
 
 	// Plugin configuration

--- a/bundle/manifests/neo4j.neo4j.com_neo4jplugins.yaml
+++ b/bundle/manifests/neo4j.neo4j.com_neo4jplugins.yaml
@@ -102,7 +102,8 @@ spec:
                   upstream Neo4j Docker entrypoint resolves and installs the JAR at pod
                   startup. For non-bundled plugins (everything except APOC core) this
                   fetches from the internet on every pod start, which is a poor fit for
-                  air-gapped or regulated environments.
+                  air-gapped or regulated environments. source.checksum is recorded for
+                  attestation but the upstream entrypoint does not verify it.
 
                   "PreBaked" — operator does NOT touch NEO4J_PLUGINS. The user is
                   responsible for delivering the JAR via a custom Neo4j image referenced
@@ -110,9 +111,21 @@ spec:
                   applies the plugin's configuration (security allowlists, unrestricted
                   procedures, ConfigMap entries) so Neo4j accepts the procedures the
                   pre-baked JAR exposes.
+
+                  "VerifiedDownload" — the operator injects an init container into the
+                  target StatefulSet's pod template. The init container downloads
+                  source.url, verifies the SHA256/SHA512 against source.checksum,
+                  and drops the JAR into the shared /plugins emptyDir BEFORE the
+                  Neo4j entrypoint runs. NEO4J_PLUGINS is NOT mutated (preventing
+                  the entrypoint's own download from racing the verified JAR).
+                  Authenticated mirrors are supported via source.authSecret;
+                  internal CAs are supported via the cluster's spec.trustedCASecrets.
+                  On checksum mismatch the init container exits non-zero, the pod
+                  stays Pending, and Neo4jPlugin.status surfaces the failure.
                 enum:
                 - Managed
                 - PreBaked
+                - VerifiedDownload
                 type: string
               name:
                 description: Plugin name
@@ -152,8 +165,9 @@ spec:
                     type: string
                 type: object
               source:
-                description: Plugin source configuration. Ignored when installMode
-                  is "PreBaked".
+                description: |-
+                  Plugin source configuration. Required when installMode is
+                  "VerifiedDownload". Ignored when installMode is "PreBaked".
                 properties:
                   authSecret:
                     description: Secret containing authentication for private repositories

--- a/charts/neo4j-operator/crds/neo4j.neo4j.com_neo4jplugins.yaml
+++ b/charts/neo4j-operator/crds/neo4j.neo4j.com_neo4jplugins.yaml
@@ -102,7 +102,8 @@ spec:
                   upstream Neo4j Docker entrypoint resolves and installs the JAR at pod
                   startup. For non-bundled plugins (everything except APOC core) this
                   fetches from the internet on every pod start, which is a poor fit for
-                  air-gapped or regulated environments.
+                  air-gapped or regulated environments. source.checksum is recorded for
+                  attestation but the upstream entrypoint does not verify it.
 
                   "PreBaked" — operator does NOT touch NEO4J_PLUGINS. The user is
                   responsible for delivering the JAR via a custom Neo4j image referenced
@@ -110,9 +111,21 @@ spec:
                   applies the plugin's configuration (security allowlists, unrestricted
                   procedures, ConfigMap entries) so Neo4j accepts the procedures the
                   pre-baked JAR exposes.
+
+                  "VerifiedDownload" — the operator injects an init container into the
+                  target StatefulSet's pod template. The init container downloads
+                  source.url, verifies the SHA256/SHA512 against source.checksum,
+                  and drops the JAR into the shared /plugins emptyDir BEFORE the
+                  Neo4j entrypoint runs. NEO4J_PLUGINS is NOT mutated (preventing
+                  the entrypoint's own download from racing the verified JAR).
+                  Authenticated mirrors are supported via source.authSecret;
+                  internal CAs are supported via the cluster's spec.trustedCASecrets.
+                  On checksum mismatch the init container exits non-zero, the pod
+                  stays Pending, and Neo4jPlugin.status surfaces the failure.
                 enum:
                 - Managed
                 - PreBaked
+                - VerifiedDownload
                 type: string
               name:
                 description: Plugin name
@@ -152,8 +165,9 @@ spec:
                     type: string
                 type: object
               source:
-                description: Plugin source configuration. Ignored when installMode
-                  is "PreBaked".
+                description: |-
+                  Plugin source configuration. Required when installMode is
+                  "VerifiedDownload". Ignored when installMode is "PreBaked".
                 properties:
                   authSecret:
                     description: Secret containing authentication for private repositories

--- a/charts/neo4j-operator/templates/deployment.yaml
+++ b/charts/neo4j-operator/templates/deployment.yaml
@@ -61,6 +61,13 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- with .Values.pluginInitContainer.image }}
+        # Override for Neo4jPlugin spec.installMode=VerifiedDownload init
+        # container image. Empty falls back to the operator's baked-in
+        # default (curlimages/curl:8.5.0) — see internal/resources/plugin_init_container.go.
+        - name: PLUGIN_INIT_CONTAINER_IMAGE
+          value: {{ . | quote }}
+        {{- end }}
         {{- with .Values.envFrom }}
         envFrom:
           {{- toYaml . | nindent 10 }}

--- a/charts/neo4j-operator/values.yaml
+++ b/charts/neo4j-operator/values.yaml
@@ -59,6 +59,17 @@ rbac:
   # — clear failure mode, easy to debug.
   externalSecretsIntegration: false
 
+# Init container image used by Neo4jPlugin spec.installMode=VerifiedDownload.
+# When a Neo4jPlugin opts into VerifiedDownload, the operator injects this
+# image as an init container on the target StatefulSet's pod template; the
+# container downloads spec.source.url, verifies the sha256/sha512 against
+# spec.source.checksum, and drops the JAR into the shared /plugins
+# emptyDir before Neo4j starts. Empty value falls back to the operator's
+# baked-in default (curlimages/curl:8.5.0). Air-gapped clusters should
+# point this at an internal mirror.
+pluginInitContainer:
+  image: ""
+
 podAnnotations: {}
 
 # Disable to let platform defaults (e.g., OpenShift SCC) control pod security settings

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -356,10 +356,11 @@ func setupProductionControllers(mgr ctrl.Manager) error {
 		{
 			name: "Neo4jPlugin",
 			controller: &controller.Neo4jPluginReconciler{
-				Client:       mgr.GetClient(),
-				Scheme:       mgr.GetScheme(),
-				Recorder:     mgr.GetEventRecorderFor("neo4j-plugin-controller"),
-				RequeueAfter: controller.GetTestRequeueAfter(),
+				Client:          mgr.GetClient(),
+				Scheme:          mgr.GetScheme(),
+				Recorder:        mgr.GetEventRecorderFor("neo4j-plugin-controller"),
+				RequeueAfter:    controller.GetTestRequeueAfter(),
+				PluginInitImage: os.Getenv("PLUGIN_INIT_CONTAINER_IMAGE"),
 			},
 		},
 		{
@@ -477,10 +478,11 @@ func setupDevelopmentControllers(mgr ctrl.Manager, controllers []string) error {
 		},
 		"plugin": func() (interface{ SetupWithManager(ctrl.Manager) error }, string) {
 			return &controller.Neo4jPluginReconciler{
-				Client:       mgr.GetClient(),
-				Scheme:       mgr.GetScheme(),
-				Recorder:     mgr.GetEventRecorderFor("neo4j-plugin-controller"),
-				RequeueAfter: controller.GetTestRequeueAfter(),
+				Client:          mgr.GetClient(),
+				Scheme:          mgr.GetScheme(),
+				Recorder:        mgr.GetEventRecorderFor("neo4j-plugin-controller"),
+				RequeueAfter:    controller.GetTestRequeueAfter(),
+				PluginInitImage: os.Getenv("PLUGIN_INIT_CONTAINER_IMAGE"),
 			}, "Neo4jPlugin"
 		},
 		"shardeddatabase": func() (interface{ SetupWithManager(ctrl.Manager) error }, string) {

--- a/config/crd/bases/neo4j.neo4j.com_neo4jplugins.yaml
+++ b/config/crd/bases/neo4j.neo4j.com_neo4jplugins.yaml
@@ -102,7 +102,8 @@ spec:
                   upstream Neo4j Docker entrypoint resolves and installs the JAR at pod
                   startup. For non-bundled plugins (everything except APOC core) this
                   fetches from the internet on every pod start, which is a poor fit for
-                  air-gapped or regulated environments.
+                  air-gapped or regulated environments. source.checksum is recorded for
+                  attestation but the upstream entrypoint does not verify it.
 
                   "PreBaked" — operator does NOT touch NEO4J_PLUGINS. The user is
                   responsible for delivering the JAR via a custom Neo4j image referenced
@@ -110,9 +111,21 @@ spec:
                   applies the plugin's configuration (security allowlists, unrestricted
                   procedures, ConfigMap entries) so Neo4j accepts the procedures the
                   pre-baked JAR exposes.
+
+                  "VerifiedDownload" — the operator injects an init container into the
+                  target StatefulSet's pod template. The init container downloads
+                  source.url, verifies the SHA256/SHA512 against source.checksum,
+                  and drops the JAR into the shared /plugins emptyDir BEFORE the
+                  Neo4j entrypoint runs. NEO4J_PLUGINS is NOT mutated (preventing
+                  the entrypoint's own download from racing the verified JAR).
+                  Authenticated mirrors are supported via source.authSecret;
+                  internal CAs are supported via the cluster's spec.trustedCASecrets.
+                  On checksum mismatch the init container exits non-zero, the pod
+                  stays Pending, and Neo4jPlugin.status surfaces the failure.
                 enum:
                 - Managed
                 - PreBaked
+                - VerifiedDownload
                 type: string
               name:
                 description: Plugin name
@@ -152,8 +165,9 @@ spec:
                     type: string
                 type: object
               source:
-                description: Plugin source configuration. Ignored when installMode
-                  is "PreBaked".
+                description: |-
+                  Plugin source configuration. Required when installMode is
+                  "VerifiedDownload". Ignored when installMode is "PreBaked".
                 properties:
                   authSecret:
                     description: Secret containing authentication for private repositories

--- a/docs/api_reference/neo4jplugin.md
+++ b/docs/api_reference/neo4jplugin.md
@@ -274,6 +274,27 @@ into air-gapped clusters that need a mirrored image.
   JAR. For large JARs (GDS ≈ 30 MB) this is bandwidth-wasteful; a
   caching PVC is a planned follow-up.
 
+### Duplicate-CR protection (all install modes)
+
+Two `Neo4jPlugin` CRs in the same namespace that target the **same
+`spec.clusterRef`** with the **same `spec.name`** would race on the
+same `/plugins` directory and the same `NEO4J_PLUGINS` env value — one
+controller adds, the other removes, restart cycle. The reconciler
+detects this and refuses to install the duplicate:
+
+- The **oldest CR (by `creationTimestamp`)** keeps reconciling
+  normally. UID is the tiebreaker on identical timestamps.
+- The **newer duplicate** is marked `status.phase=Failed` with a
+  message naming the older CR, and a `PluginDuplicate` Warning Event
+  is emitted. It stops reconciling until the older CR is deleted.
+- A duplicate that's mid-delete (DeletionTimestamp set) doesn't block
+  its replacement — a stuck finalizer on the older CR can't lock out
+  the survivor.
+
+Action when you see `phase=Failed` with a duplicate message: delete
+the unwanted CR. The surviving CR reconciles on its next watch event
+(triggered by the deletion) and takes ownership.
+
 ## Examples
 
 ### APOC Plugin for Cluster

--- a/docs/api_reference/neo4jplugin.md
+++ b/docs/api_reference/neo4jplugin.md
@@ -85,8 +85,8 @@ kind: Neo4jPlugin
 | `name` | `string` | ✅ | Plugin name (e.g., "apoc", "graph-data-science") |
 | `version` | `string` | ✅ | Plugin version to install (must match Neo4j version compatibility) |
 | `enabled` | `boolean` | ❌ | Enable the plugin (default: `true`) |
-| `installMode` | `string` | ❌ | `Managed` (default) — operator adds plugin to `NEO4J_PLUGINS`. `PreBaked` — operator only writes config; JAR must be in a custom image. See [Supply-chain](#supply-chain). |
-| `source` | [`PluginSource`](#pluginsource) | ❌ | Plugin source configuration (default: official repository). Ignored when `installMode: PreBaked`. |
+| `installMode` | `string` | ❌ | `Managed` (default) — operator adds plugin to `NEO4J_PLUGINS`. `PreBaked` — operator only writes config; JAR must be in a custom image. `VerifiedDownload` — operator injects an init container that downloads `source.url` and verifies it against `source.checksum` before Neo4j starts. See [Supply-chain](#supply-chain). |
+| `source` | [`PluginSource`](#pluginsource) | ❌ | Plugin source configuration (default: official repository). **Required** when `installMode: VerifiedDownload`. Ignored when `installMode: PreBaked`. |
 | `dependencies` | [`[]PluginDependency`](#plugindependency) | ❌ | Plugin dependencies (automatically resolved) |
 | `config` | `map[string]string` | ❌ | Plugin-specific configuration (becomes `NEO4J_*` env vars) |
 | `security` | [`PluginSecurity`](#pluginsecurity) | ❌ | Security settings and procedure restrictions |
@@ -214,9 +214,65 @@ should never have to guess the algorithm.
 consume `source.checksum` at download time. The operator records the
 field for audit and exposes it on the StatefulSet, but enforcement at
 the moment of download requires either (a) pinning to PreBaked or (b)
-a future init-container verifier that re-hashes the JAR after the
-entrypoint has finished. Until that lands, treat `source.checksum` as
-attestation, not enforcement, and prefer PreBaked for production.
+the VerifiedDownload mode described next.
+
+### `installMode: VerifiedDownload` (verified download via init container)
+
+When `installMode: VerifiedDownload` is set, the operator injects an init
+container into the target StatefulSet's pod template. The init container
+downloads `spec.source.url`, computes the SHA256/SHA512 of the downloaded
+file, compares it against `spec.source.checksum`, and writes the JAR to
+the shared `/plugins` emptyDir **before** Neo4j starts. `NEO4J_PLUGINS`
+is **not** mutated for this plugin (same skip semantics as PreBaked) —
+the upstream entrypoint's own download path is bypassed entirely, so it
+can't race the verified JAR.
+
+```yaml
+apiVersion: neo4j.neo4j.com/v1beta1
+kind: Neo4jPlugin
+spec:
+  clusterRef: my-cluster
+  name: graph-data-science
+  version: "2.13.0"
+  installMode: VerifiedDownload
+  source:
+    type: url
+    url: https://github.com/neo4j/graph-data-science/releases/download/2.13.0/neo4j-graph-data-science-2.13.0.jar
+    checksum: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+```
+
+**Failure mode**: on checksum mismatch the init container exits non-zero,
+the pod stays Pending, and `kubectl describe pod` shows the failure on
+the init container's `state.terminated.message`. Fix the URL or checksum
+and reconcile — the next pod spawn re-runs the init container.
+
+**Authenticated mirrors** are supported via `spec.source.authSecret`.
+The named Secret should carry either a `token` key (used as
+`Authorization: Bearer <token>`) or a `header` key (used verbatim as the
+full `Authorization:` header value). Mounted at `/etc/plugin-auth` and
+consumed by the init script.
+
+**Internal CAs** are supported via the owning cluster's (or standalone's)
+`spec.trustedCASecrets` list. Each Secret's `ca.crt` (or the per-Secret
+`Key` override) is mounted under `/etc/plugin-ca`; the init script
+concatenates the certificates into a single CA bundle and points curl at
+it via `--cacert`.
+
+**Init container image** defaults to `curlimages/curl:8.5.0`. Override
+via the Helm chart's `pluginInitContainer.image` value when installing
+into air-gapped clusters that need a mirrored image.
+
+**Limitations**:
+- `spec.source.type` must be `url` or `custom` — the entrypoint's
+  `official`/`community` types resolve via an internal manifest the
+  user can't point at a verifiable URL, so they're rejected at admission.
+- `spec.dependencies` are rejected on a VerifiedDownload plugin —
+  mixed install paths in a single CR confuse the supply-chain story.
+  Create each dependency as its own `Neo4jPlugin` CR with its own
+  `source.url` + `checksum`.
+- Every pod restart re-runs the init container, which re-downloads the
+  JAR. For large JARs (GDS ≈ 30 MB) this is bandwidth-wasteful; a
+  caching PVC is a planned follow-up.
 
 ## Examples
 

--- a/internal/controller/events.go
+++ b/internal/controller/events.go
@@ -56,6 +56,13 @@ const (
 const (
 	EventReasonPluginInstalled     = "PluginInstalled"
 	EventReasonPluginInstallFailed = "PluginInstallFailed"
+	// EventReasonPluginDuplicate is emitted on a Neo4jPlugin when another
+	// CR in the same namespace targets the same clusterRef with the same
+	// spec.name. The reconciler refuses to install when this would cause
+	// two reconcilers to race on the same /plugins directory + the same
+	// NEO4J_PLUGINS env value; the older CR (by creationTimestamp) wins
+	// and the newer one is marked Failed.
+	EventReasonPluginDuplicate = "PluginDuplicate"
 )
 
 // Split-brain events

--- a/internal/controller/plugin_controller.go
+++ b/internal/controller/plugin_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -56,12 +57,45 @@ const (
 	// Operator still applies plugin configuration (security allowlists,
 	// unrestricted procedures, ConfigMap entries).
 	PluginInstallModePreBaked = "PreBaked"
+
+	// PluginInstallModeVerifiedDownload — operator injects an init
+	// container into the target StatefulSet that downloads spec.source.url,
+	// verifies the SHA256/SHA512 against spec.source.checksum, and drops
+	// the JAR into the shared /plugins emptyDir before Neo4j starts. As
+	// with PreBaked, NEO4J_PLUGINS is NOT mutated — the entrypoint's own
+	// download path is bypassed entirely so it can't race the verified
+	// JAR. Configuration env vars / ConfigMap entries still flow.
+	PluginInstallModeVerifiedDownload = "VerifiedDownload"
+
+	// PluginInitContainersAnnotation tracks the names of init containers
+	// the plugin controller owns on a given StatefulSet, so the controller
+	// can remove only its own containers on plugin uninstall without
+	// disturbing init containers added by other controllers / users.
+	// Value format: comma-separated list of container names.
+	PluginInitContainersAnnotation = "neo4j.com/plugin-init-containers"
 )
 
 // isPreBakedInstallMode reports whether the operator should skip the
 // NEO4J_PLUGINS env mutation for this plugin and only apply configuration.
 func isPreBakedInstallMode(plugin *neo4jv1beta1.Neo4jPlugin) bool {
 	return plugin.Spec.InstallMode == PluginInstallModePreBaked
+}
+
+// isVerifiedDownloadInstallMode reports whether the operator should
+// inject an init container for this plugin AND skip the NEO4J_PLUGINS
+// env mutation (same env-skip semantics as PreBaked, but with a new
+// JAR-delivery path).
+func isVerifiedDownloadInstallMode(plugin *neo4jv1beta1.Neo4jPlugin) bool {
+	return plugin.Spec.InstallMode == PluginInstallModeVerifiedDownload
+}
+
+// shouldSkipNeo4jPluginsEnv reports whether either of the
+// JAR-already-in-/plugins install modes is active. Both PreBaked and
+// VerifiedDownload share the "operator must NOT add this plugin to
+// NEO4J_PLUGINS" semantics — wrapping both into one predicate keeps
+// the callsite in installPluginViaEnvironment readable.
+func shouldSkipNeo4jPluginsEnv(plugin *neo4jv1beta1.Neo4jPlugin) bool {
+	return isPreBakedInstallMode(plugin) || isVerifiedDownloadInstallMode(plugin)
 }
 
 // getAdminSecretName safely extracts the admin secret name from cluster spec with fallback to default
@@ -86,6 +120,14 @@ type Neo4jPluginReconciler struct {
 	Scheme       *runtime.Scheme
 	Recorder     record.EventRecorder
 	RequeueAfter time.Duration
+
+	// PluginInitImage overrides the default init container image
+	// (resources.DefaultPluginInitContainerImage) used for
+	// VerifiedDownload mode. Wired from the operator's
+	// PLUGIN_INIT_CONTAINER_IMAGE env var which the helm chart sets
+	// from .Values.pluginInitContainer.image. Empty = use the default
+	// hardcoded in the resource builder.
+	PluginInitImage string
 }
 
 // PluginFinalizer is the finalizer for Neo4j plugin resources
@@ -494,6 +536,24 @@ func (r *Neo4jPluginReconciler) uninstallPlugin(ctx context.Context, plugin *neo
 		return nil
 	}
 
+	// VerifiedDownload installs need the init container + auth/CA
+	// volumes removed from the StatefulSet on uninstall — otherwise
+	// the next reconcile would still try to download and the pod
+	// would re-add the JAR to the emptyDir each restart. Done first
+	// so the PreBaked-style "skip JAR removal" guard below doesn't
+	// short-circuit the cleanup.
+	if isVerifiedDownloadInstallMode(plugin) {
+		if err := r.removeVerifiedDownloadInitContainer(ctx, plugin, deployment); err != nil {
+			// Non-fatal — the finalizer release shouldn't block on a
+			// reconcile race against the cluster controller. Next
+			// reconcile of the cluster will eventually drop the stale
+			// init container.
+			logger.Error(err, "Failed to remove VerifiedDownload init container; releasing finalizer anyway", "plugin", plugin.Spec.Name)
+		}
+		logger.Info("Removed VerifiedDownload init container", "plugin", plugin.Spec.Name)
+		return nil
+	}
+
 	// PreBaked installs are JARs the operator did not deliver — never run the
 	// jar-removal Job against them. The user-supplied custom image owns
 	// /plugins/*; touching it could orphan files the operator did not put
@@ -606,10 +666,17 @@ func (r *Neo4jPluginReconciler) updatePluginStatus(ctx context.Context, plugin *
 // This is the recommended approach by Neo4j for Docker plugin installation
 func (r *Neo4jPluginReconciler) installPluginViaEnvironment(ctx context.Context, plugin *neo4jv1beta1.Neo4jPlugin, deployment *DeploymentInfo) error {
 	logger := log.FromContext(ctx)
-	preBaked := isPreBakedInstallMode(plugin)
-	if preBaked {
+	// preBaked retained as the local variable name for diff stability —
+	// it gates the same code paths whether the user is bringing the JAR
+	// via a custom image (PreBaked) or via the operator-injected init
+	// container (VerifiedDownload).
+	preBaked := shouldSkipNeo4jPluginsEnv(plugin)
+	switch {
+	case isVerifiedDownloadInstallMode(plugin):
+		logger.Info("Configuring plugin in VerifiedDownload mode — injecting checksum-verifying init container, skipping NEO4J_PLUGINS mutation", "plugin", plugin.Spec.Name)
+	case isPreBakedInstallMode(plugin):
 		logger.Info("Configuring plugin in PreBaked mode — skipping NEO4J_PLUGINS mutation", "plugin", plugin.Spec.Name)
-	} else {
+	default:
 		logger.Info("Installing plugin via NEO4J_PLUGINS environment variable", "plugin", plugin.Spec.Name)
 	}
 
@@ -870,10 +937,226 @@ func (r *Neo4jPluginReconciler) installPluginViaEnvironment(ctx context.Context,
 
 	logger.Info("Successfully updated StatefulSet with plugin configuration", "plugin", pluginName)
 
+	// VerifiedDownload mode: after the regular config/env-var write,
+	// inject the checksum-verifying init container so the JAR lands in
+	// /plugins before Neo4j starts. This is the only code path that
+	// emits init containers; PreBaked relies on the user's custom
+	// image carrying the JAR, and Managed delegates to the entrypoint.
+	if isVerifiedDownloadInstallMode(plugin) {
+		if err := r.injectVerifiedDownloadInitContainer(ctx, plugin, deployment); err != nil {
+			return fmt.Errorf("failed to inject verified-download init container: %w", err)
+		}
+	}
+
 	// Note: ConfigMap updates for standalone deployments are now handled earlier in reconcile flow
 	// before connectivity checks to ensure security settings are applied before Neo4j starts
 
 	return nil
+}
+
+// injectVerifiedDownloadInitContainer adds (or updates) the plugin's
+// init container on the target StatefulSet's pod template, plus the
+// matching auth/CA volumes. Ownership-tracked via the
+// PluginInitContainersAnnotation so the controller can remove its
+// own containers on uninstall without disturbing foreign ones.
+//
+// Same retry-on-conflict mechanics as the env-var path — the
+// StatefulSet's ResourceVersion races with the cluster controller's
+// own reconciles.
+func (r *Neo4jPluginReconciler) injectVerifiedDownloadInitContainer(
+	ctx context.Context,
+	plugin *neo4jv1beta1.Neo4jPlugin,
+	deployment *DeploymentInfo,
+) error {
+	stsKey := types.NamespacedName{
+		Name:      r.getStatefulSetName(deployment),
+		Namespace: deployment.Namespace,
+	}
+	containerName := resources.PluginInitContainerName(plugin.Spec.Name)
+
+	// CA bundle is sourced from the OWNING cluster/standalone's
+	// trustedCASecrets field — the JAR fetch typically goes to an
+	// internal Artifactory using the same corporate CA the rest of
+	// the deployment already trusts.
+	var caSecrets []neo4jv1beta1.TrustedCASecret
+	switch deployment.Type {
+	case "cluster":
+		if c, ok := deployment.Object.(*neo4jv1beta1.Neo4jEnterpriseCluster); ok {
+			caSecrets = c.Spec.TrustedCASecrets
+		}
+	case "standalone":
+		if s, ok := deployment.Object.(*neo4jv1beta1.Neo4jEnterpriseStandalone); ok {
+			caSecrets = s.Spec.TrustedCASecrets
+		}
+	}
+
+	desired := resources.BuildPluginVerifiedDownloadInitContainer(plugin, r.PluginInitImage, caSecrets)
+	authVol := resources.BuildPluginAuthVolume(plugin)
+	caVol := resources.BuildPluginCAVolume(caSecrets)
+
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		sts := &appsv1.StatefulSet{}
+		if err := r.Get(ctx, stsKey, sts); err != nil {
+			return err
+		}
+
+		podSpec := &sts.Spec.Template.Spec
+
+		// Replace existing init container of the same name; otherwise append.
+		// Same name is the source of truth — Kubernetes itself enforces
+		// uniqueness, and our annotation tracks ownership for cleanup.
+		found := false
+		for i, ic := range podSpec.InitContainers {
+			if ic.Name == containerName {
+				podSpec.InitContainers[i] = desired
+				found = true
+				break
+			}
+		}
+		if !found {
+			podSpec.InitContainers = append(podSpec.InitContainers, desired)
+		}
+
+		// Add volumes if not already present (multiple VerifiedDownload
+		// plugins on the same cluster share the CA volume; each plugin
+		// has its own auth volume).
+		if authVol != nil && !podSpecHasVolume(podSpec, authVol.Name) {
+			podSpec.Volumes = append(podSpec.Volumes, *authVol)
+		}
+		if caVol != nil && !podSpecHasVolume(podSpec, caVol.Name) {
+			podSpec.Volumes = append(podSpec.Volumes, *caVol)
+		}
+
+		// Record ownership in the annotation so the uninstall path can
+		// remove only our init containers. The annotation lives on the
+		// PodTemplate annotation map so it travels with the spec
+		// fingerprint and triggers a rolling restart on change.
+		if sts.Spec.Template.Annotations == nil {
+			sts.Spec.Template.Annotations = map[string]string{}
+		}
+		owned := parsePluginInitOwned(sts.Spec.Template.Annotations[PluginInitContainersAnnotation])
+		if _, exists := owned[containerName]; !exists {
+			owned[containerName] = struct{}{}
+			sts.Spec.Template.Annotations[PluginInitContainersAnnotation] = formatPluginInitOwned(owned)
+		}
+
+		return r.Update(ctx, sts)
+	})
+}
+
+// removeVerifiedDownloadInitContainer is the inverse of
+// injectVerifiedDownloadInitContainer: drops the plugin's init
+// container from the StatefulSet PodSpec, removes the plugin-specific
+// auth volume if present, and updates the ownership annotation. The
+// shared CA volume is left alone — other VerifiedDownload plugins on
+// the same StatefulSet may still be using it; deleting it
+// unilaterally would break them.
+//
+// Idempotent: a second call (or a call after a delete-already-happened
+// scenario) is a no-op via the "not found" early returns.
+func (r *Neo4jPluginReconciler) removeVerifiedDownloadInitContainer(
+	ctx context.Context,
+	plugin *neo4jv1beta1.Neo4jPlugin,
+	deployment *DeploymentInfo,
+) error {
+	stsKey := types.NamespacedName{
+		Name:      r.getStatefulSetName(deployment),
+		Namespace: deployment.Namespace,
+	}
+	containerName := resources.PluginInitContainerName(plugin.Spec.Name)
+	authVolName := "plugin-auth-" + plugin.Spec.Name
+
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		sts := &appsv1.StatefulSet{}
+		if err := r.Get(ctx, stsKey, sts); err != nil {
+			if errors.IsNotFound(err) {
+				return nil // StatefulSet already gone — nothing to clean up.
+			}
+			return err
+		}
+
+		podSpec := &sts.Spec.Template.Spec
+		changed := false
+
+		// Strip the init container.
+		filtered := podSpec.InitContainers[:0]
+		for _, ic := range podSpec.InitContainers {
+			if ic.Name == containerName {
+				changed = true
+				continue
+			}
+			filtered = append(filtered, ic)
+		}
+		podSpec.InitContainers = filtered
+
+		// Strip the per-plugin auth volume (CA volume is shared — leave it).
+		filteredVols := podSpec.Volumes[:0]
+		for _, v := range podSpec.Volumes {
+			if v.Name == authVolName {
+				changed = true
+				continue
+			}
+			filteredVols = append(filteredVols, v)
+		}
+		podSpec.Volumes = filteredVols
+
+		// Drop ourselves from the ownership annotation.
+		if sts.Spec.Template.Annotations != nil {
+			owned := parsePluginInitOwned(sts.Spec.Template.Annotations[PluginInitContainersAnnotation])
+			if _, ok := owned[containerName]; ok {
+				delete(owned, containerName)
+				if len(owned) == 0 {
+					delete(sts.Spec.Template.Annotations, PluginInitContainersAnnotation)
+				} else {
+					sts.Spec.Template.Annotations[PluginInitContainersAnnotation] = formatPluginInitOwned(owned)
+				}
+				changed = true
+			}
+		}
+
+		if !changed {
+			return nil // Nothing to update — return without bumping ResourceVersion.
+		}
+		return r.Update(ctx, sts)
+	})
+}
+
+// podSpecHasVolume reports whether a volume of the given name is
+// already declared on the PodSpec. Used to avoid duplicate Volume
+// entries when multiple VerifiedDownload plugins land on the same
+// StatefulSet over successive reconciles.
+func podSpecHasVolume(podSpec *corev1.PodSpec, name string) bool {
+	for _, v := range podSpec.Volumes {
+		if v.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// parsePluginInitOwned + formatPluginInitOwned shuttle the comma-separated
+// annotation value through a set so add/remove operations are
+// order-independent and idempotent. Empty/whitespace tokens are
+// skipped.
+func parsePluginInitOwned(raw string) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, name := range strings.Split(raw, ",") {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		out[name] = struct{}{}
+	}
+	return out
+}
+
+func formatPluginInitOwned(set map[string]struct{}) string {
+	names := make([]string, 0, len(set))
+	for n := range set {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return strings.Join(names, ",")
 }
 
 // updateStandaloneConfigMapForPlugin updates the ConfigMap for standalone deployments with plugin security settings

--- a/internal/controller/plugin_controller.go
+++ b/internal/controller/plugin_controller.go
@@ -133,6 +133,68 @@ type Neo4jPluginReconciler struct {
 // PluginFinalizer is the finalizer for Neo4j plugin resources
 const PluginFinalizer = "neo4j.neo4j.com/plugin-finalizer"
 
+// checkForDuplicatePlugin lists every Neo4jPlugin in the same namespace
+// and returns the metadata.name of the CR that should "own" the
+// (clusterRef, plugin name) tuple — i.e. the one this controller will
+// actually reconcile. The newer duplicate is expected to drop itself
+// into Failed state and stop reconciling.
+//
+// Selection rules:
+//   - Candidates with a different clusterRef or a different plugin name
+//     are ignored.
+//   - Candidates currently being deleted (DeletionTimestamp != nil)
+//     are ignored — they're on their way out, no point handing them
+//     ownership.
+//   - Among the remaining candidates (including the plugin under
+//     reconciliation), the oldest CreationTimestamp wins; UID is the
+//     tiebreaker when timestamps collide (which is rare but possible
+//     in fast test loops).
+//
+// Returns the empty string if no other live CR contests the tuple —
+// the caller treats that the same as "this CR is the winner".
+func (r *Neo4jPluginReconciler) checkForDuplicatePlugin(
+	ctx context.Context,
+	plugin *neo4jv1beta1.Neo4jPlugin,
+) (string, error) {
+	list := &neo4jv1beta1.Neo4jPluginList{}
+	if err := r.List(ctx, list, client.InNamespace(plugin.Namespace)); err != nil {
+		return "", fmt.Errorf("failed to list Neo4jPlugin in namespace %q: %w", plugin.Namespace, err)
+	}
+
+	winner := plugin
+	contested := false
+	for i := range list.Items {
+		candidate := &list.Items[i]
+		if candidate.UID == plugin.UID {
+			continue
+		}
+		if candidate.Spec.ClusterRef != plugin.Spec.ClusterRef {
+			continue
+		}
+		if candidate.Spec.Name != plugin.Spec.Name {
+			continue
+		}
+		if candidate.DeletionTimestamp != nil {
+			continue
+		}
+		contested = true
+		// Older CreationTimestamp wins. If timestamps tie, lower UID
+		// wins — gives a deterministic ordering across replicas of
+		// the operator.
+		if candidate.CreationTimestamp.Before(&winner.CreationTimestamp) {
+			winner = candidate
+		} else if candidate.CreationTimestamp.Equal(&winner.CreationTimestamp) &&
+			string(candidate.UID) < string(winner.UID) {
+			winner = candidate
+		}
+	}
+
+	if !contested {
+		return "", nil
+	}
+	return winner.Name, nil
+}
+
 //+kubebuilder:rbac:groups=neo4j.neo4j.com,resources=neo4jplugins,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=neo4j.neo4j.com,resources=neo4jplugins/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=neo4j.neo4j.com,resources=neo4jplugins/finalizers,verbs=update
@@ -165,6 +227,32 @@ func (r *Neo4jPluginReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{Requeue: true}, nil
+	}
+
+	// Refuse to reconcile if another Neo4jPlugin CR already owns this
+	// (clusterRef, plugin name) tuple. Two reconcilers racing on the
+	// same /plugins directory + NEO4J_PLUGINS env var produces flapping
+	// state (one CR adds, the other removes, restart cycle). Validator
+	// can't catch this — it's structural-only, no cross-CR visibility.
+	// Resolved here at reconcile time with a deterministic "oldest
+	// wins" tiebreaker; newer duplicates surface the conflict via
+	// status + Event and stop reconciling. When the winner is deleted,
+	// the watch on Neo4jPlugin fires for the survivor — at which point
+	// the previously-failed duplicate becomes the new winner on its
+	// own next reconcile.
+	winner, dupErr := r.checkForDuplicatePlugin(ctx, plugin)
+	if dupErr != nil {
+		logger.Error(dupErr, "Failed to check for duplicate Neo4jPlugin CRs")
+		return ctrl.Result{}, dupErr
+	}
+	if winner != "" && winner != plugin.Name {
+		msg := fmt.Sprintf(
+			"duplicate Neo4jPlugin: %q (older) already targets cluster %q with plugin name %q; delete one CR before this one can reconcile",
+			winner, plugin.Spec.ClusterRef, plugin.Spec.Name,
+		)
+		r.updatePluginStatus(ctx, plugin, "Failed", msg)
+		r.Recorder.Event(plugin, corev1.EventTypeWarning, EventReasonPluginDuplicate, msg)
+		return ctrl.Result{}, nil
 	}
 
 	// Get target deployment (cluster or standalone)

--- a/internal/controller/plugin_install_mode_test.go
+++ b/internal/controller/plugin_install_mode_test.go
@@ -13,6 +13,7 @@ package controller
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -182,4 +183,160 @@ func TestInstallPluginViaEnvironment_PreBaked_PreservesExistingPluginsEnv(t *tes
 
 	pluginsVal, _ := findEnv(&got.Spec.Template.Spec.Containers[0], "NEO4J_PLUGINS")
 	assert.Equal(t, `["apoc"]`, pluginsVal, "PreBaked must not append GDS to a pre-existing NEO4J_PLUGINS")
+}
+
+// TestCheckForDuplicatePlugin_NoConflict — single CR, no other plugins
+// in the namespace. Returns "" (no contention).
+func TestCheckForDuplicatePlugin_NoConflict(t *testing.T) {
+	const ns = "default"
+	plugin := &neo4jv1beta1.Neo4jPlugin{
+		ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: ns, UID: "uid-1"},
+		Spec: neo4jv1beta1.Neo4jPluginSpec{
+			ClusterRef: "c1",
+			Name:       "apoc",
+			Version:    "5.26.0",
+		},
+	}
+	r := newPluginTestReconciler(t, plugin)
+
+	winner, err := r.checkForDuplicatePlugin(context.Background(), plugin)
+	require.NoError(t, err)
+	assert.Equal(t, "", winner, "no other CRs contesting -> empty winner string")
+}
+
+// TestCheckForDuplicatePlugin_OlderWins — two CRs for same
+// (clusterRef, name). The older one wins; the younger sees the older's
+// metadata.name returned and is expected to mark itself Failed.
+func TestCheckForDuplicatePlugin_OlderWins(t *testing.T) {
+	const ns = "default"
+	older := &neo4jv1beta1.Neo4jPlugin{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "older",
+			Namespace:         ns,
+			UID:               "uid-older",
+			CreationTimestamp: metav1.NewTime(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)),
+		},
+		Spec: neo4jv1beta1.Neo4jPluginSpec{ClusterRef: "c1", Name: "apoc", Version: "5.26.0"},
+	}
+	newer := &neo4jv1beta1.Neo4jPlugin{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "newer",
+			Namespace:         ns,
+			UID:               "uid-newer",
+			CreationTimestamp: metav1.NewTime(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)),
+		},
+		Spec: neo4jv1beta1.Neo4jPluginSpec{ClusterRef: "c1", Name: "apoc", Version: "5.26.0"},
+	}
+	r := newPluginTestReconciler(t, older, newer)
+
+	// From the newer's perspective: older wins.
+	winner, err := r.checkForDuplicatePlugin(context.Background(), newer)
+	require.NoError(t, err)
+	assert.Equal(t, "older", winner)
+
+	// From the older's perspective: it wins itself.
+	winner, err = r.checkForDuplicatePlugin(context.Background(), older)
+	require.NoError(t, err)
+	assert.Equal(t, "older", winner)
+}
+
+// TestCheckForDuplicatePlugin_IgnoresDifferentCluster — same plugin
+// name but different clusterRef is fine. Two clusters in the same
+// namespace can both install APOC; their CRs are independent.
+func TestCheckForDuplicatePlugin_IgnoresDifferentCluster(t *testing.T) {
+	const ns = "default"
+	a := &neo4jv1beta1.Neo4jPlugin{
+		ObjectMeta: metav1.ObjectMeta{Name: "apoc-on-a", Namespace: ns, UID: "uid-a"},
+		Spec:       neo4jv1beta1.Neo4jPluginSpec{ClusterRef: "cluster-a", Name: "apoc", Version: "5.26.0"},
+	}
+	b := &neo4jv1beta1.Neo4jPlugin{
+		ObjectMeta: metav1.ObjectMeta{Name: "apoc-on-b", Namespace: ns, UID: "uid-b"},
+		Spec:       neo4jv1beta1.Neo4jPluginSpec{ClusterRef: "cluster-b", Name: "apoc", Version: "5.26.0"},
+	}
+	r := newPluginTestReconciler(t, a, b)
+
+	winner, err := r.checkForDuplicatePlugin(context.Background(), a)
+	require.NoError(t, err)
+	assert.Equal(t, "", winner, "different clusterRef -> no contention")
+}
+
+// TestCheckForDuplicatePlugin_IgnoresDifferentPluginName — same
+// cluster but different plugin name is fine. A cluster can install
+// both APOC and GDS via two separate Neo4jPlugin CRs.
+func TestCheckForDuplicatePlugin_IgnoresDifferentPluginName(t *testing.T) {
+	const ns = "default"
+	apoc := &neo4jv1beta1.Neo4jPlugin{
+		ObjectMeta: metav1.ObjectMeta{Name: "apoc-cr", Namespace: ns, UID: "uid-apoc"},
+		Spec:       neo4jv1beta1.Neo4jPluginSpec{ClusterRef: "c1", Name: "apoc", Version: "5.26.0"},
+	}
+	gds := &neo4jv1beta1.Neo4jPlugin{
+		ObjectMeta: metav1.ObjectMeta{Name: "gds-cr", Namespace: ns, UID: "uid-gds"},
+		Spec:       neo4jv1beta1.Neo4jPluginSpec{ClusterRef: "c1", Name: "graph-data-science", Version: "2.13.0"},
+	}
+	r := newPluginTestReconciler(t, apoc, gds)
+
+	winner, err := r.checkForDuplicatePlugin(context.Background(), apoc)
+	require.NoError(t, err)
+	assert.Equal(t, "", winner, "different plugin name -> no contention")
+}
+
+// TestCheckForDuplicatePlugin_IgnoresDeletingCR — a duplicate that's
+// already mid-delete (DeletionTimestamp set) should not block the
+// surviving CR from taking ownership. Otherwise a stuck finalizer on
+// the older CR would lock out its replacement indefinitely.
+func TestCheckForDuplicatePlugin_IgnoresDeletingCR(t *testing.T) {
+	const ns = "default"
+	now := metav1.Now()
+	older := &neo4jv1beta1.Neo4jPlugin{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "older-deleting",
+			Namespace:         ns,
+			UID:               "uid-old",
+			CreationTimestamp: metav1.NewTime(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)),
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"neo4j.neo4j.com/plugin-finalizer"},
+		},
+		Spec: neo4jv1beta1.Neo4jPluginSpec{ClusterRef: "c1", Name: "apoc", Version: "5.26.0"},
+	}
+	newer := &neo4jv1beta1.Neo4jPlugin{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "newer-live",
+			Namespace:         ns,
+			UID:               "uid-new",
+			CreationTimestamp: metav1.NewTime(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)),
+		},
+		Spec: neo4jv1beta1.Neo4jPluginSpec{ClusterRef: "c1", Name: "apoc", Version: "5.26.0"},
+	}
+	r := newPluginTestReconciler(t, older, newer)
+
+	winner, err := r.checkForDuplicatePlugin(context.Background(), newer)
+	require.NoError(t, err)
+	assert.Equal(t, "", winner, "older being deleted -> newer takes over with no contention")
+}
+
+// TestCheckForDuplicatePlugin_UIDTiebreaker — when two CRs share the
+// exact same CreationTimestamp (fast test loops, kubectl apply
+// races), the lower UID wins. Deterministic across operator replicas.
+func TestCheckForDuplicatePlugin_UIDTiebreaker(t *testing.T) {
+	const ns = "default"
+	ts := metav1.NewTime(time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC))
+	a := &neo4jv1beta1.Neo4jPlugin{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "a", Namespace: ns, UID: "uid-aaaa",
+			CreationTimestamp: ts,
+		},
+		Spec: neo4jv1beta1.Neo4jPluginSpec{ClusterRef: "c1", Name: "apoc", Version: "5.26.0"},
+	}
+	b := &neo4jv1beta1.Neo4jPlugin{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "b", Namespace: ns, UID: "uid-bbbb",
+			CreationTimestamp: ts,
+		},
+		Spec: neo4jv1beta1.Neo4jPluginSpec{ClusterRef: "c1", Name: "apoc", Version: "5.26.0"},
+	}
+	r := newPluginTestReconciler(t, a, b)
+
+	winner, err := r.checkForDuplicatePlugin(context.Background(), b)
+	require.NoError(t, err)
+	assert.Equal(t, "a", winner, "lower UID wins the tiebreaker")
 }

--- a/internal/resources/plugin_init_container.go
+++ b/internal/resources/plugin_init_container.go
@@ -1,0 +1,284 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package resources
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
+)
+
+// DefaultPluginInitContainerImage is the curl+sha256sum image baked
+// into the resource builder when no override is provided. Helm exposes
+// Values.pluginInitContainer.image which is forwarded to the operator
+// via the PLUGIN_INIT_CONTAINER_IMAGE env var (downward to
+// cmd/main.go); air-gapped clusters point it at a mirror.
+//
+// curlimages/curl ships busybox under the hood, which gives us
+// sha256sum and sha512sum without a second binary. Pinned to a digest
+// would be even better, but the chart override is the right escape
+// hatch for users who want that level of pinning.
+const DefaultPluginInitContainerImage = "curlimages/curl:8.5.0"
+
+// PluginInitContainerName returns the deterministic name of the init
+// container the operator injects for a VerifiedDownload plugin. The
+// name is used both as the container's metadata.name AND as the value
+// tracked in the StatefulSet's neo4j.com/plugin-init-containers
+// annotation so the plugin controller can remove its own containers
+// on uninstall without disturbing foreign init containers (e.g.
+// truststore JKS builder injected by the cluster controller).
+func PluginInitContainerName(pluginName string) string {
+	// Container names must be a DNS-1123 label. The Neo4jPlugin's
+	// spec.name is already validated to that subset, so no further
+	// sanitisation is needed.
+	return "plugin-init-" + pluginName
+}
+
+// BuildPluginVerifiedDownloadInitContainer returns the init container
+// spec that downloads a single plugin's JAR, verifies its checksum
+// against spec.source.checksum, and drops the file into the shared
+// /plugins emptyDir before the Neo4j entrypoint runs.
+//
+//   - image     overrides DefaultPluginInitContainerImage when non-empty
+//     (sourced from the operator's PLUGIN_INIT_CONTAINER_IMAGE env var).
+//   - caSecrets is the cluster/standalone's TrustedCASecrets list. Each
+//     Secret's CA bundle is mounted under /etc/plugin-ca and curl is
+//     pointed at the resulting concatenated file. Empty list = system
+//     CA only.
+//
+// The script behaviour:
+//
+//  1. Reads PLUGIN_URL, PLUGIN_CHECKSUM, PLUGIN_TARGET from env.
+//  2. Optionally adds an Authorization header from /etc/plugin-auth/token
+//     when source.authSecret is set (mounted by the caller).
+//  3. curl --fail --location -o $PLUGIN_TARGET (with optional --cacert
+//     when CA bundle present).
+//  4. Computes sha256sum or sha512sum based on the checksum prefix.
+//  5. Compares against the expected value. Mismatch -> exit non-zero.
+//
+// Container resource limits are deliberately conservative (32Mi memory,
+// 50m CPU) — the script is a curl + hash, not a workload.
+func BuildPluginVerifiedDownloadInitContainer(
+	plugin *neo4jv1beta1.Neo4jPlugin,
+	image string,
+	caSecrets []neo4jv1beta1.TrustedCASecret,
+) corev1.Container {
+	if image == "" {
+		image = DefaultPluginInitContainerImage
+	}
+	if plugin.Spec.Source == nil {
+		// Defensive: the validator rejects VerifiedDownload without
+		// source, so this shouldn't fire. Returning a benign container
+		// instead of panicking keeps the operator resilient if the
+		// validator is bypassed (e.g. spec applied via raw apiserver).
+		return corev1.Container{Name: PluginInitContainerName(plugin.Spec.Name), Image: image}
+	}
+
+	envVars := []corev1.EnvVar{
+		{Name: "PLUGIN_NAME", Value: plugin.Spec.Name},
+		{Name: "PLUGIN_URL", Value: plugin.Spec.Source.URL},
+		{Name: "PLUGIN_CHECKSUM", Value: plugin.Spec.Source.Checksum},
+		// Target file lives under /plugins/<name>.jar. The Neo4j
+		// entrypoint loads anything matching /plugins/*.jar, so the
+		// filename convention matches what a manual install would
+		// produce.
+		{Name: "PLUGIN_TARGET", Value: "/plugins/" + plugin.Spec.Name + ".jar"},
+	}
+
+	volumeMounts := []corev1.VolumeMount{
+		{Name: pluginsVolumeName, MountPath: "/plugins"},
+	}
+
+	// Auth secret: if spec.source.authSecret is set, the caller wires
+	// the Secret as a projected volume at /etc/plugin-auth. We expect
+	// the Secret to carry either a `token` key (used as a Bearer
+	// header) or `header` (full Authorization header value). The
+	// script below probes for both in priority order.
+	if plugin.Spec.Source.AuthSecret != "" {
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      pluginAuthVolumeName(plugin.Spec.Name),
+			MountPath: "/etc/plugin-auth",
+			ReadOnly:  true,
+		})
+	}
+
+	// CA bundle: concatenate every TrustedCASecret's `ca.crt` (or the
+	// per-secret Key override) into a single file at runtime via the
+	// script — projection into /etc/plugin-ca/<secret>.crt. curl is
+	// then pointed at the concatenation.
+	if len(caSecrets) > 0 {
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      pluginCAVolumeName,
+			MountPath: "/etc/plugin-ca",
+			ReadOnly:  true,
+		})
+	}
+
+	return corev1.Container{
+		Name:            PluginInitContainerName(plugin.Spec.Name),
+		Image:           image,
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		Env:             envVars,
+		Command:         []string{"/bin/sh"},
+		Args:            []string{"-c", pluginInitScript(plugin.Spec.Source.AuthSecret != "", len(caSecrets) > 0)},
+		VolumeMounts:    volumeMounts,
+		SecurityContext: DefaultNeo4jContainerSecurityContext(),
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("16Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+				corev1.ResourceMemory: resource.MustParse("32Mi"),
+			},
+		},
+	}
+}
+
+// BuildPluginAuthVolume returns the projected Secret volume that
+// surfaces the authSecret to the init container. The caller is the
+// plugin controller — when merging the init container into the
+// StatefulSet PodSpec it must also append this volume.
+func BuildPluginAuthVolume(plugin *neo4jv1beta1.Neo4jPlugin) *corev1.Volume {
+	if plugin.Spec.Source == nil || plugin.Spec.Source.AuthSecret == "" {
+		return nil
+	}
+	return &corev1.Volume{
+		Name: pluginAuthVolumeName(plugin.Spec.Name),
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: plugin.Spec.Source.AuthSecret,
+			},
+		},
+	}
+}
+
+// BuildPluginCAVolume returns the projected volume that fans the
+// cluster's TrustedCASecrets into /etc/plugin-ca/<secret>.crt. nil if
+// no secrets are configured. Shared across all VerifiedDownload
+// plugins on the same cluster — only one volume per pod.
+func BuildPluginCAVolume(caSecrets []neo4jv1beta1.TrustedCASecret) *corev1.Volume {
+	if len(caSecrets) == 0 {
+		return nil
+	}
+	sources := make([]corev1.VolumeProjection, 0, len(caSecrets))
+	for _, s := range caSecrets {
+		key := s.Key
+		if key == "" {
+			key = "ca.crt"
+		}
+		sources = append(sources, corev1.VolumeProjection{
+			Secret: &corev1.SecretProjection{
+				LocalObjectReference: corev1.LocalObjectReference{Name: s.Name},
+				Items:                []corev1.KeyToPath{{Key: key, Path: s.Name + ".crt"}},
+			},
+		})
+	}
+	return &corev1.Volume{
+		Name: pluginCAVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			Projected: &corev1.ProjectedVolumeSource{Sources: sources},
+		},
+	}
+}
+
+// pluginInitScript is the /bin/sh body the init container executes.
+// withAuth and withCA gate the optional steps so the script remains
+// minimal in the common case (public URL, system CA).
+//
+// Failure semantics: any non-zero exit aborts. The pod stays Pending
+// with the init container's terminated reason visible via
+// `kubectl describe pod`; the plugin reconciler surfaces it into
+// Neo4jPlugin.status.message on the next reconcile.
+func pluginInitScript(withAuth, withCA bool) string {
+	var b strings.Builder
+	b.WriteString(`set -eu
+echo "[plugin-init] starting download for plugin=${PLUGIN_NAME} target=${PLUGIN_TARGET}"
+`)
+
+	// Build curl invocation. --fail makes HTTP errors non-zero,
+	// --location follows redirects (most plugin registries do), and
+	// --silent keeps logs readable while --show-error still prints on
+	// failure.
+	b.WriteString("CURL_ARGS=\"--fail --location --silent --show-error\"\n")
+
+	if withCA {
+		// Concatenate every certificate file in /etc/plugin-ca into a
+		// single bundle; curl accepts only one --cacert path. The
+		// projected volume drops files as <secret-name>.crt.
+		b.WriteString(`mkdir -p /tmp/plugin-init
+cat /etc/plugin-ca/*.crt > /tmp/plugin-init/ca-bundle.crt
+CURL_ARGS="${CURL_ARGS} --cacert /tmp/plugin-init/ca-bundle.crt"
+echo "[plugin-init] using custom CA bundle"
+`)
+	}
+
+	if withAuth {
+		// Auth Secret may carry one of two keys:
+		//   * token  — used as `Authorization: Bearer <token>`
+		//   * header — used verbatim as `Authorization: <value>`
+		// Probe in order. Either is enough; missing both is a hard
+		// error since the user explicitly opted into authSecret.
+		b.WriteString(`if [ -f /etc/plugin-auth/header ]; then
+    AUTH_HEADER="Authorization: $(cat /etc/plugin-auth/header)"
+elif [ -f /etc/plugin-auth/token ]; then
+    AUTH_HEADER="Authorization: Bearer $(cat /etc/plugin-auth/token)"
+else
+    echo "[plugin-init] ERROR: authSecret mounted but neither 'header' nor 'token' key present" >&2
+    exit 1
+fi
+CURL_ARGS="${CURL_ARGS} --header"
+echo "[plugin-init] using authenticated download"
+`)
+		// The actual curl invocation handles the header as a separate
+		// arg so the value can contain spaces safely.
+		b.WriteString(`curl ${CURL_ARGS} "${AUTH_HEADER}" -o "${PLUGIN_TARGET}" "${PLUGIN_URL}"
+`)
+	} else {
+		b.WriteString(`curl ${CURL_ARGS} -o "${PLUGIN_TARGET}" "${PLUGIN_URL}"
+`)
+	}
+
+	// Verify checksum. Prefix decides algorithm — validator enforced
+	// sha256:|sha512:.
+	b.WriteString(`case "${PLUGIN_CHECKSUM}" in
+    sha256:*) ALGO="sha256sum"; EXPECTED="${PLUGIN_CHECKSUM#sha256:}" ;;
+    sha512:*) ALGO="sha512sum"; EXPECTED="${PLUGIN_CHECKSUM#sha512:}" ;;
+    *) echo "[plugin-init] ERROR: unsupported checksum prefix in ${PLUGIN_CHECKSUM}" >&2; exit 1 ;;
+esac
+ACTUAL=$(${ALGO} "${PLUGIN_TARGET}" | awk '{print $1}')
+if [ "${ACTUAL}" != "${EXPECTED}" ]; then
+    echo "[plugin-init] ERROR: checksum mismatch for ${PLUGIN_NAME}" >&2
+    echo "[plugin-init]   expected: ${EXPECTED}" >&2
+    echo "[plugin-init]   actual:   ${ACTUAL}" >&2
+    rm -f "${PLUGIN_TARGET}"
+    exit 1
+fi
+echo "[plugin-init] verified ${PLUGIN_NAME} (${ALGO} ok)"
+`)
+
+	return b.String()
+}
+
+// Volume / mount names shared across the helpers. Constants so the
+// caller (plugin controller) can append the matching Volume to the
+// StatefulSet without re-deriving the name.
+const (
+	pluginsVolumeName  = "plugins"
+	pluginCAVolumeName = "plugin-ca"
+)
+
+func pluginAuthVolumeName(pluginName string) string {
+	// Volume names share the DNS-1123 namespace; the prefix keeps
+	// them obviously plugin-owned to the operator.
+	return "plugin-auth-" + pluginName
+}

--- a/internal/resources/plugin_init_container_test.go
+++ b/internal/resources/plugin_init_container_test.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package resources_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
+	"github.com/neo4j-partners/neo4j-kubernetes-operator/internal/resources"
+)
+
+// pluginWithSource returns a minimal Neo4jPlugin spec'd for
+// VerifiedDownload, with optional authSecret. Centralised so each
+// test case stays focused on the one shape it's asserting.
+func pluginWithSource(name, url, checksum, authSecret string) *neo4jv1beta1.Neo4jPlugin {
+	return &neo4jv1beta1.Neo4jPlugin{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: neo4jv1beta1.Neo4jPluginSpec{
+			Name:        name,
+			Version:     "1.0.0",
+			InstallMode: "VerifiedDownload",
+			Source: &neo4jv1beta1.PluginSource{
+				Type:       "url",
+				URL:        url,
+				Checksum:   checksum,
+				AuthSecret: authSecret,
+			},
+		},
+	}
+}
+
+// TestBuildPluginVerifiedDownloadInitContainer_DefaultImage locks in
+// the baked-in default when the caller passes "" — air-gapped clusters
+// override via the helm value but everyone else gets curlimages/curl.
+func TestBuildPluginVerifiedDownloadInitContainer_DefaultImage(t *testing.T) {
+	const validSHA256 = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	plugin := pluginWithSource("gds", "https://example.com/gds.jar", validSHA256, "")
+
+	c := resources.BuildPluginVerifiedDownloadInitContainer(plugin, "", nil)
+
+	assert.Equal(t, resources.PluginInitContainerName("gds"), c.Name)
+	assert.Equal(t, resources.DefaultPluginInitContainerImage, c.Image,
+		"empty image override must fall back to baked-in default")
+}
+
+// TestBuildPluginVerifiedDownloadInitContainer_ImageOverride confirms
+// the chart override flows through. Without this the air-gap escape
+// hatch from the helm value silently fails.
+func TestBuildPluginVerifiedDownloadInitContainer_ImageOverride(t *testing.T) {
+	const validSHA256 = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	plugin := pluginWithSource("gds", "https://example.com/gds.jar", validSHA256, "")
+
+	c := resources.BuildPluginVerifiedDownloadInitContainer(plugin, "internal.mirror/curl:8.5.0", nil)
+
+	assert.Equal(t, "internal.mirror/curl:8.5.0", c.Image)
+}
+
+// TestBuildPluginVerifiedDownloadInitContainer_EnvVarsCarryCheckpoint
+// verifies the four env vars the init script reads are present with
+// the expected values. The script depends on this contract — break it
+// and the script either no-ops or downloads the wrong thing.
+func TestBuildPluginVerifiedDownloadInitContainer_EnvVarsCarryCheckpoint(t *testing.T) {
+	const validSHA256 = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	plugin := pluginWithSource("gds", "https://example.com/gds.jar", validSHA256, "")
+
+	c := resources.BuildPluginVerifiedDownloadInitContainer(plugin, "", nil)
+
+	envMap := map[string]string{}
+	for _, e := range c.Env {
+		envMap[e.Name] = e.Value
+	}
+	assert.Equal(t, "gds", envMap["PLUGIN_NAME"])
+	assert.Equal(t, "https://example.com/gds.jar", envMap["PLUGIN_URL"])
+	assert.Equal(t, validSHA256, envMap["PLUGIN_CHECKSUM"])
+	assert.Equal(t, "/plugins/gds.jar", envMap["PLUGIN_TARGET"])
+}
+
+// TestBuildPluginVerifiedDownloadInitContainer_NoAuthNoCA asserts the
+// minimal-volume case: no authSecret, no trustedCASecrets. Only the
+// shared /plugins emptyDir mount should appear. Anything more is
+// scope creep that grows the pod spec for no reason.
+func TestBuildPluginVerifiedDownloadInitContainer_NoAuthNoCA(t *testing.T) {
+	const validSHA256 = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	plugin := pluginWithSource("gds", "https://example.com/gds.jar", validSHA256, "")
+
+	c := resources.BuildPluginVerifiedDownloadInitContainer(plugin, "", nil)
+
+	require.Len(t, c.VolumeMounts, 1, "no auth + no CA must produce only the /plugins mount")
+	assert.Equal(t, "/plugins", c.VolumeMounts[0].MountPath)
+	// Script must not reference the auth/ca branches.
+	assert.NotContains(t, c.Args[1], "AUTH_HEADER", "auth branch must be absent without authSecret")
+	assert.NotContains(t, c.Args[1], "ca-bundle.crt", "CA branch must be absent without trustedCASecrets")
+}
+
+// TestBuildPluginVerifiedDownloadInitContainer_WithAuth verifies the
+// authSecret volume mount + the script's auth-header branch land
+// together. Half-wiring (mount without script, or script without
+// mount) would silently fall back to anonymous downloads.
+func TestBuildPluginVerifiedDownloadInitContainer_WithAuth(t *testing.T) {
+	const validSHA256 = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	plugin := pluginWithSource("gds", "https://artifactory.example.com/gds.jar", validSHA256, "artifactory-creds")
+
+	c := resources.BuildPluginVerifiedDownloadInitContainer(plugin, "", nil)
+
+	var foundAuth bool
+	for _, vm := range c.VolumeMounts {
+		if vm.MountPath == "/etc/plugin-auth" {
+			foundAuth = true
+		}
+	}
+	assert.True(t, foundAuth, "authSecret must produce an /etc/plugin-auth mount")
+	script := c.Args[1]
+	assert.Contains(t, script, "/etc/plugin-auth/header")
+	assert.Contains(t, script, "/etc/plugin-auth/token")
+	assert.Contains(t, script, "Bearer")
+}
+
+// TestBuildPluginVerifiedDownloadInitContainer_WithCA verifies that
+// when trustedCASecrets are supplied, the script concatenates them
+// and points curl at the bundle. This is the path that lets internal
+// Artifactory behind a corporate CA work without manual init-image
+// customisation.
+func TestBuildPluginVerifiedDownloadInitContainer_WithCA(t *testing.T) {
+	const validSHA256 = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	plugin := pluginWithSource("gds", "https://internal/gds.jar", validSHA256, "")
+	caSecrets := []neo4jv1beta1.TrustedCASecret{
+		{Name: "corp-root-ca"},
+		{Name: "intermediate-ca", Key: "tls.crt"},
+	}
+
+	c := resources.BuildPluginVerifiedDownloadInitContainer(plugin, "", caSecrets)
+
+	var foundCA bool
+	for _, vm := range c.VolumeMounts {
+		if vm.MountPath == "/etc/plugin-ca" {
+			foundCA = true
+		}
+	}
+	assert.True(t, foundCA, "trustedCASecrets must produce an /etc/plugin-ca mount")
+	script := c.Args[1]
+	assert.Contains(t, script, "/etc/plugin-ca/*.crt")
+	assert.Contains(t, script, "--cacert")
+	assert.Contains(t, script, "ca-bundle.crt")
+}
+
+// TestBuildPluginCAVolume_PerSecretKey asserts the projected volume
+// honours per-Secret Key overrides (default "ca.crt"). cert-manager-
+// issued Secrets use that exact key, so the default works; custom
+// providers (Vault PKI, etc.) often emit tls.crt instead.
+func TestBuildPluginCAVolume_PerSecretKey(t *testing.T) {
+	caSecrets := []neo4jv1beta1.TrustedCASecret{
+		{Name: "corp-root-ca"},                    // implicit ca.crt
+		{Name: "intermediate-ca", Key: "tls.crt"}, // explicit override
+	}
+	vol := resources.BuildPluginCAVolume(caSecrets)
+
+	require.NotNil(t, vol)
+	require.NotNil(t, vol.Projected)
+	require.Len(t, vol.Projected.Sources, 2)
+
+	require.Len(t, vol.Projected.Sources[0].Secret.Items, 1)
+	assert.Equal(t, "ca.crt", vol.Projected.Sources[0].Secret.Items[0].Key,
+		"missing Key on TrustedCASecret must default to ca.crt")
+	assert.Equal(t, "corp-root-ca.crt", vol.Projected.Sources[0].Secret.Items[0].Path)
+
+	require.Len(t, vol.Projected.Sources[1].Secret.Items, 1)
+	assert.Equal(t, "tls.crt", vol.Projected.Sources[1].Secret.Items[0].Key)
+	assert.Equal(t, "intermediate-ca.crt", vol.Projected.Sources[1].Secret.Items[0].Path)
+}
+
+// TestPluginInitScript_ChecksumAlgoBranching verifies the script
+// dispatches to sha256sum vs sha512sum based on the checksum prefix.
+// Locking this in via test means a future refactor of the script
+// can't silently fall back to sha256 for a sha512:-prefixed value
+// (which would still pass the validator but mismatch every time).
+func TestPluginInitScript_ChecksumAlgoBranching(t *testing.T) {
+	plugin := pluginWithSource("gds", "https://x/y.jar",
+		"sha512:cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e", "")
+
+	c := resources.BuildPluginVerifiedDownloadInitContainer(plugin, "", nil)
+	script := c.Args[1]
+
+	// Script must reference both algos in the case-statement (sha256
+	// for backwards compat with most published checksums, sha512 for
+	// the user's choice). We don't test against a downloaded file —
+	// that's a live integration test, not a unit test. Lock in the
+	// case statement instead.
+	assert.True(t,
+		strings.Contains(script, "sha256:*)") && strings.Contains(script, "sha512:*)"),
+		"script must dispatch on both sha256: and sha512: prefixes")
+	assert.Contains(t, script, "sha256sum")
+	assert.Contains(t, script, "sha512sum")
+}

--- a/internal/validation/plugin_validator.go
+++ b/internal/validation/plugin_validator.go
@@ -91,6 +91,65 @@ func (v *PluginValidator) Validate(plugin *neo4jv1beta1.Neo4jPlugin) field.Error
 		allErrs = append(allErrs, v.validatePluginResources(plugin.Spec.Resources)...)
 	}
 
+	// Cross-field gates for installMode: VerifiedDownload.
+	allErrs = append(allErrs, v.validateVerifiedDownloadMode(plugin)...)
+
+	return allErrs
+}
+
+// validateVerifiedDownloadMode enforces the gates the VerifiedDownload
+// install mode requires for the init container's verified-download
+// flow to be coherent:
+//
+//   - source.url + source.checksum are mandatory (init container has
+//     nothing to download / verify without them).
+//   - source.type must be "url" or "custom" — the entrypoint's
+//     "official"/"community" types resolve via an internal manifest the
+//     user can't point at a verifiable URL.
+//   - dependencies are rejected. Mixed install paths in one CR
+//     (main plugin via init container, dependencies via NEO4J_PLUGINS
+//     entrypoint download) confuse the supply-chain story — each
+//     dependency should be its own Neo4jPlugin CR with its own
+//     verifiable URL.
+//
+// Same-name CR duplicate detection is enforced controller-side via
+// the plugin controller's reconcile (needs K8s client access).
+func (v *PluginValidator) validateVerifiedDownloadMode(plugin *neo4jv1beta1.Neo4jPlugin) field.ErrorList {
+	if plugin.Spec.InstallMode != "VerifiedDownload" {
+		return nil
+	}
+	var allErrs field.ErrorList
+
+	if plugin.Spec.Source == nil || plugin.Spec.Source.URL == "" {
+		allErrs = append(allErrs, field.Required(
+			field.NewPath("spec", "source", "url"),
+			"installMode: VerifiedDownload requires spec.source.url so the init container has somewhere to download from",
+		))
+	}
+	if plugin.Spec.Source == nil || plugin.Spec.Source.Checksum == "" {
+		allErrs = append(allErrs, field.Required(
+			field.NewPath("spec", "source", "checksum"),
+			"installMode: VerifiedDownload requires spec.source.checksum (sha256:<64 hex> or sha512:<128 hex>) for the init container to verify against",
+		))
+	}
+	if plugin.Spec.Source != nil {
+		switch plugin.Spec.Source.Type {
+		case "official", "community":
+			allErrs = append(allErrs, field.Invalid(
+				field.NewPath("spec", "source", "type"),
+				plugin.Spec.Source.Type,
+				"installMode: VerifiedDownload requires source.type=url or source.type=custom — official/community resolve via the Neo4j entrypoint's internal manifest and cannot be pointed at a verifiable URL",
+			))
+		}
+	}
+
+	if len(plugin.Spec.Dependencies) > 0 {
+		allErrs = append(allErrs, field.Forbidden(
+			field.NewPath("spec", "dependencies"),
+			"installMode: VerifiedDownload does not support spec.dependencies — each dependency must be its own Neo4jPlugin CR with its own spec.source.url + checksum so the entire chain is verified",
+		))
+	}
+
 	return allErrs
 }
 

--- a/internal/validation/plugin_validator_test.go
+++ b/internal/validation/plugin_validator_test.go
@@ -552,3 +552,93 @@ func TestPluginValidator_compareVersions(t *testing.T) {
 		})
 	}
 }
+
+// TestPluginValidator_VerifiedDownloadGates locks in the three
+// cross-field gates the VerifiedDownload install mode imposes. Each
+// gate exists for a specific reason in the supply-chain story —
+// breaking them silently makes the verified-download flow look
+// healthy while actually shipping unverified or partially-verified
+// JARs.
+func TestPluginValidator_VerifiedDownloadGates(t *testing.T) {
+	validator := NewPluginValidator()
+
+	const validSHA256 = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+	base := func(src *neo4jv1beta1.PluginSource, deps []neo4jv1beta1.PluginDependency) *neo4jv1beta1.Neo4jPlugin {
+		return &neo4jv1beta1.Neo4jPlugin{
+			ObjectMeta: metav1.ObjectMeta{Name: "p"},
+			Spec: neo4jv1beta1.Neo4jPluginSpec{
+				ClusterRef:   "c",
+				Name:         "apoc",
+				Version:      "5.26.0",
+				Enabled:      true,
+				InstallMode:  "VerifiedDownload",
+				Source:       src,
+				Dependencies: deps,
+			},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		source  *neo4jv1beta1.PluginSource
+		deps    []neo4jv1beta1.PluginDependency
+		wantErr bool
+		errSubs string
+	}{
+		{
+			name:   "valid url+checksum passes",
+			source: &neo4jv1beta1.PluginSource{Type: "url", URL: "https://x/p.jar", Checksum: validSHA256},
+		},
+		{
+			name:    "missing url is rejected",
+			source:  &neo4jv1beta1.PluginSource{Type: "url", Checksum: validSHA256},
+			wantErr: true, errSubs: "spec.source.url",
+		},
+		{
+			name:    "missing checksum is rejected",
+			source:  &neo4jv1beta1.PluginSource{Type: "url", URL: "https://x/p.jar"},
+			wantErr: true, errSubs: "spec.source.checksum",
+		},
+		{
+			name:    "type=official is rejected — no verifiable URL",
+			source:  &neo4jv1beta1.PluginSource{Type: "official", URL: "https://x/p.jar", Checksum: validSHA256},
+			wantErr: true, errSubs: "url or source.type=custom",
+		},
+		{
+			name:    "type=community is rejected — no verifiable URL",
+			source:  &neo4jv1beta1.PluginSource{Type: "community", URL: "https://x/p.jar", Checksum: validSHA256},
+			wantErr: true, errSubs: "url or source.type=custom",
+		},
+		{
+			name:   "type=custom passes with url+checksum",
+			source: &neo4jv1beta1.PluginSource{Type: "custom", URL: "https://x/p.jar", Checksum: validSHA256},
+		},
+		{
+			name:   "dependencies are rejected — each must be its own CR",
+			source: &neo4jv1beta1.PluginSource{Type: "url", URL: "https://x/p.jar", Checksum: validSHA256},
+			deps: []neo4jv1beta1.PluginDependency{
+				{Name: "apoc-core", VersionConstraint: ">=5.0.0"},
+			},
+			wantErr: true, errSubs: "spec.dependencies",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := validator.Validate(base(tt.source, tt.deps))
+			if tt.wantErr {
+				if len(errs) == 0 {
+					t.Fatalf("expected an error, got none")
+				}
+				if tt.errSubs != "" && !strings.Contains(errs.ToAggregate().Error(), tt.errSubs) {
+					t.Errorf("expected error to contain %q, got %v", tt.errSubs, errs)
+				}
+				return
+			}
+			if len(errs) > 0 {
+				t.Fatalf("expected no errors, got %v", errs)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes the runtime supply-chain enforcement gap that PR #96 documented but couldn't close inside the validator alone. New `installMode: VerifiedDownload` (alongside `Managed` and `PreBaked`) + the same-name CR duplicate-detection gate documented as a planned follow-up.

## VerifiedDownload mode in one paragraph

Set `installMode: VerifiedDownload` + `spec.source.url` + `spec.source.checksum`. Operator generates an init container (`curlimages/curl:8.5.0` by default; overridable via `.Values.pluginInitContainer.image` → `PLUGIN_INIT_CONTAINER_IMAGE` env var) that downloads the URL, computes `sha256sum` or `sha512sum` based on the checksum prefix, compares against `spec.source.checksum`, and drops the JAR into the shared `/plugins` `emptyDir` before Neo4j starts. **`NEO4J_PLUGINS` is NOT mutated for this plugin** (same skip semantics as `PreBaked`) so the entrypoint's own download can't race the verified JAR. Mismatch → init container exits non-zero → pod stays Pending → reconciler surfaces the failure via status.

## Duplicate-CR protection (all install modes)

The validator can't see other CRs (structural-only). Reconcile-time gate enforces: two `Neo4jPlugin` CRs in the same namespace contesting the same `(clusterRef, spec.name)` tuple are resolved by `creationTimestamp` (oldest wins), with `UID` as tiebreaker. CRs being deleted don't contest. Newer duplicates set `status.phase=Failed`, emit a `PluginDuplicate` Warning Event, and stop reconciling until the older CR is deleted.

## Scope decisions (per upstream design discussion)

- **Private-URL auth**: ✅ included. `spec.source.authSecret` → mounted at `/etc/plugin-auth`; script probes for `header` then `token` keys (Bearer fallback).
- **Custom CA bundle**: ✅ included. Owning cluster's `spec.trustedCASecrets` → projected at `/etc/plugin-ca/<secret>.crt`; script concatenates + points curl at `--cacert`.
- **Init image override**: ✅ baked-in default + Helm value `pluginInitContainer.image`.
- **`spec.dependencies + VerifiedDownload`**: rejected. Each dependency must be its own Neo4jPlugin CR with its own URL + checksum.
- **`source.type=official|community + VerifiedDownload`**: rejected. Those resolve via the entrypoint's internal manifest, no verifiable URL.
- **Duplicate-CR detection**: ✅ included. Was originally deferred; pulled into this PR per follow-up scope.

## Files

| File | Change |
|---|---|
| `api/v1beta1/neo4jplugin_types.go` | `InstallMode` enum expanded to `Managed;PreBaked;VerifiedDownload`. |
| `internal/resources/plugin_init_container.go` (new) | `BuildPluginVerifiedDownloadInitContainer`, `BuildPluginAuthVolume`, `BuildPluginCAVolume`, `PluginInitContainerName`, init-script generator. |
| `internal/validation/plugin_validator.go` | New `validateVerifiedDownloadMode` enforces source.url/checksum required, source.type ∈ {url, custom}, dependencies rejected. |
| `internal/controller/plugin_controller.go` | New mode constants, `isVerifiedDownloadInstallMode`/`shouldSkipNeo4jPluginsEnv`, `injectVerifiedDownloadInitContainer`, `removeVerifiedDownloadInitContainer`, `checkForDuplicatePlugin`. Annotation-tracked ownership via `neo4j.com/plugin-init-containers`. Reconcile gate against duplicate CRs. |
| `internal/controller/events.go` | New `EventReasonPluginDuplicate`. |
| `cmd/main.go` | `PluginInitImage` threaded through both reconciler construction sites. |
| `charts/neo4j-operator/values.yaml` | `pluginInitContainer.image` value. |
| `charts/neo4j-operator/templates/deployment.yaml` | Emits `PLUGIN_INIT_CONTAINER_IMAGE` env var when value is set. |
| `docs/api_reference/neo4jplugin.md` | New `VerifiedDownload` + `Duplicate-CR protection` subsections under Supply-chain. |
| Generated: CRD bases, helm CRDs, bundle CSV | Regenerated via `make sync-all bundle`. |

## Tests

- **8 init-container tests** (`internal/resources/plugin_init_container_test.go`): default image, override image, env var contract, no-auth/no-CA minimal volumes, with-auth script+mount, with-CA script+`--cacert`+mount, per-Secret Key override on the CA volume, sha256/sha512 script dispatch.
- **7 validator-gate sub-tests** (`TestPluginValidator_VerifiedDownloadGates`): valid url+checksum, missing url rejected, missing checksum rejected, official/community rejected, custom passes, dependencies rejected.
- **6 duplicate-detection tests** (`TestCheckForDuplicatePlugin_*`): no-conflict, older-wins, different-cluster ignored, different-name ignored, deleting-CR ignored, UID tiebreaker.
- `make test-unit` green; validation coverage `71.4% → 71.6%`.
- `make check-drift` green.

## Out of scope (called out in docs)

- JAR caching across pod restarts (every restart re-downloads — bandwidth-wasteful for GDS). Would need a PVC; follow-up PR.

## Test plan

- [x] `make test-unit` green.
- [x] `make check-drift` clean.
- [x] `make build` clean.
- [ ] Manual on Kind:
  - [ ] `Neo4jPlugin` with `installMode: VerifiedDownload` against a real GDS URL with correct sha256 — confirm init container exits 0, plugin loads.
  - [ ] Same CR with a deliberately-wrong checksum — confirm pod stays Pending with mismatch shown in `describe`.
  - [ ] `spec.source.authSecret` against an authenticated mirror — confirm Bearer token is sent.
  - [ ] Two CRs targeting same cluster + same plugin name — confirm newer goes Failed, deleting older lets the survivor recover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)