### PR TITLE
chore(cluster): remove dead isNeo4jVersion526OrHigher

### DIFF
--- a/internal/resources/cluster.go
+++ b/internal/resources/cluster.go
@@ -1842,13 +1842,6 @@ func BuildMonitoringConfig(mon *neo4jv1beta1.MonitoringSpec) string {
 	return strings.Join(lines, "\n") + "\n"
 }
 
-// isNeo4jVersion526OrHigher checks if the Neo4j image is the 5.26.x semver LTS release.
-// Neo4j moved to CalVer (2025.x.x) after 5.26 — no 5.27+ semver versions exist.
-// CalVer images are handled separately via version.IsCalver checks.
-func isNeo4jVersion526OrHigher(imageTag string) bool {
-	return strings.Contains(imageTag, "5.26")
-}
-
 // IsNeo4jVersion202512OrHigher checks if the Neo4j version supports property sharding.
 // Property sharding (Infinigraph) was introduced in 2025.12; calver only — no semver version supports it.
 // See: https://neo4j.com/docs/operations-manual/current/scalability/sharded-property-databases/overview/


### PR DESCRIPTION
## Summary

Removes \`isNeo4jVersion526OrHigher\` from \`internal/resources/cluster.go\`. The function has no callers — the only call site was inlined to use \`neo4j.ParseVersion\` directly in commit b8c561b (the MCP / CalVer refactor) and the function survived as dead code.

## Why not just fix it?

The original implementation was \`strings.Contains(imageTag, \"5.26\")\`. That falsely matches:

- CalVer tags like \`2025.26.0-enterprise\`
- Ill-formed semver tags like \`5.260\`, \`5.261\`
- Hypothetical \`15.26.x\` etc.

Any future caller wiring it up would inherit the bug. Since there is no caller today and the canonical pattern (\`version.Major == 5 && version.Minor >= 26\` against \`neo4j.ParseVersion\`) is already used by the live \`IsNeo4jVersion202512OrHigher\` / \`IsNeo4jVersion202510OrHigher\` / \`getKubernetesDiscoveryParameter\` call sites, dead-code removal is the right outcome.

## Test plan

- [x] \`go build ./...\` — passes
- [x] pre-commit hooks (golangci-lint, staticcheck, drift gate) — passed locally
- [ ] CI unit + lint suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)