### PR TITLE
test(restore): drop dead owner variable in TestReplicasReconciliationPaused

### DIFF
--- a/internal/controller/neo4jrestore_coordination_test.go
+++ b/internal/controller/neo4jrestore_coordination_test.go
@@ -279,13 +279,10 @@ func TestReplicasReconciliationPaused(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			var owner interface{ GetAnnotations() map[string]string }
 			if tc.owner == nil {
 				assert.Equal(t, tc.expected, replicasReconciliationPaused(nil))
 				return
 			}
-			owner = tc.owner
-			_ = owner
 			assert.Equal(t, tc.expected, replicasReconciliationPaused(tc.owner))
 		})
 	}


### PR DESCRIPTION
## Summary

\`TestReplicasReconciliationPaused\` in \`internal/controller/neo4jrestore_coordination_test.go\` (introduced in #120) had three lines of pure noise inside each subtest body:

\`\`\`go
var owner interface{ GetAnnotations() map[string]string }
// ...
owner = tc.owner
_ = owner
\`\`\`

The \`owner\` variable was declared, assigned from \`tc.owner\`, and then immediately discarded. The actual assertion always called \`replicasReconciliationPaused(tc.owner)\` directly. Removing the three lines leaves test behaviour unchanged.

## Test plan

- [x] \`go test -count=1 -race -run TestReplicasReconciliationPaused ./internal/controller/\` — green
- [x] pre-commit hooks — green
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)