### PR TITLE
docs: fix v1alpha1 example + consolidate OIDC HTTPS warning

### DIFF
--- a/docs/user_guide/migration_guide.md
+++ b/docs/user_guide/migration_guide.md
@@ -704,7 +704,7 @@ v1.6.0-alpha included breaking changes to the `v1alpha1` API to stabilize fields
 
 Example — before:
 ```yaml
-apiVersion: neo4j.neo4j.com/v1beta1
+apiVersion: neo4j.neo4j.com/v1alpha1
 kind: Neo4jRestore
 spec:
   targetCluster: my-cluster
@@ -716,7 +716,7 @@ spec:
 
 After:
 ```yaml
-apiVersion: neo4j.neo4j.com/v1beta1
+apiVersion: neo4j.neo4j.com/v1alpha1
 kind: Neo4jRestore
 spec:
   clusterRef: my-cluster

--- a/docs/user_guide/security.md
+++ b/docs/user_guide/security.md
@@ -248,11 +248,9 @@ stringData:
 
 ### OIDC / SSO Integration
 
-> **Prerequisite (Neo4j 2026.x): OIDC endpoints must use HTTPS.** Configure TLS for your identity provider (or place it behind a TLS-terminating proxy) before enabling OIDC. Neo4j validates every OIDC URI at config-parse time; any `http://` value causes startup to fail with `Error evaluating value for setting … does not have required scheme 'https'`. There is no insecure-mode override.
+> **⚠️ Prerequisite (Neo4j 2026.x): OIDC endpoints must use HTTPS.** `wellKnownDiscoveryURI`, `authEndpoint`, `tokenEndpoint`, `jwksURI`, `userInfoURI`, and `issuer` are all validated at config-parse time; any `http://` value causes Neo4j to refuse to start with `Error evaluating value for setting … does not have required scheme 'https'`. There is no insecure-mode override. Configure TLS for your identity provider — or place it behind a TLS-terminating proxy — before enabling OIDC. Self-hosted IDPs that default to HTTP in dev need a TLS-terminating proxy (and the proxy's CA in [`spec.trustedCASecrets`](#jvm-truststore-for-internal-cas)) before the cluster can boot.
 
 The operator supports one or more OIDC providers via the `spec.auth.oidc` map. Each key becomes the provider name in Neo4j's config (`dbms.security.oidc.<name>.*`).
-
-> **⚠️ Neo4j 2026.x requires HTTPS for every OIDC URI.** `wellKnownDiscoveryURI`, `authEndpoint`, `tokenEndpoint`, `jwksURI`, `userInfoURI`, and `issuer` are all validated at config-parse time; an `http://` value causes Neo4j to refuse to start with `Error evaluating value for setting … does not have required scheme 'https'`. There is no insecure-mode override. Self-hosted IDPs that default to HTTP in dev need a TLS-terminating proxy (and the proxy's CA in [`spec.trustedCASecrets`](#jvm-truststore-for-internal-cas)) before the cluster can boot.
 
 #### OIDC and ABAC setup checklist
 


### PR DESCRIPTION
## Summary

Two small documentation cleanups surfaced during review of the migration and security guides.

### \`docs/user_guide/migration_guide.md\`

The \"Upgrading to v1.6.0-alpha\" section had a before/after \`Neo4jRestore\` example that used \`apiVersion: neo4j.neo4j.com/v1beta1\` — but v1beta1 wasn't introduced until v1.7.0-alpha (called out a few hundred lines higher in the same file). Both before and after now correctly use \`v1alpha1\` so the example is internally consistent with the section it lives under.

### \`docs/user_guide/security.md\`

The OIDC / SSO section opened with two nearly identical blockquote warnings about Neo4j 2026.x requiring HTTPS — four lines apart. Consolidated into a single prerequisite blockquote at the top of the section that retains every detail of both:

- the list of validated URI fields (\`wellKnownDiscoveryURI\`, \`authEndpoint\`, …, \`issuer\`)
- the parse-time failure mode and the no-insecure-override fact
- the dev-time TLS-terminating proxy guidance
- the truststore cross-link

No new content, no deleted content — just deduplication.

## Test plan

- [x] mdformat / yamllint / drift-gate pre-commit hooks pass
- [ ] manual rendering check on GitHub
- [ ] CI lint suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)