### PR TITLE
fix(cluster): stop emitting unused port 5000; gate BOOTSTRAP_STRATEGY to SemVer

### DIFF
--- a/internal/resources/cluster.go
+++ b/internal/resources/cluster.go
@@ -46,7 +46,12 @@ const (
 	HTTPPort = 7474
 	// HTTPSPort is the default port for Neo4j HTTPS API
 	HTTPSPort = 7473
-	// LegacyClusterPort is the Neo4j V1 cluster port (deprecated). Active discovery uses DiscoveryPort (6000).
+	// LegacyClusterPort is the Neo4j V1 discovery / cluster port. Deprecated;
+	// not used by this operator at runtime — V2 discovery on DiscoveryPort
+	// (6000) is the only active path. The constant is kept because the
+	// {cluster}-discovery K8s Service still exposes port 5000 (pending a
+	// separate removal pass). It is no longer added to the headless service,
+	// internals service, or pod containerPorts (issue #117-adjacent cleanup).
 	LegacyClusterPort = 5000
 	// DiscoveryPort is the default port for Neo4j cluster discovery
 	DiscoveryPort = 6000
@@ -283,12 +288,8 @@ func BuildHeadlessServiceForEnterprise(cluster *neo4jv1beta1.Neo4jEnterpriseClus
 					TargetPort: intstr.FromInt(HTTPPort),
 					Protocol:   corev1.ProtocolTCP,
 				},
-				{
-					Name:       "tcp-discovery",
-					Port:       LegacyClusterPort,
-					TargetPort: intstr.FromInt(LegacyClusterPort),
-					Protocol:   corev1.ProtocolTCP,
-				},
+				// Port 5000 (tcp-discovery, V1) intentionally not exposed —
+				// active V2 discovery rides on tcp-tx (6000) below.
 				{
 					Name:       "tcp-tx",
 					Port:       DiscoveryPort,
@@ -405,12 +406,8 @@ func BuildInternalsServiceForEnterprise(cluster *neo4jv1beta1.Neo4jEnterpriseClu
 					TargetPort: intstr.FromInt(HTTPPort),
 					Protocol:   corev1.ProtocolTCP,
 				},
-				{
-					Name:       "tcp-discovery",
-					Port:       LegacyClusterPort,
-					TargetPort: intstr.FromInt(LegacyClusterPort),
-					Protocol:   corev1.ProtocolTCP,
-				},
+				// Port 5000 (tcp-discovery, V1) intentionally not exposed —
+				// active V2 discovery rides on tcp-tx (6000) below.
 				{
 					Name:       "tcp-tx",
 					Port:       DiscoveryPort,
@@ -1377,11 +1374,8 @@ func BuildPodSpecForEnterprise(cluster *neo4jv1beta1.Neo4jEnterpriseCluster, ser
 				ContainerPort: HTTPSPort,
 				Protocol:      corev1.ProtocolTCP,
 			},
-			{
-				Name:          "tcp-discovery",
-				ContainerPort: LegacyClusterPort,
-				Protocol:      corev1.ProtocolTCP,
-			},
+			// Port 5000 (tcp-discovery, V1) intentionally not exposed —
+			// active V2 discovery rides on tcp-tx (6000) below.
 			{
 				Name:          "tcp-tx",
 				ContainerPort: DiscoveryPort,
@@ -1643,8 +1637,8 @@ db.format=block
 
 # Enterprise clustering configuration for Neo4j 5.x
 # Note: advertised addresses will be set dynamically by startup script
-# Port 5000: V2 discovery protocol (tcp-discovery)
-# Port 6000: Cluster catchup/transaction protocol (tcp-tx)
+# Port 5000: V1 discovery protocol (tcp-discovery) — DEPRECATED, not used by this operator
+# Port 6000: V2 discovery + cluster catchup/transaction protocol (tcp-tx) — active
 # Port 7000: RAFT consensus (raft)
 server.cluster.listen_address=0.0.0.0:6000
 server.routing.listen_address=0.0.0.0:7688

--- a/internal/resources/cluster.go
+++ b/internal/resources/cluster.go
@@ -1929,19 +1929,7 @@ echo "Server index: ${SERVER_INDEX}"
 # Minimum: 2 servers (servers self-organize for database hosting)
 echo "Multi-server cluster: using LIST discovery with static pod FQDNs"
 
-# ME/OTHER bootstrap strategy: server-0 bootstraps, all others join.
-# With Parallel pod management all pods start simultaneously. Using LIST discovery
-# with static pod FQDNs (via the headless service DNS) and minimum_initial_system_primaries_count
-# set to TOTAL_SERVERS ensures all servers discover each other before RAFT election.
-# Server-0 (me) is preferred bootstrapper; all others (other) join when ready.
-if [ "$SERVER_INDEX" = "0" ]; then
-    echo "Server 0: Using bootstrapping strategy 'me' (preferred cluster bootstrapper)"
-    BOOTSTRAP_STRATEGY="me"
-else
-    echo "Server ${SERVER_INDEX}: Using bootstrapping strategy 'other' (joining cluster)"
-    BOOTSTRAP_STRATEGY="other"
-fi
-echo "Configuring cluster with bootstrap strategy: ${BOOTSTRAP_STRATEGY}"
+` + buildBootstrapStrategyShellBlock(cluster) + `
 
 cat >> /tmp/neo4j-config/neo4j.conf << EOF
 
@@ -2097,6 +2085,38 @@ internal.dbms.cluster.discovery.resolution_timeout=1d`
 // in both Neo4j 5.26.x and 2025.x CalVer.
 func getMinInitialPrimariesSetting(_ *neo4jv1beta1.Neo4jEnterpriseCluster) string {
 	return "dbms.cluster.minimum_initial_system_primaries_count"
+}
+
+// buildBootstrapStrategyShellBlock returns the shell snippet that assigns
+// BOOTSTRAP_STRATEGY (me on server-0, other elsewhere) before
+// buildVersionSpecificDiscoveryConfig inserts ${BOOTSTRAP_STRATEGY} into
+// the SemVer-only internal.dbms.cluster.discovery.system_bootstrapping_strategy
+// directive.
+//
+// CalVer (2025.x+) does not honour system_bootstrapping_strategy at all — the
+// V2 discovery protocol elects a bootstrapper from the LIST endpoints
+// without an explicit hint — so on CalVer the variable would be assigned
+// and never consumed. Return an empty string so the dead assignment isn't
+// even emitted into the startup script.
+func buildBootstrapStrategyShellBlock(cluster *neo4jv1beta1.Neo4jEnterpriseCluster) string {
+	if isCalverImage(cluster.Spec.Image.Tag) {
+		return `# CalVer (2025.x+): V2 discovery elects a bootstrapper from the LIST endpoints;
+# internal.dbms.cluster.discovery.system_bootstrapping_strategy is SemVer-only,
+# so no BOOTSTRAP_STRATEGY assignment is emitted here.`
+	}
+	return `# ME/OTHER bootstrap strategy: server-0 bootstraps, all others join.
+# With Parallel pod management all pods start simultaneously. Using LIST discovery
+# with static pod FQDNs (via the headless service DNS) and minimum_initial_system_primaries_count
+# set to TOTAL_SERVERS ensures all servers discover each other before RAFT election.
+# Server-0 (me) is preferred bootstrapper; all others (other) join when ready.
+if [ "$SERVER_INDEX" = "0" ]; then
+    echo "Server 0: Using bootstrapping strategy 'me' (preferred cluster bootstrapper)"
+    BOOTSTRAP_STRATEGY="me"
+else
+    echo "Server ${SERVER_INDEX}: Using bootstrapping strategy 'other' (joining cluster)"
+    BOOTSTRAP_STRATEGY="other"
+fi
+echo "Configuring cluster with bootstrap strategy: ${BOOTSTRAP_STRATEGY}"`
 }
 
 // ValidateServerRoleHints validates server role hints configuration

--- a/internal/resources/cluster_startup_test.go
+++ b/internal/resources/cluster_startup_test.go
@@ -310,12 +310,30 @@ func TestListDiscoveryConfiguration(t *testing.T) {
 					"2025.x should NOT set V2_ONLY (V2 is the only protocol)")
 				assert.NotContains(t, startupScript, "dbms.cluster.discovery.v2.endpoints=",
 					"2025.x should NOT use the old v2.endpoints setting name")
+				// CalVer doesn't honour system_bootstrapping_strategy, so the
+				// BOOTSTRAP_STRATEGY shell assignment must not be emitted —
+				// otherwise it's dead work in every pod startup.
+				assert.NotContains(t, startupScript, "BOOTSTRAP_STRATEGY=\"me\"",
+					"CalVer startup script must NOT emit the SemVer-only BOOTSTRAP_STRATEGY assignment")
+				assert.NotContains(t, startupScript, "BOOTSTRAP_STRATEGY=\"other\"",
+					"CalVer startup script must NOT emit the SemVer-only BOOTSTRAP_STRATEGY assignment")
+				assert.NotContains(t, startupScript, "internal.dbms.cluster.discovery.system_bootstrapping_strategy=",
+					"CalVer does not honour internal.dbms.cluster.discovery.system_bootstrapping_strategy as a config directive")
 			} else {
 				// SemVer 5.26.x: explicit V2_ONLY and v2.endpoints required
 				assert.Contains(t, startupScript, "dbms.cluster.discovery.version=V2_ONLY",
 					"5.x startup script must explicitly set V2_ONLY discovery mode")
 				assert.Contains(t, startupScript, "dbms.cluster.discovery.v2.endpoints=",
 					"5.x startup script should use dbms.cluster.discovery.v2.endpoints")
+				// SemVer must still emit the BOOTSTRAP_STRATEGY assignment so
+				// the ${BOOTSTRAP_STRATEGY} substitution inside the discovery
+				// config resolves to "me" / "other".
+				assert.Contains(t, startupScript, "BOOTSTRAP_STRATEGY=\"me\"",
+					"SemVer startup script must emit BOOTSTRAP_STRATEGY=me for server-0")
+				assert.Contains(t, startupScript, "BOOTSTRAP_STRATEGY=\"other\"",
+					"SemVer startup script must emit BOOTSTRAP_STRATEGY=other for non-zero indices")
+				assert.Contains(t, startupScript, "system_bootstrapping_strategy=${BOOTSTRAP_STRATEGY}",
+					"SemVer startup script must reference ${BOOTSTRAP_STRATEGY} in the discovery config")
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Two unrelated-but-adjacent cleanups in \`internal/resources/cluster.go\`, surfaced by review of the port-naming and startup-script logic.

### Commit 1: drop port 5000 (\`tcp-discovery\`) from emitted Service/STS specs

\`LegacyClusterPort\` (5000, Neo4j's V1 cluster discovery port) is **not used** by this operator at runtime — V2 discovery on port 6000 (\`tcp-tx\`) is the only active path for both SemVer 5.26.x and CalVer 2025.x+. The validator at \`internal/validation/config_validator.go:67\` even rejects users setting \`dbms.kubernetes.discovery.service_port_name\`, and the in-code comments already correctly describe port 5000 as deprecated.

Despite that, port 5000 was still being emitted as a \"tcp-discovery\" port on:

- \`BuildHeadlessServiceForEnterprise\`
- \`BuildInternalsServiceForEnterprise\`
- the StatefulSet's pod \`containerPorts\`

Effect: \`kubectl describe svc\` showed a port named \"tcp-discovery\" that wasn't actually used for discovery, contradicting the docs in \`docs/user_guide/clustering.md\` and \`docs/developer_guide/architecture.md\` that already say \"port 5000 — never used by this operator.\"

Drop the three port entries. Each is replaced by a one-line comment so the intent (\"V1 intentionally not exposed; V2 rides on tcp-tx\") is recoverable from the source.

The \`{cluster}-discovery\` Service (\`BuildDiscoveryServiceForEnterprise\`) is **left in place** — removing the entire Service would orphan live resources on upgraded clusters and needs its own migration story. That's a separate cleanup.

The \`LegacyClusterPort\` constant itself is kept (still referenced by the discovery Service above, plus user-facing docs and the explanatory comments around discovery config), with its comment updated to make the new emission scope explicit.

### Commit 2: gate \`BOOTSTRAP_STRATEGY\` shell assignment to SemVer only

The Neo4j startup script always assigned \`BOOTSTRAP_STRATEGY=\"me\"\` (server-0) or \`\"other\"\` (others), but the variable is referenced exactly once — inside \`buildVersionSpecificDiscoveryConfig\`'s **SemVer branch**, as the value for \`internal.dbms.cluster.discovery.system_bootstrapping_strategy\`. CalVer (2025.x+) doesn't support that directive at all; V2 discovery elects a bootstrapper from the LIST endpoints with no hint. So on CalVer the variable was computed and immediately discarded — dead work, and confusing for anyone reading the script.

Extract a \`buildBootstrapStrategyShellBlock(cluster)\` helper. SemVer returns the real \`if/else\` assignment; CalVer returns a short explanatory comment.

## Reporter's proposals vs. what was done

For context — the review proposed five findings on this file:

- **Findings 1–4 (port 5000):** I diverged from the reporter's proposals. They were inconsistent with each other (rename to \`-legacy-discovery\` on one service, \`-discovery-legacy\` on another, and \"swap port to 6000 keeping name tcp-discovery\" on a third). The root-cause fix is removal, not renaming — covered above.
- **Finding 5 (BOOTSTRAP_STRATEGY):** the reporter's diff wrapped the assignment in \`if [ \"\${IS_SEMVER}\" = \"true\" ]\`, but there's no \`IS_SEMVER\` variable in the script — the patch would have always taken the \`else\` branch and broken SemVer cluster formation. The Go-side conditional in this PR achieves the same intent correctly.

## Tests

Added assertions to the existing \`TestListDiscoveryConfiguration\` (which exercises both SemVer and CalVer image tags):

- SemVer scripts **must** emit \`BOOTSTRAP_STRATEGY=\"me\"\`, \`BOOTSTRAP_STRATEGY=\"other\"\`, and the \`system_bootstrapping_strategy=\${BOOTSTRAP_STRATEGY}\` reference.
- CalVer scripts **must not** emit either assignment, and **must not** contain \`internal.dbms.cluster.discovery.system_bootstrapping_strategy=\` as a config directive.

No new test for the port removal — the existing \`internal/resources\` suite covers ServiceSpec construction, and removing the port doesn't change any observable behaviour beyond \`kubectl describe\` output.

## CRD / bundle changes

None.

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`go vet ./...\` — clean
- [x] full controller + resources unit suites — green (~53s combined)
- [x] pre-commit hooks (gofmt, goimports, golangci-lint, staticcheck, drift gate) — green
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)