### PR TITLE
docs(security): add Kyverno conformance policy pack

### DIFF
--- a/docs/user_guide/security.md
+++ b/docs/user_guide/security.md
@@ -967,6 +967,18 @@ spec:
 
 > **Why TLS 1.3 over TLS 1.2.** PCI DSS v4.0 mandates a TLS 1.2 minimum but expects active migration toward TLS 1.3. Several adjacent regimes also discourage TLS 1.2 for new builds — FIPS-140-3 module validations and NIST SP 800-52r2 guidance both recommend TLS 1.3 as the baseline (the latter as guidance, not a strict prohibition). If every client in your environment supports TLS 1.3, drop `TLSv1.2` from the `tls_versions` list — the commented-out TLS 1.3-only target-state lines in the example above show the resulting hardened form.
 
+## Conformance Policies (Kyverno)
+
+A starter pack of [Kyverno](https://kyverno.io/) ClusterPolicies that
+audit Neo4j CRs against this operator's recommended production posture
+(enterprise image, TLS enabled, monitoring on, no `runAsNonRoot=false`
+override, explicit resource limits) is included at
+[`examples/security/policies/`](../../examples/security/policies/).
+All policies ship in `Audit` mode and match only user-facing CRs, so
+they never block operator reconciliation. See the directory's README
+for install, the Audit → Enforce migration path, and the list of
+bundled example CRs that intentionally trip Audit warnings.
+
 ## Security Best Practices Checklist
 
 ### Deployment Security

--- a/examples/security/policies/01-enterprise-image.yaml
+++ b/examples/security/policies/01-enterprise-image.yaml
@@ -1,0 +1,35 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: neo4j-enterprise-image-required
+  annotations:
+    policies.kyverno.io/title: Neo4j Enterprise image required
+    policies.kyverno.io/category: Neo4j Operator Conformance
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/subject: Neo4jEnterpriseCluster, Neo4jEnterpriseStandalone
+    policies.kyverno.io/description: >-
+      The Neo4j Operator only supports Neo4j Enterprise images. Community
+      images lack clustering, RBAC, and the procedures the operator depends on.
+      The operator's inline validator already rejects non-enterprise tags;
+      this policy is a defence-in-depth check that surfaces the issue at
+      admission time instead of inside a controller reconcile.
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: image-tag-must-be-enterprise
+      match:
+        any:
+          - resources:
+              kinds:
+                - neo4j.neo4j.com/v1beta1/Neo4jEnterpriseCluster
+                - neo4j.neo4j.com/v1beta1/Neo4jEnterpriseStandalone
+      validate:
+        message: >-
+          spec.image.tag must end with "-enterprise" (e.g. "5.26.0-enterprise"
+          or "2025.01.0-enterprise"). The Neo4j Operator does not support
+          Community Edition images.
+        pattern:
+          spec:
+            image:
+              tag: "*-enterprise"

--- a/examples/security/policies/02-tls-required.yaml
+++ b/examples/security/policies/02-tls-required.yaml
@@ -1,0 +1,33 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: neo4j-tls-required
+  annotations:
+    policies.kyverno.io/title: Neo4j TLS recommended
+    policies.kyverno.io/category: Neo4j Operator Conformance
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Neo4jEnterpriseCluster, Neo4jEnterpriseStandalone
+    policies.kyverno.io/description: >-
+      Audits Neo4j CRs that have TLS disabled. Production workloads should use
+      spec.tls.mode=cert-manager so Bolt/HTTPS traffic is encrypted and the
+      Bolt connector enforces tls_level=REQUIRED.
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: tls-must-not-be-disabled
+      match:
+        any:
+          - resources:
+              kinds:
+                - neo4j.neo4j.com/v1beta1/Neo4jEnterpriseCluster
+                - neo4j.neo4j.com/v1beta1/Neo4jEnterpriseStandalone
+      validate:
+        message: >-
+          spec.tls.mode is "disabled". Production deployments should set
+          spec.tls.mode=cert-manager with an issuerRef so Bolt traffic is
+          encrypted and the operator wires up SSL policies.
+        pattern:
+          spec:
+            =(tls):
+              mode: "!disabled"

--- a/examples/security/policies/03-monitoring-enabled.yaml
+++ b/examples/security/policies/03-monitoring-enabled.yaml
@@ -1,0 +1,35 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: neo4j-monitoring-enabled
+  annotations:
+    policies.kyverno.io/title: Neo4j monitoring recommended
+    policies.kyverno.io/category: Neo4j Operator Conformance
+    policies.kyverno.io/severity: low
+    policies.kyverno.io/subject: Neo4jEnterpriseCluster, Neo4jEnterpriseStandalone
+    policies.kyverno.io/description: >-
+      Audits Neo4j CRs that do not enable spec.monitoring. With monitoring
+      enabled the operator populates status.diagnostics (servers and
+      databases), evaluates the ServersHealthy and DatabasesHealthy
+      conditions, and exports the neo4j_operator_server_health Prometheus
+      metric.
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: monitoring-should-be-enabled
+      match:
+        any:
+          - resources:
+              kinds:
+                - neo4j.neo4j.com/v1beta1/Neo4jEnterpriseCluster
+                - neo4j.neo4j.com/v1beta1/Neo4jEnterpriseStandalone
+      validate:
+        message: >-
+          spec.monitoring.enabled is not true. Production deployments should
+          enable monitoring so the operator collects SHOW SERVERS / SHOW
+          DATABASES diagnostics and exposes per-server health metrics.
+        pattern:
+          spec:
+            monitoring:
+              enabled: true

--- a/examples/security/policies/04-runAsNonRoot-not-disabled.yaml
+++ b/examples/security/policies/04-runAsNonRoot-not-disabled.yaml
@@ -1,0 +1,54 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: neo4j-runAsNonRoot-not-disabled
+  annotations:
+    policies.kyverno.io/title: Neo4j must not override runAsNonRoot to false
+    policies.kyverno.io/category: Neo4j Operator Conformance
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/subject: Neo4jEnterpriseCluster, Neo4jEnterpriseStandalone
+    policies.kyverno.io/description: >-
+      The operator's default pod and container securityContext sets
+      runAsNonRoot=true. Users can override via spec.securityContext for
+      platforms like OpenShift, but overriding runAsNonRoot=false silently
+      lets Neo4j start as UID 0, which conflicts with Pod Security Standards
+      "restricted" and most cluster baselines. This policy audits any
+      override that explicitly disables runAsNonRoot.
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: pod-securityContext-runAsNonRoot
+      match:
+        any:
+          - resources:
+              kinds:
+                - neo4j.neo4j.com/v1beta1/Neo4jEnterpriseCluster
+                - neo4j.neo4j.com/v1beta1/Neo4jEnterpriseStandalone
+      validate:
+        message: >-
+          spec.securityContext.podSecurityContext.runAsNonRoot must not be
+          set to false. Remove the override (the operator default is true)
+          or set it to true explicitly.
+        pattern:
+          spec:
+            =(securityContext):
+              =(podSecurityContext):
+                =(runAsNonRoot): true
+    - name: container-securityContext-runAsNonRoot
+      match:
+        any:
+          - resources:
+              kinds:
+                - neo4j.neo4j.com/v1beta1/Neo4jEnterpriseCluster
+                - neo4j.neo4j.com/v1beta1/Neo4jEnterpriseStandalone
+      validate:
+        message: >-
+          spec.securityContext.containerSecurityContext.runAsNonRoot must not
+          be set to false. Remove the override (the operator default is true)
+          or set it to true explicitly.
+        pattern:
+          spec:
+            =(securityContext):
+              =(containerSecurityContext):
+                =(runAsNonRoot): true

--- a/examples/security/policies/05-resource-limits.yaml
+++ b/examples/security/policies/05-resource-limits.yaml
@@ -1,0 +1,37 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: neo4j-resource-limits-required
+  annotations:
+    policies.kyverno.io/title: Neo4j resource limits required
+    policies.kyverno.io/category: Neo4j Operator Conformance
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Neo4jEnterpriseCluster, Neo4jEnterpriseStandalone
+    policies.kyverno.io/description: >-
+      Audits Neo4j CRs without spec.resources.limits.memory or
+      spec.resources.limits.cpu. Neo4j Enterprise needs at least 1.5Gi of
+      memory and OOMKill loops are difficult to diagnose without explicit
+      limits. Requests-only configurations are accepted by the operator but
+      not recommended for production.
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: resource-limits-memory-and-cpu
+      match:
+        any:
+          - resources:
+              kinds:
+                - neo4j.neo4j.com/v1beta1/Neo4jEnterpriseCluster
+                - neo4j.neo4j.com/v1beta1/Neo4jEnterpriseStandalone
+      validate:
+        message: >-
+          spec.resources.limits.memory and spec.resources.limits.cpu should
+          both be set. Neo4j Enterprise requires at least 1.5Gi memory; set
+          explicit limits to avoid runaway memory growth and unbounded CPU.
+        pattern:
+          spec:
+            resources:
+              limits:
+                memory: "?*"
+                cpu: "?*"

--- a/examples/security/policies/README.md
+++ b/examples/security/policies/README.md
@@ -1,0 +1,119 @@
+# Kyverno Conformance Policies
+
+A pack of [Kyverno](https://kyverno.io/) ClusterPolicies that audit Neo4j
+Operator custom resources against the production posture this operator
+recommends. Use them as a starting point — copy into a cluster, run in
+`Audit` for a release or two, then graduate the ones that fit your
+environment to `Enforce`.
+
+## What's here
+
+| File | What it checks | Severity |
+|---|---|---|
+| `01-enterprise-image.yaml` | `spec.image.tag` ends with `-enterprise` | high |
+| `02-tls-required.yaml` | `spec.tls.mode != "disabled"` | medium |
+| `03-monitoring-enabled.yaml` | `spec.monitoring.enabled == true` | low |
+| `04-runAsNonRoot-not-disabled.yaml` | User does not override `runAsNonRoot=false` | high |
+| `05-resource-limits.yaml` | `spec.resources.limits.memory` and `.cpu` are set | medium |
+
+All five policies match only the operator's user-facing CRs
+(`Neo4jEnterpriseCluster`, `Neo4jEnterpriseStandalone`). They do **not**
+match the operator-emitted StatefulSets, Services, ConfigMaps, or any
+other downstream resources, so they do not interfere with reconciliation.
+
+## Will these break my operator or my CRs?
+
+No. By design:
+
+- **`validationFailureAction: Audit`** — every policy ships in Audit mode.
+  Violations are surfaced via `PolicyReport` / `ClusterPolicyReport`
+  resources and Kyverno's metrics; they do not block CREATE or UPDATE.
+- **No `status` interception** — Kyverno's `match.any.resources.kinds`
+  matches only the parent resource. Reconciler status writes go through
+  the `status` subresource and Kyverno does not validate those, so
+  status updates from the operator are never gated by these policies.
+- **Defence in depth** — policy 01 (enterprise image) duplicates the
+  operator's inline validator (CLAUDE.md guarantees community images are
+  rejected). Even if Kyverno is missing or disabled, the operator still
+  rejects the CR. The Kyverno pass just surfaces the same error at
+  admission time so users see it before a reconcile.
+
+If you graduate a policy to `Enforce`, the policy will reject CREATE /
+UPDATE that violates the pattern. The operator itself is never the one
+hitting these admission checks — only user-applied CRs are.
+
+## Install
+
+```bash
+# 1. Install Kyverno (see https://kyverno.io/docs/installation/)
+kubectl create -f https://github.com/kyverno/kyverno/releases/latest/download/install.yaml
+
+# 2. Apply the policy pack
+kubectl apply -f examples/security/policies/
+
+# 3. Inspect violations
+kubectl get clusterpolicyreport -A
+kubectl get policyreport -A
+```
+
+## Audit → Enforce migration
+
+When you are ready to move a policy from Audit to Enforce:
+
+```bash
+# Inspect what would be blocked
+kubectl get clusterpolicyreport -A -o json | jq '.items[].results[] | select(.policy=="neo4j-tls-required" and .result=="fail")'
+
+# Patch a single policy
+kubectl patch clusterpolicy neo4j-tls-required \
+  --type merge \
+  -p '{"spec":{"validationFailureAction":"Enforce"}}'
+```
+
+Suggested rollout order:
+
+1. `neo4j-enterprise-image-required` — already enforced by the operator;
+   moving to Enforce just shifts the rejection earlier. Safe.
+2. `neo4j-runAsNonRoot-not-disabled` — only fires on explicit overrides,
+   so most users are not affected.
+3. `neo4j-resource-limits-required` — surfaces production-readiness gaps.
+4. `neo4j-tls-required` — keep Audit on dev/test namespaces, Enforce on
+   prod namespaces (use Kyverno's `match.any.resources.namespaces` to
+   scope).
+5. `neo4j-monitoring-enabled` — lowest severity, keep in Audit unless
+   monitoring is contractually required.
+
+## Expected Audit warnings on the bundled examples
+
+These example CRs intentionally use minimal configuration and will show
+up in `PolicyReport` once the pack is applied. They are not bugs — they
+are valid configurations for development and the policies are advisory:
+
+| Example | Will fail |
+|---|---|
+| `examples/clusters/minimal-cluster.yaml` | 02 (tls disabled), 03 (no monitoring) |
+| `examples/clusters/auth-example.yaml` | 02, 03 |
+| `examples/clusters/cluster-with-read-replicas.yaml` | 02, 03 |
+| `examples/clusters/storage-expansion.yaml` | 02, 03 |
+| `examples/clusters/three-node-simple.yaml` | 02, 03 |
+| `examples/standalone/single-node-standalone.yaml` | 02 |
+| `examples/standalone/ldap-standalone.yaml` | 02, 03 |
+| `examples/clusters/tls-cluster*.yaml` | 03 (most have monitoring unset) |
+| `examples/clusters/production-optimized-cluster.yaml` | 03 |
+
+Most cluster examples that enable TLS still leave `spec.monitoring`
+unset; production deployments should set `spec.monitoring.enabled: true`.
+
+## Limitations
+
+- These policies do not validate operator-emitted resources (StatefulSet
+  pods, init containers, services). Use Kyverno's own
+  [pod-security-standards](https://kyverno.io/policies/pod-security/)
+  policies in parallel if you want to gate the pods the operator creates.
+- They do not check `Neo4jBackup`, `Neo4jRestore`, `Neo4jDatabase`,
+  `Neo4jUser`, `Neo4jRole`, `Neo4jRoleBinding`, `Neo4jPlugin`, or
+  `Neo4jAuthRule` CRs. The validation those CRs need is already inline
+  in the controllers (see CLAUDE.md rule 26).
+- Pattern matching uses Kyverno v1 syntax. If you are on an older
+  Kyverno version (<1.10) the `=(field)` conditional anchor and the
+  multi-kind `match.any.resources.kinds` form may need adjustment.


### PR DESCRIPTION
## Summary

Five Audit-mode Kyverno ClusterPolicies under `examples/security/policies/` that audit Neo4j CRs against the operator's recommended production posture, plus a README and a one-paragraph cross-reference in the security guide.

| Policy | Checks | Severity |
|---|---|---|
| `01-enterprise-image.yaml` | `spec.image.tag` ends with `-enterprise` | high |
| `02-tls-required.yaml` | `spec.tls.mode != "disabled"` | medium |
| `03-monitoring-enabled.yaml` | `spec.monitoring.enabled == true` | low |
| `04-runAsNonRoot-not-disabled.yaml` | User does not override `runAsNonRoot=false` (pod + container) | high |
| `05-resource-limits.yaml` | `spec.resources.limits.memory` and `.cpu` are set | medium |

Addresses security review item #7 Part A (conformance policies).

## Will this break the operator or existing CRs?

No. By design:

- **`validationFailureAction: Audit`** on every policy — violations surface as `PolicyReport` / `ClusterPolicyReport` resources, not as admission rejections.
- **Matches only user-facing CRs** (`Neo4jEnterpriseCluster`, `Neo4jEnterpriseStandalone`). Operator-emitted resources (StatefulSet, Service, ConfigMap, init containers) are never matched.
- **Does not intercept `status` subresource writes**, so reconciler status updates are never gated.
- **Defence in depth**: policy 01 duplicates the operator's inline validator. If Kyverno is missing or disabled the operator still rejects community images.

## What changes for users today?

The README catalogues which bundled example CRs intentionally trip warnings once the pack is installed (e.g. `minimal-cluster.yaml` will show Audit warnings for 02 and 03). These are advisory — the example CRs remain valid for dev/test.

No code, CRD, controller, or Helm-chart changes. Pure additive documentation + examples.

## Test plan

- [ ] `helm install kyverno kyverno/kyverno` on a Kind cluster, `kubectl apply -f examples/security/policies/`, confirm all five ClusterPolicies reach `Ready`.
- [ ] Apply `examples/clusters/minimal-cluster.yaml` and confirm: CR is admitted, operator reconciles to Ready, and `PolicyReport` shows the expected 02 + 03 failures (no others).
- [ ] Apply `examples/clusters/tls-cluster-production.yaml` and confirm only 03 fires (TLS is enabled, monitoring is not).
- [ ] Patch one policy to `Enforce` and confirm a fresh non-conforming CR is rejected at admission, while the operator's pre-existing reconciliations on already-admitted CRs continue unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)