### PR TITLE
fix(backup): propagate ctx into isStandaloneTarget lookup

### DIFF
--- a/internal/controller/neo4jbackup_controller.go
+++ b/internal/controller/neo4jbackup_controller.go
@@ -614,7 +614,7 @@ func (r *Neo4jBackupReconciler) buildBackupCommand(ctx context.Context, backup *
 	// Falls back to the cluster shape on any lookup error so the
 	// existing cluster-backup path remains the no-op default.
 	fromAddresses := resources.BuildBackupFromAddresses(cluster)
-	if isStandalone, standalone, lookupErr := r.isStandaloneTarget(context.Background(), backup); lookupErr == nil && isStandalone && standalone != nil {
+	if isStandalone, standalone, lookupErr := r.isStandaloneTarget(ctx, backup); lookupErr == nil && isStandalone && standalone != nil {
 		fromAddresses = resources.BuildStandaloneBackupFromAddress(standalone)
 	}
 	allDatabases := backup.Spec.Target.Kind == "Cluster"


### PR DESCRIPTION
## Summary

\`buildBackupCommand\` (\`internal/controller/neo4jbackup_controller.go:579\`) takes \`ctx context.Context\` as its first parameter, but at line 617 the standalone-target detection call passes \`context.Background()\` instead:

\`\`\`go
// before
if isStandalone, standalone, lookupErr := r.isStandaloneTarget(context.Background(), backup); ...

// after
if isStandalone, standalone, lookupErr := r.isStandaloneTarget(ctx, backup); ...
\`\`\`

That detaches the API \`Get\` inside \`isStandaloneTarget\` from the caller's deadline, cancellation, and tracing. Concretely:

- a reconcile cancelled at the manager level (shutdown / deadline) still does this lookup
- any tracing or request-scoped logging wired to the reconcile \`ctx\` is missing from the call
- in tests, an injected \`ctx\` with a tighter timeout wouldn't propagate

One-line fix.

## Test plan

- [x] \`go build ./...\` — clean
- [x] pre-commit hooks (gofmt, goimports, golangci-lint, staticcheck, drift gate) — green
- [ ] CI unit + lint suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)