### PR TITLE
fix(restore): coordinate scale-down with cluster controller via annotation (#117)

### DIFF
--- a/internal/controller/neo4jenterprisecluster_controller.go
+++ b/internal/controller/neo4jenterprisecluster_controller.go
@@ -570,6 +570,20 @@ func (r *Neo4jEnterpriseClusterReconciler) CreateOrUpdateResource(ctx context.Co
 	return r.createOrUpdateResource(ctx, obj, owner)
 }
 
+// replicasReconciliationPaused reports whether the cluster controller should
+// leave sts.Spec.Replicas alone for this owner. Today the only pause signal
+// is the restore-in-progress annotation set by Neo4jRestoreReconciler (issue
+// #117), but extracting the check makes the gate testable in isolation and
+// gives a single place to add new pause signals (e.g. operator-wide
+// maintenance mode) without touching the resource builder.
+func replicasReconciliationPaused(owner client.Object) bool {
+	if owner == nil {
+		return false
+	}
+	_, paused := owner.GetAnnotations()[RestoreInProgressAnnotation]
+	return paused
+}
+
 func (r *Neo4jEnterpriseClusterReconciler) createOrUpdateResource(ctx context.Context, obj client.Object, owner client.Object) error {
 	logger := log.FromContext(ctx)
 
@@ -656,8 +670,17 @@ func (r *Neo4jEnterpriseClusterReconciler) createOrUpdateResourceInternal(ctx co
 				originalMeta := sts.ObjectMeta.DeepCopy()
 				originalStatus := sts.Status.DeepCopy()
 
-				// Apply desired spec
-				sts.Spec.Replicas = desiredSpec.Replicas
+				// Apply desired spec — but yield on replicas while a
+				// Neo4jRestore is coordinating a scale-down → restore →
+				// scale-up cycle on this cluster (issue #117). Without
+				// this gate the cluster controller races the restore
+				// controller every reconcile and the scale-to-0 never
+				// sticks. Only the replicas line is skipped; everything
+				// else (services, ConfigMap, certs, template updates)
+				// continues to reconcile normally.
+				if !replicasReconciliationPaused(owner) {
+					sts.Spec.Replicas = desiredSpec.Replicas
+				}
 				sts.Spec.UpdateStrategy = desiredSpec.UpdateStrategy
 				sts.Spec.PersistentVolumeClaimRetentionPolicy = desiredSpec.PersistentVolumeClaimRetentionPolicy
 				sts.Spec.MinReadySeconds = desiredSpec.MinReadySeconds

--- a/internal/controller/neo4jrestore_controller.go
+++ b/internal/controller/neo4jrestore_controller.go
@@ -61,6 +61,23 @@ const (
 	SourceTypeGCS    = "gcs"
 )
 
+// RestoreInProgressAnnotation is set on the target Neo4jEnterpriseCluster /
+// Neo4jEnterpriseStandalone CR while a Neo4jRestore is actively coordinating
+// a scale-down → restore → scale-up cycle. Its value is the name of the
+// owning Neo4jRestore CR.
+//
+// The Neo4jEnterpriseClusterReconciler reads this annotation and, when set,
+// stops forcing sts.Spec.Replicas back to spec.topology.servers — so the
+// restore controller's scale-to-0 actually sticks. Without this coordination
+// the two controllers race on every reconcile (issue #117) and the cluster
+// never goes offline, leaving neo4j-admin restore unable to acquire the
+// database file lock.
+//
+// The annotation is set immediately before stopCluster() and cleared in
+// every restore exit path: startCluster() on success, the finalizer on CR
+// delete, and the failure path when stopCluster itself fails.
+const RestoreInProgressAnnotation = "neo4j.com/restore-in-progress"
+
 // Neo4jRestoreReconciler reconciles a Neo4jRestore object
 type Neo4jRestoreReconciler struct {
 	client.Client
@@ -177,6 +194,17 @@ func (r *Neo4jRestoreReconciler) handleDeletion(ctx context.Context, restore *ne
 		return ctrl.Result{RequeueAfter: r.RequeueAfter}, err
 	}
 
+	// Release the cluster controller's hold on STS replicas if this restore
+	// died mid-cycle (e.g. user deleted the CR while stopCluster was in
+	// progress). Without this the target cluster is permanently un-scalable.
+	// Idempotent — only clears the annotation if THIS restore set it. Issue #117.
+	if restore.Spec.ClusterRef != "" {
+		if err := r.clearRestoreInProgressAnnotation(ctx, restore, restore.Spec.ClusterRef, restore.Namespace); err != nil {
+			logger.Error(err, "Failed to clear restore-in-progress annotation during finalizer cleanup")
+			return ctrl.Result{RequeueAfter: r.RequeueAfter}, err
+		}
+	}
+
 	// Remove finalizer
 	controllerutil.RemoveFinalizer(restore, RestoreFinalizer)
 	return ctrl.Result{}, r.Update(ctx, restore)
@@ -208,10 +236,34 @@ func (r *Neo4jRestoreReconciler) startRestore(ctx context.Context, restore *neo4
 
 	// Stop cluster if required
 	if restore.Spec.StopCluster {
+		// Mark the cluster as having a restore in progress BEFORE scaling
+		// the STS to 0 — otherwise the cluster controller scales it right
+		// back up on its next reconcile (issue #117).
+		if err := r.setRestoreInProgressAnnotation(ctx, restore, cluster); err != nil {
+			logger.Error(err, "Failed to set restore-in-progress annotation")
+			r.updateRestoreStatus(ctx, restore, StatusFailed, fmt.Sprintf("Failed to coordinate cluster scale-down: %v", err))
+			return ctrl.Result{RequeueAfter: r.RequeueAfter}, err
+		}
 		if err := r.stopCluster(ctx, cluster); err != nil {
 			logger.Error(err, "Failed to stop cluster")
+			// Clear the annotation so the cluster controller resumes
+			// reconciling replicas — otherwise a failed stopCluster
+			// leaves the cluster permanently un-scalable.
+			if cleanupErr := r.clearRestoreInProgressAnnotation(ctx, restore, cluster.Name, cluster.Namespace); cleanupErr != nil {
+				logger.Error(cleanupErr, "Failed to clear restore-in-progress annotation after stopCluster failure")
+			}
 			r.updateRestoreStatus(ctx, restore, StatusFailed, fmt.Sprintf("Failed to stop cluster: %v", err))
 			return ctrl.Result{RequeueAfter: r.RequeueAfter}, err
+		}
+	} else {
+		// stopCluster=false means "the cluster is already quiesced — don't
+		// touch the STS." Refuse if any server pods are still running:
+		// silently writing the restore into a fresh PVC mount (or, worse
+		// pre-fix, into an EmptyDir) is invisible data loss (issue #117).
+		if err := r.refuseRestoreIfPodsRunning(ctx, restore, cluster); err != nil {
+			logger.Error(err, "Refusing restore against running cluster")
+			r.updateRestoreStatus(ctx, restore, StatusFailed, err.Error())
+			return ctrl.Result{}, err
 		}
 	}
 
@@ -285,6 +337,16 @@ func (r *Neo4jRestoreReconciler) handleRestoreSuccess(ctx context.Context, resto
 			logger.Error(err, "Failed to start cluster after restore")
 			r.updateRestoreStatus(ctx, restore, StatusFailed, fmt.Sprintf("Failed to start cluster after restore: %v", err))
 			return ctrl.Result{RequeueAfter: r.RequeueAfter}, err
+		}
+
+		// Release the cluster controller's hold on Replicas now that we've
+		// scaled the STS back to the original count. Subsequent cluster
+		// reconciles re-assert sts.Spec.Replicas = spec.topology.servers,
+		// which equals the value startCluster just wrote — so this is
+		// safe with no flap. Issue #117.
+		if err := r.clearRestoreInProgressAnnotation(ctx, restore, cluster.Name, cluster.Namespace); err != nil {
+			logger.Error(err, "Failed to clear restore-in-progress annotation")
+			// Non-fatal — the finalizer path will clean it up if needed.
 		}
 
 		// Wait for cluster to be ready
@@ -781,31 +843,30 @@ func (r *Neo4jRestoreReconciler) buildRestoreVolumeMounts(restore *neo4jv1beta1.
 }
 
 func (r *Neo4jRestoreReconciler) buildRestoreVolumes(ctx context.Context, restore *neo4jv1beta1.Neo4jRestore) []corev1.Volume {
-	var dataVolume corev1.Volume
-	if restore.Spec.StopCluster {
-		// For offline restore, write directly to the first pod's data PVC.
-		// Clusters use "data-{name}-server-0", standalones use "neo4j-data-{name}-0".
-		dataPVCName := fmt.Sprintf("data-%s-server-0", restore.Spec.ClusterRef)
-		pvc := &corev1.PersistentVolumeClaim{}
-		if err := r.Get(ctx, types.NamespacedName{Name: dataPVCName, Namespace: restore.Namespace}, pvc); err != nil {
-			// Cluster PVC not found — try standalone naming
-			dataPVCName = fmt.Sprintf("neo4j-data-%s-0", restore.Spec.ClusterRef)
-		}
-		dataVolume = corev1.Volume{
-			Name: "neo4j-data",
-			VolumeSource: corev1.VolumeSource{
-				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-					ClaimName: dataPVCName,
-				},
+	// Always mount the cluster's data PVC for /data — never an EmptyDir.
+	// Writing the restored database into an EmptyDir succeeded silently and
+	// then evaporated when the Pod exited, so users running stopCluster=false
+	// observed "restore complete" with the cluster's actual data unchanged
+	// (issue #117). The stopCluster flag now only controls whether the
+	// operator coordinates the scale-down; the data volume is always the
+	// real PVC. The startRestore preflight blocks running restores against
+	// a live cluster when stopCluster=false, so the multi-attach scenario
+	// is caught earlier with a clear error.
+	//
+	// Clusters use "data-{name}-server-0", standalones use "neo4j-data-{name}-0".
+	dataPVCName := fmt.Sprintf("data-%s-server-0", restore.Spec.ClusterRef)
+	pvc := &corev1.PersistentVolumeClaim{}
+	if err := r.Get(ctx, types.NamespacedName{Name: dataPVCName, Namespace: restore.Namespace}, pvc); err != nil {
+		// Cluster PVC not found — try standalone naming
+		dataPVCName = fmt.Sprintf("neo4j-data-%s-0", restore.Spec.ClusterRef)
+	}
+	dataVolume := corev1.Volume{
+		Name: "neo4j-data",
+		VolumeSource: corev1.VolumeSource{
+			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+				ClaimName: dataPVCName,
 			},
-		}
-	} else {
-		dataVolume = corev1.Volume{
-			Name: "neo4j-data",
-			VolumeSource: corev1.VolumeSource{
-				EmptyDir: &corev1.EmptyDirVolumeSource{},
-			},
-		}
+		},
 	}
 
 	volumes := []corev1.Volume{dataVolume}
@@ -936,6 +997,72 @@ func (r *Neo4jRestoreReconciler) resolveStatefulSetName(ctx context.Context, clu
 		return cluster.Name, nil
 	}
 	return "", fmt.Errorf("StatefulSet not found for %s (tried %s-server and %s)", cluster.Name, cluster.Name, cluster.Name)
+}
+
+// refuseRestoreIfPodsRunning returns an error if the target cluster has any
+// server pods. Used when restore.spec.stopCluster=false to prevent silently
+// running a restore against a live cluster (which holds the database file
+// lock and would either fail neo4j-admin restore or, worse, write the result
+// into a non-PVC volume that's discarded when the pod exits — issue #117).
+func (r *Neo4jRestoreReconciler) refuseRestoreIfPodsRunning(ctx context.Context, restore *neo4jv1beta1.Neo4jRestore, cluster *neo4jv1beta1.Neo4jEnterpriseCluster) error {
+	pods := &corev1.PodList{}
+	if err := r.List(ctx, pods,
+		client.InNamespace(cluster.Namespace),
+		client.MatchingLabels(resources.ServerPodSelector(cluster.Name))); err != nil {
+		return fmt.Errorf("failed to list server pods for restore preflight: %w", err)
+	}
+	if len(pods.Items) > 0 {
+		return fmt.Errorf("restore %q cannot run against a live cluster: %d server pod(s) of %q are still present. Set spec.stopCluster=true to let the operator coordinate the scale-down, or scale the cluster to 0 manually before applying this restore",
+			restore.Name, len(pods.Items), cluster.Name)
+	}
+	return nil
+}
+
+// setRestoreInProgressAnnotation marks the target cluster CR with the
+// restore-in-progress annotation so the cluster controller stops re-asserting
+// sts.Spec.Replicas (issue #117). If the annotation is already set to a
+// different restore, returns an error — two restores against the same cluster
+// cannot run concurrently.
+func (r *Neo4jRestoreReconciler) setRestoreInProgressAnnotation(ctx context.Context, restore *neo4jv1beta1.Neo4jRestore, cluster *neo4jv1beta1.Neo4jEnterpriseCluster) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		latest := &neo4jv1beta1.Neo4jEnterpriseCluster{}
+		if err := r.Get(ctx, client.ObjectKeyFromObject(cluster), latest); err != nil {
+			return err
+		}
+		if existing, ok := latest.Annotations[RestoreInProgressAnnotation]; ok && existing != restore.Name {
+			return fmt.Errorf("cluster %q already has a restore in progress by Neo4jRestore %q; cannot start %q", cluster.Name, existing, restore.Name)
+		}
+		if latest.Annotations == nil {
+			latest.Annotations = map[string]string{}
+		}
+		if latest.Annotations[RestoreInProgressAnnotation] == restore.Name {
+			return nil
+		}
+		latest.Annotations[RestoreInProgressAnnotation] = restore.Name
+		return r.Update(ctx, latest)
+	})
+}
+
+// clearRestoreInProgressAnnotation removes the restore-in-progress annotation
+// from the target cluster CR, but only if it was set by THIS restore CR.
+// Idempotent — safe to call from cleanup paths even if the annotation was
+// never set or was already cleared.
+func (r *Neo4jRestoreReconciler) clearRestoreInProgressAnnotation(ctx context.Context, restore *neo4jv1beta1.Neo4jRestore, clusterName, clusterNamespace string) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		latest := &neo4jv1beta1.Neo4jEnterpriseCluster{}
+		if err := r.Get(ctx, types.NamespacedName{Name: clusterName, Namespace: clusterNamespace}, latest); err != nil {
+			if errors.IsNotFound(err) {
+				return nil // cluster gone — nothing to clean
+			}
+			return err
+		}
+		owner, ok := latest.Annotations[RestoreInProgressAnnotation]
+		if !ok || owner != restore.Name {
+			return nil // not our annotation to clear
+		}
+		delete(latest.Annotations, RestoreInProgressAnnotation)
+		return r.Update(ctx, latest)
+	})
 }
 
 func (r *Neo4jRestoreReconciler) stopCluster(ctx context.Context, cluster *neo4jv1beta1.Neo4jEnterpriseCluster) error {

--- a/internal/controller/neo4jrestore_coordination_test.go
+++ b/internal/controller/neo4jrestore_coordination_test.go
@@ -1,0 +1,333 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
+)
+
+// Tests for the cluster-coordination machinery introduced for issue #117:
+// the restore-in-progress annotation, the stopCluster=false preflight, and
+// the volume builder. These are pure-controller unit tests against a fake
+// client — no envtest — because the end-to-end "restore controller and
+// cluster controller cooperate on STS Replicas" path runs into the same
+// cluster-controller-fights-status problem that surfaced on #118, and the
+// coordination logic itself is fully covered by these unit tests.
+
+func newRestoreTestReconciler(t *testing.T, objs ...runtime.Object) *Neo4jRestoreReconciler {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, neo4jv1beta1.AddToScheme(scheme))
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(objs...).
+		Build()
+	return &Neo4jRestoreReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(16),
+	}
+}
+
+func minimalClusterForRestore(name, namespace string) *neo4jv1beta1.Neo4jEnterpriseCluster {
+	return &neo4jv1beta1.Neo4jEnterpriseCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: neo4jv1beta1.Neo4jEnterpriseClusterSpec{
+			Image:    neo4jv1beta1.ImageSpec{Repo: "neo4j", Tag: "5.26-enterprise"},
+			Topology: neo4jv1beta1.TopologyConfiguration{Servers: 2},
+		},
+	}
+}
+
+func minimalRestore(name, namespace, clusterRef string) *neo4jv1beta1.Neo4jRestore {
+	return &neo4jv1beta1.Neo4jRestore{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: neo4jv1beta1.Neo4jRestoreSpec{
+			ClusterRef:   clusterRef,
+			DatabaseName: "neo4j",
+		},
+	}
+}
+
+func TestSetRestoreInProgressAnnotation(t *testing.T) {
+	ctx := context.Background()
+	ns := "default"
+
+	t.Run("sets annotation on a clean cluster", func(t *testing.T) {
+		cluster := minimalClusterForRestore("c", ns)
+		restore := minimalRestore("r1", ns, "c")
+		r := newRestoreTestReconciler(t, cluster, restore)
+
+		require.NoError(t, r.setRestoreInProgressAnnotation(ctx, restore, cluster))
+
+		got := &neo4jv1beta1.Neo4jEnterpriseCluster{}
+		require.NoError(t, r.Get(ctx, types.NamespacedName{Name: "c", Namespace: ns}, got))
+		assert.Equal(t, "r1", got.Annotations[RestoreInProgressAnnotation])
+	})
+
+	t.Run("idempotent when annotation already names this restore", func(t *testing.T) {
+		cluster := minimalClusterForRestore("c", ns)
+		cluster.Annotations = map[string]string{RestoreInProgressAnnotation: "r1"}
+		restore := minimalRestore("r1", ns, "c")
+		r := newRestoreTestReconciler(t, cluster, restore)
+
+		require.NoError(t, r.setRestoreInProgressAnnotation(ctx, restore, cluster))
+
+		got := &neo4jv1beta1.Neo4jEnterpriseCluster{}
+		require.NoError(t, r.Get(ctx, types.NamespacedName{Name: "c", Namespace: ns}, got))
+		assert.Equal(t, "r1", got.Annotations[RestoreInProgressAnnotation])
+	})
+
+	t.Run("refuses when a different restore is already in progress", func(t *testing.T) {
+		cluster := minimalClusterForRestore("c", ns)
+		cluster.Annotations = map[string]string{RestoreInProgressAnnotation: "older-restore"}
+		restore := minimalRestore("r1", ns, "c")
+		r := newRestoreTestReconciler(t, cluster, restore)
+
+		err := r.setRestoreInProgressAnnotation(ctx, restore, cluster)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "older-restore")
+		assert.Contains(t, err.Error(), "r1")
+
+		// Annotation must NOT have been overwritten.
+		got := &neo4jv1beta1.Neo4jEnterpriseCluster{}
+		require.NoError(t, r.Get(ctx, types.NamespacedName{Name: "c", Namespace: ns}, got))
+		assert.Equal(t, "older-restore", got.Annotations[RestoreInProgressAnnotation])
+	})
+}
+
+func TestClearRestoreInProgressAnnotation(t *testing.T) {
+	ctx := context.Background()
+	ns := "default"
+
+	t.Run("clears annotation set by this restore", func(t *testing.T) {
+		cluster := minimalClusterForRestore("c", ns)
+		cluster.Annotations = map[string]string{RestoreInProgressAnnotation: "r1"}
+		restore := minimalRestore("r1", ns, "c")
+		r := newRestoreTestReconciler(t, cluster, restore)
+
+		require.NoError(t, r.clearRestoreInProgressAnnotation(ctx, restore, "c", ns))
+
+		got := &neo4jv1beta1.Neo4jEnterpriseCluster{}
+		require.NoError(t, r.Get(ctx, types.NamespacedName{Name: "c", Namespace: ns}, got))
+		_, present := got.Annotations[RestoreInProgressAnnotation]
+		assert.False(t, present, "annotation should be cleared")
+	})
+
+	t.Run("leaves annotation set by a DIFFERENT restore alone", func(t *testing.T) {
+		cluster := minimalClusterForRestore("c", ns)
+		cluster.Annotations = map[string]string{RestoreInProgressAnnotation: "other-restore"}
+		restore := minimalRestore("r1", ns, "c")
+		r := newRestoreTestReconciler(t, cluster, restore)
+
+		require.NoError(t, r.clearRestoreInProgressAnnotation(ctx, restore, "c", ns))
+
+		got := &neo4jv1beta1.Neo4jEnterpriseCluster{}
+		require.NoError(t, r.Get(ctx, types.NamespacedName{Name: "c", Namespace: ns}, got))
+		assert.Equal(t, "other-restore", got.Annotations[RestoreInProgressAnnotation],
+			"clear must be a no-op when the annotation belongs to a different restore")
+	})
+
+	t.Run("no-op when annotation is absent", func(t *testing.T) {
+		cluster := minimalClusterForRestore("c", ns)
+		restore := minimalRestore("r1", ns, "c")
+		r := newRestoreTestReconciler(t, cluster, restore)
+
+		require.NoError(t, r.clearRestoreInProgressAnnotation(ctx, restore, "c", ns))
+	})
+
+	t.Run("no-op when cluster CR is gone", func(t *testing.T) {
+		restore := minimalRestore("r1", ns, "gone")
+		r := newRestoreTestReconciler(t, restore)
+
+		// Cleanly handles a missing cluster — the restore finalizer must be
+		// able to release even after the cluster has already been deleted.
+		require.NoError(t, r.clearRestoreInProgressAnnotation(ctx, restore, "gone", ns))
+	})
+}
+
+func TestRefuseRestoreIfPodsRunning(t *testing.T) {
+	ctx := context.Background()
+	ns := "default"
+
+	serverPod := func(podName string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      podName,
+				Namespace: ns,
+				Labels: map[string]string{
+					"app.kubernetes.io/instance":  "c",
+					"app.kubernetes.io/component": "database",
+				},
+			},
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "neo4j", Image: "neo4j:5.26-enterprise"}}},
+		}
+	}
+
+	t.Run("no pods → allowed", func(t *testing.T) {
+		cluster := minimalClusterForRestore("c", ns)
+		restore := minimalRestore("r1", ns, "c")
+		r := newRestoreTestReconciler(t, cluster, restore)
+
+		require.NoError(t, r.refuseRestoreIfPodsRunning(ctx, restore, cluster))
+	})
+
+	t.Run("server pods exist → refused with actionable error", func(t *testing.T) {
+		cluster := minimalClusterForRestore("c", ns)
+		restore := minimalRestore("r1", ns, "c")
+		r := newRestoreTestReconciler(t, cluster, restore, serverPod("c-server-0"), serverPod("c-server-1"))
+
+		err := r.refuseRestoreIfPodsRunning(ctx, restore, cluster)
+		require.Error(t, err)
+		msg := err.Error()
+		assert.Contains(t, msg, "2 server pod(s)")
+		assert.Contains(t, msg, "stopCluster=true")
+		assert.Contains(t, msg, "\"r1\"")
+	})
+
+	t.Run("pods of an unrelated cluster don't trigger refusal", func(t *testing.T) {
+		cluster := minimalClusterForRestore("c", ns)
+		restore := minimalRestore("r1", ns, "c")
+		other := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "other-server-0",
+				Namespace: ns,
+				Labels: map[string]string{
+					"app.kubernetes.io/instance":  "other",
+					"app.kubernetes.io/component": "database",
+				},
+			},
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "neo4j", Image: "neo4j:5.26-enterprise"}}},
+		}
+		r := newRestoreTestReconciler(t, cluster, restore, other)
+
+		require.NoError(t, r.refuseRestoreIfPodsRunning(ctx, restore, cluster))
+	})
+}
+
+func TestReplicasReconciliationPaused(t *testing.T) {
+	// The single check that makes the cluster controller yield on
+	// sts.Spec.Replicas during a restore (issue #117). Extracted as a
+	// helper so this gate can be unit-tested without standing up an
+	// envtest and the full createOrUpdateResource machinery.
+	cases := []struct {
+		name     string
+		owner    *neo4jv1beta1.Neo4jEnterpriseCluster
+		expected bool
+	}{
+		{
+			name:     "nil owner is not paused",
+			owner:    nil,
+			expected: false,
+		},
+		{
+			name:     "no annotations is not paused",
+			owner:    &neo4jv1beta1.Neo4jEnterpriseCluster{},
+			expected: false,
+		},
+		{
+			name: "unrelated annotation is not paused",
+			owner: &neo4jv1beta1.Neo4jEnterpriseCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"some.other/annotation": "yes"},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "restore-in-progress annotation pauses",
+			owner: &neo4jv1beta1.Neo4jEnterpriseCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{RestoreInProgressAnnotation: "r1"},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "restore-in-progress with empty value still pauses",
+			// Defensive: an empty value still indicates a restore controller
+			// has marked the cluster. Treat "present" as the gate, not
+			// "non-empty".
+			owner: &neo4jv1beta1.Neo4jEnterpriseCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{RestoreInProgressAnnotation: ""},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var owner interface{ GetAnnotations() map[string]string }
+			if tc.owner == nil {
+				assert.Equal(t, tc.expected, replicasReconciliationPaused(nil))
+				return
+			}
+			owner = tc.owner
+			_ = owner
+			assert.Equal(t, tc.expected, replicasReconciliationPaused(tc.owner))
+		})
+	}
+}
+
+func TestBuildRestoreVolumesAlwaysMountsDataPVC(t *testing.T) {
+	ctx := context.Background()
+	ns := "default"
+
+	// Pre-fix, stopCluster=false silently mounted an EmptyDir at /data, so the
+	// restore wrote to ephemeral storage. Regression-lock that this never
+	// happens again regardless of stopCluster.
+	cases := []struct {
+		name        string
+		stopCluster bool
+	}{
+		{"stopCluster=true mounts data PVC", true},
+		{"stopCluster=false also mounts data PVC (issue #117)", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cluster := minimalClusterForRestore("c", ns)
+			restore := minimalRestore("r1", ns, "c")
+			restore.Spec.StopCluster = tc.stopCluster
+			r := newRestoreTestReconciler(t, cluster, restore)
+
+			vols := r.buildRestoreVolumes(ctx, restore)
+
+			var dataVolume *corev1.Volume
+			for i := range vols {
+				if vols[i].Name == "neo4j-data" {
+					dataVolume = &vols[i]
+					break
+				}
+			}
+			require.NotNil(t, dataVolume, "neo4j-data volume must be present")
+			require.Nil(t, dataVolume.EmptyDir, "neo4j-data must NOT be an EmptyDir")
+			require.NotNil(t, dataVolume.PersistentVolumeClaim, "neo4j-data must mount a PVC")
+			assert.True(t,
+				strings.Contains(dataVolume.PersistentVolumeClaim.ClaimName, "c"),
+				"PVC claim name should reference the cluster: got %q", dataVolume.PersistentVolumeClaim.ClaimName)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #117.

## Summary

Restore to a running cluster was completely broken on v1.9.2. Two independent bugs in \`Neo4jRestore\`, both surface immediately the moment a user applies a restore CR.

### Bug 1: cluster controller fights restore controller on STS replicas

\`neo4jrestore_controller.go:stopCluster\` scales the cluster's StatefulSet to \`Replicas=0\` so \`neo4j-admin database restore\` can acquire the per-database file lock. But \`neo4jenterprisecluster_controller.go:660\` unconditionally re-asserts \`sts.Spec.Replicas = desiredSpec.Replicas\` on every reconcile of the cluster CR. The cluster controller wins within seconds, pods come back, the restore controller's 10-second pod-count poll never sees 0, and the restore times out at 5 minutes.

**Fix:** introduce a transient annotation, \`neo4j.com/restore-in-progress\`, set on the target cluster CR. The cluster controller's new \`replicasReconciliationPaused\` predicate skips the \`Replicas\` line — and only that line — while the annotation is present. Services, ConfigMap, certs, template updates all continue to reconcile normally.

The restore controller owns the annotation's full lifecycle:
- set immediately before \`stopCluster\`
- clear after \`startCluster\` scales the STS back up
- clear in the failure path if \`stopCluster\` itself errored
- clear in the finalizer so a mid-restore CR delete can't leave the cluster permanently un-scalable

An overlap guard refuses \`setRestoreInProgressAnnotation\` if the annotation already names a *different* \`Neo4jRestore\` — two concurrent restores against the same cluster would otherwise clobber each other.

### Bug 2: \`stopCluster: false\` silently wrote the restored data into an EmptyDir

\`buildRestoreVolumes\` branched on \`restore.Spec.StopCluster\`: true mounted \`data-{cluster}-server-0\`, false mounted an \`EmptyDir{}\`. Result: \`stopCluster=false\` restores reported success, the Pod exited, the EmptyDir evaporated, and the cluster's actual data on PVC was never touched. **Invisible data loss.**

**Fix:** \`buildRestoreVolumes\` always mounts the cluster's data PVC. The \`stopCluster\` flag now governs ONLY whether the operator coordinates the scale-down. To prevent the multi-attach scenario this previously masked, \`startRestore\` preflights via \`refuseRestoreIfPodsRunning\` when \`stopCluster=false\`: any server pods present → restore fails fast with a clear, actionable error.

## Why an annotation, not \`spec.topology.servers=0\` (Option B in the issue)

Letting users set \`servers=0\` makes the intent ambiguous (restore? decommission? bug?) and bypasses the \`+kubebuilder:validation:Minimum\` guard. A transient operator-managed annotation keeps the semantics explicit and cluster-controller-readable.

## Tests

Five new pure-function unit tests in \`internal/controller/neo4jrestore_coordination_test.go\`:

| Test | What it locks in |
|---|---|
| \`TestReplicasReconciliationPaused\` | the cluster controller's gate that yields on \`Replicas\` |
| \`TestSetRestoreInProgressAnnotation\` | sets cleanly, idempotent on same owner, refuses different owner |
| \`TestClearRestoreInProgressAnnotation\` | clears own, ignores foreign, no-op on absent, no-op on missing cluster CR (finalizer path) |
| \`TestRefuseRestoreIfPodsRunning\` | refuses on live pods with the actionable message, allows on empty namespace, ignores pods of unrelated clusters |
| \`TestBuildRestoreVolumesAlwaysMountsDataPVC\` | regression-lock: \`neo4j-data\` is NEVER an EmptyDir, for both stopCluster=true and false |

All five are fake-client unit tests (no envtest). End-to-end envtest of the cluster controller actually yielding STS replicas during a restore would run into the same cluster-controller-resets-status fragility that surfaced on #118; the coordination logic itself is fully covered by these direct unit tests.

Full unit suite green locally:
\`\`\`
KUBEBUILDER_ASSETS=\$(pwd)/bin/k8s/1.31.0-darwin-arm64 \\
  go test -count=1 -race -timeout 15m ./internal/controller/ ./internal/resources/ ./internal/validation/
ok  internal/controller  52.323s
ok  internal/resources   2.121s
ok  internal/validation  3.510s
\`\`\`

## Manual test plan for reviewer

1. Apply \`examples/clusters/minimal-cluster.yaml\`; wait for \`status.phase=Ready\`.
2. Apply a \`Neo4jBackup\`; let it complete.
3. Apply a \`Neo4jRestore\` with \`spec.stopCluster=true\` pointing at the same cluster.
4. Watch \`kubectl get sts -w\` — replicas should drop to 0, restore Job runs against the data PVC, then replicas should scale back to the original count.
5. Check the cluster CR's annotations during steps 4 — should show \`neo4j.com/restore-in-progress: <restore-name>\` while scaled down, gone after.
6. Apply a second \`Neo4jRestore\` against the same cluster while the first is running → should fail with a clear "already has a restore in progress" message.
7. Apply a \`Neo4jRestore\` with \`spec.stopCluster=false\` against a *running* cluster → should fail immediately with the actionable "server pods are still present" message.

## CRD changes

None. The annotation is purely a controller-to-controller coordination signal.

## Test plan checklist

- [x] \`go build ./...\` — clean
- [x] \`go vet ./...\` — clean
- [x] \`make check-drift\` — clean
- [x] full controller/resources/validation unit suite — green
- [x] pre-commit hooks (gofmt, goimports, golangci-lint, staticcheck, drift gate) — green
- [ ] CI unit + lint suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)