### PR TITLE
chore(k8s): bump user-facing minimum to 1.32 + test floor to 1.34

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,12 @@ jobs:
 
     - name: Set up Helm
       uses: azure/setup-helm@v5
+      with:
+        # Pin to match pages-helm.yml + .tool-versions. Without an
+        # explicit version the action installs whatever Helm 3.x is
+        # current at job time, so the release workflow would silently
+        # drift from the pages workflow that pins v3.16.0.
+        version: 3.16.0
 
     - name: Get build date
       id: build-date

--- a/.tool-versions
+++ b/.tool-versions
@@ -6,4 +6,4 @@ kubectl 1.36.0
 kustomize 5.4.3
 helm 3.16.0
 golangci-lint 1.64.8
-ginkgo 2.28.3
+ginkgo 2.29.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ The project includes a `.tool-versions` file that pins the exact tool versions u
 # Install mise (one-time)
 curl https://mise.jdx.dev/install.sh | sh
 
-# Install all pinned versions (Go 1.26, Kind 0.27.0, kubectl 1.31.0, etc.)
+# Install all pinned versions (Go 1.26, Kind 0.27.0, kubectl 1.36.0, etc.)
 mise install
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,13 @@ ENVTEST_K8S_VERSION = 1.34.0
 # tests run one minor ahead at the upstream N-2 floor.
 KIND_NODE_IMAGE ?= kindest/node:v1.34.0
 
+# CERT_MANAGER_VERSION pins the cert-manager release applied to dev and
+# test clusters. The user-facing minimum per docs/README is v1.18+; we
+# install a known-good v1.20.x for tests. Single source of truth —
+# scripts/test-env.sh and hack/deploy-dev.sh both read this via env so
+# bumping here propagates to every cluster path.
+CERT_MANAGER_VERSION ?= v1.20.0
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -899,8 +906,8 @@ dev-cluster: ## Create a Kind cluster for development
 		kind create cluster --name neo4j-operator-dev --image $(KIND_NODE_IMAGE) --config hack/kind-config.yaml; \
 		echo "Waiting for cluster to be ready..."; \
 		kubectl wait --for=condition=ready node --all --timeout=300s; \
-		echo "Installing cert-manager..."; \
-		kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.20.0/cert-manager.yaml; \
+		echo "Installing cert-manager $(CERT_MANAGER_VERSION)..."; \
+		kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/$(CERT_MANAGER_VERSION)/cert-manager.yaml; \
 		kubectl wait --for=condition=ready pod -l app.kubernetes.io/instance=cert-manager -n cert-manager --timeout=300s; \
 		echo "Creating self-signed ClusterIssuer for development..."; \
 		kubectl apply -f config/dev/self-signed-issuer.yaml || echo "Self-signed issuer creation skipped (file may not exist)"; \
@@ -911,8 +918,8 @@ dev-cluster: ## Create a Kind cluster for development
 
 .PHONY: test-cluster
 test-cluster: ## Create a Kind cluster for testing
-	@echo "Creating test cluster (image: $(KIND_NODE_IMAGE))..."
-	@KIND_NODE_IMAGE=$(KIND_NODE_IMAGE) ./scripts/test-env.sh cluster
+	@echo "Creating test cluster (image: $(KIND_NODE_IMAGE), cert-manager: $(CERT_MANAGER_VERSION))..."
+	@KIND_NODE_IMAGE=$(KIND_NODE_IMAGE) CERT_MANAGER_VERSION=$(CERT_MANAGER_VERSION) ./scripts/test-env.sh cluster
 
 .PHONY: test-cluster-clean
 test-cluster-clean: ## Clean operator resources from test cluster

--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ test-unit: manifests generate fmt vet envtest ## Run unit tests (no cluster requ
 
 # Integration Tests
 .PHONY: test-integration
-test-integration: test-cluster ginkgo kustomize ## Run integration tests (production mode, neo4j-operator-system)
+test-integration: manifests generate test-cluster ginkgo kustomize ## Run integration tests (production mode, neo4j-operator-system)
 	@echo "🔗 Running integration tests..."
 	@kind export kubeconfig --name neo4j-operator-test
 	@echo "📦 Building and loading operator image..."

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,14 @@ IMG ?= ghcr.io/neo4j-partners/neo4j-kubernetes-operator:latest
 # MCP: use the official Docker Hub image (mcp/neo4j-cypher).
 # No custom image build is required.
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.31.0
+ENVTEST_K8S_VERSION = 1.34.0
+
+# KIND_NODE_IMAGE pins the Kubernetes version used by dev and test clusters.
+# Kept in sync with ENVTEST_K8S_VERSION so unit-test envtest, dev cluster,
+# and CI integration cluster all run against the same K8s version. The
+# user-facing minimum is currently 1.32 (see README + Helm Chart.yaml);
+# tests run one minor ahead at the upstream N-2 floor.
+KIND_NODE_IMAGE ?= kindest/node:v1.34.0
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -880,10 +887,10 @@ operator-setup: ## Deploy operator to available Kind cluster
 
 .PHONY: dev-cluster
 dev-cluster: ## Create a Kind cluster for development
-	@echo "Creating development cluster..."
+	@echo "Creating development cluster (image: $(KIND_NODE_IMAGE))..."
 	@./scripts/setup-kind-dirs.sh
 	@if ! kind get clusters | grep -q "neo4j-operator-dev"; then \
-		kind create cluster --name neo4j-operator-dev --config hack/kind-config.yaml; \
+		kind create cluster --name neo4j-operator-dev --image $(KIND_NODE_IMAGE) --config hack/kind-config.yaml; \
 		echo "Waiting for cluster to be ready..."; \
 		kubectl wait --for=condition=ready node --all --timeout=300s; \
 		echo "Installing cert-manager..."; \

--- a/Makefile
+++ b/Makefile
@@ -223,10 +223,16 @@ test: test-unit test-integration ## Run all tests
 	@echo "✅ All tests completed"
 
 .PHONY: test-coverage
-test-coverage: ## Generate coverage report
+test-coverage: manifests generate fmt vet envtest ## Generate coverage report
 	@echo "📊 Generating coverage report..."
 	@mkdir -p coverage
-	@./scripts/run-tests-clean.sh go test -coverprofile=coverage/coverage.out -covermode=atomic ./...
+	@# Coverage runs `go test ./...` which includes the controller suite (envtest).
+	@# We MUST set KUBEBUILDER_ASSETS the same way test-unit does — without it the
+	@# controller suite can't find the envtest API server binaries and fails to
+	@# start. Pre-fix: suite_test.go had a hardcoded BinaryAssetsDirectory that
+	@# silently masked this gap, but only because stale prior-version binaries
+	@# happened to exist under bin/k8s/.
+	@./scripts/run-tests-clean.sh env KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -coverprofile=coverage/coverage.out -covermode=atomic ./...
 	@go tool cover -html=coverage/coverage.out -o coverage/coverage.html
 	@go tool cover -func=coverage/coverage.out | tail -1
 
@@ -905,8 +911,8 @@ dev-cluster: ## Create a Kind cluster for development
 
 .PHONY: test-cluster
 test-cluster: ## Create a Kind cluster for testing
-	@echo "Creating test cluster..."
-	@./scripts/test-env.sh cluster
+	@echo "Creating test cluster (image: $(KIND_NODE_IMAGE))..."
+	@KIND_NODE_IMAGE=$(KIND_NODE_IMAGE) ./scripts/test-env.sh cluster
 
 .PHONY: test-cluster-clean
 test-cluster-clean: ## Clean operator resources from test cluster

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The Operator deploys Neo4j EE v5.26+.  It supports both clustered and standalone
 ## 📋 Requirements
 
 - **Neo4j**: Version 5.26 LTS (the final SemVer release) or any CalVer release (2025.x, 2026.x, and onward)
-- **Kubernetes**: Version 1.30 or higher
+- **Kubernetes**: Version 1.32 or higher
 - **Go**: Version 1.24+ (for development)
 - **cert-manager**: Version 1.18+ (optional, only required for TLS-enabled Neo4j deployments)
 

--- a/bundle/manifests/neo4j-kubernetes-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/neo4j-kubernetes-operator.clusterserviceversion.yaml
@@ -558,7 +558,7 @@ spec:
   - email: 1254077+priyolahiri@users.noreply.github.com
     name: Priyadarshi Lahiri
   maturity: alpha
-  minKubeVersion: "1.30.0"
+  minKubeVersion: "1.32.0"
   provider:
     name: Neo4j Partners
     url: https://github.com/neo4j-partners

--- a/charts/neo4j-operator/Chart.yaml
+++ b/charts/neo4j-operator/Chart.yaml
@@ -4,7 +4,7 @@ description: Neo4j Enterprise Operator for Kubernetes - Manages Neo4j Enterprise
 type: application
 version: 0.0.1
 appVersion: "0.0.1"
-kubeVersion: ">=1.30.0-0"
+kubeVersion: ">=1.32.0-0"
 keywords:
   - neo4j
   - graph

--- a/charts/neo4j-operator/README.md
+++ b/charts/neo4j-operator/README.md
@@ -4,7 +4,7 @@ This Helm chart deploys the Neo4j Enterprise Operator for Kubernetes, which mana
 
 ## Prerequisites
 
-- Kubernetes 1.30+
+- Kubernetes 1.32+
 - Helm 3.8+
 - kubectl configured to access your cluster
 - (Optional) cert-manager for TLS certificate management

--- a/config/manifests/bases/neo4j-kubernetes-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/neo4j-kubernetes-operator.clusterserviceversion.yaml
@@ -196,7 +196,7 @@ spec:
   - email: 1254077+priyolahiri@users.noreply.github.com
     name: Priyadarshi Lahiri
   maturity: alpha
-  minKubeVersion: "1.30.0"
+  minKubeVersion: "1.32.0"
   provider:
     name: Neo4j Partners
     url: https://github.com/neo4j-partners

--- a/docs/developer_guide/development.md
+++ b/docs/developer_guide/development.md
@@ -280,9 +280,12 @@ The operator implements a **server-based architecture**:
 make test-unit
 
 # Run specific controller tests
+# `./internal/controller` needs envtest binaries — `make test-unit` sets
+# KUBEBUILDER_ASSETS automatically; direct `go test` requires:
+#   export KUBEBUILDER_ASSETS=$(bin/setup-envtest use 1.34.0 --bin-dir bin -p path)
 go test ./internal/controller -run TestClusterReconciler -v
 
-# Run validation tests
+# Run validation tests (no envtest needed)
 go test ./internal/validation -v
 ```
 
@@ -559,7 +562,9 @@ export GOMAXPROCS=4
 ```bash
 # CI/CD testing
 export CI=true
-export KUBEBUILDER_ASSETS="$(pwd)/bin/k8s/1.34.0-linux-amd64"
+# Resolve the envtest asset path via setup-envtest so it tracks Makefile's
+# ENVTEST_K8S_VERSION automatically — no need to hand-edit when bumping.
+export KUBEBUILDER_ASSETS=$(bin/setup-envtest use 1.34.0 --bin-dir bin -p path)
 ```
 
 ## Next Steps

--- a/docs/developer_guide/development.md
+++ b/docs/developer_guide/development.md
@@ -559,7 +559,7 @@ export GOMAXPROCS=4
 ```bash
 # CI/CD testing
 export CI=true
-export KUBEBUILDER_ASSETS="$(pwd)/bin/k8s/1.31.0-linux-amd64"
+export KUBEBUILDER_ASSETS="$(pwd)/bin/k8s/1.34.0-linux-amd64"
 ```
 
 ## Next Steps

--- a/docs/developer_guide/makefile_reference.md
+++ b/docs/developer_guide/makefile_reference.md
@@ -959,7 +959,7 @@ make clean
 ### Testing Configuration
 - `CI`: Enable CI mode (affects resource limits)
 - `GITHUB_ACTIONS`: Enable GitHub Actions mode
-- `ENVTEST_K8S_VERSION`: Kubernetes version for testing (1.31.0)
+- `ENVTEST_K8S_VERSION`: Kubernetes version for testing (1.34.0)
 
 ### Bundle Configuration
 - `CHANNELS`: Bundle channels for OLM

--- a/docs/developer_guide/makefile_reference.md
+++ b/docs/developer_guide/makefile_reference.md
@@ -251,7 +251,8 @@ make test-unit
 #### `make test-coverage`
 **Description**: Generate detailed coverage report
 **Usage**: `make test-coverage`
-**Dependencies**: Test environment
+**Dependencies**: `manifests generate fmt vet envtest` (auto-resolved)
+**Env**: `KUBEBUILDER_ASSETS` is set automatically from `ENVTEST_K8S_VERSION` — the controller suite needs it to start envtest. Running `go test -coverprofile ./...` directly without `make` requires you to export it yourself.
 **Output**: `coverage/coverage.html`
 **Example**:
 ```bash
@@ -265,7 +266,7 @@ make test-coverage
 #### `make test-integration`
 **Description**: Run comprehensive integration tests with real Kubernetes API
 **Usage**: `make test-integration`
-**Dependencies**: `test-cluster`, Kind cluster
+**Dependencies**: `manifests generate test-cluster ginkgo kustomize` — the `manifests`/`generate` prereqs guarantee CRDs and RBAC deployed to the test cluster match the current controller source. Skipping `manifests` (e.g., by calling kustomize directly) silently deploys stale schemas.
 **Duration**: ~10-15 minutes
 **Features**:
 - Auto-creates test cluster if needed
@@ -350,8 +351,13 @@ make test-cleanup
 **Usage**: `make test-cluster`
 **Dependencies**: Kind installed
 **Cluster Name**: `neo4j-operator-test`
+**Variables** (Makefile defaults, overridable via `make VAR=...`):
+- `KIND_NODE_IMAGE ?= kindest/node:v1.34.0` — pins the K8s version. Kept in sync with `ENVTEST_K8S_VERSION` so unit tests, dev cluster, and integration tests all run on the same K8s.
+- `CERT_MANAGER_VERSION ?= v1.20.0` — pins the cert-manager release.
+
+Both are threaded into `scripts/test-env.sh` via environment variables; the script enforces them as required (no fallback) so direct invocations can't drift from the Makefile defaults.
+
 **Features**:
-- Includes cert-manager v1.20.0
 - Pre-configured with self-signed issuer
 - Optimized for testing workloads
 

--- a/docs/developer_guide/testing.md
+++ b/docs/developer_guide/testing.md
@@ -35,9 +35,14 @@ Unit tests are fast, require no Kubernetes cluster, and test individual function
 make test-unit
 
 # Run specific package tests
+# Note: ./internal/controller and any package that imports envtest needs
+# KUBEBUILDER_ASSETS set — `make test-unit` handles this for you.
+# To run directly with `go test`, export it first:
+export KUBEBUILDER_ASSETS="$(bin/setup-envtest use $(awk -F= '/ENVTEST_K8S_VERSION/ {gsub(/ /,""); print $2}' Makefile) --bin-dir bin -p path)"
+
 go test ./internal/controller -v
-go test ./internal/validation -v
-go test ./api/v1beta1 -v
+go test ./internal/validation -v   # no envtest needed
+go test ./api/v1beta1 -v           # no envtest needed
 
 # Run specific test functions
 go test ./internal/controller -run TestGetStatefulSetName -v
@@ -497,7 +502,9 @@ Tests run automatically in CI with:
 ```bash
 # Environment variables for CI
 export CI=true
-export KUBEBUILDER_ASSETS="$(pwd)/bin/k8s/1.34.0-linux-amd64"
+# Resolve KUBEBUILDER_ASSETS via setup-envtest so it tracks Makefile's
+# ENVTEST_K8S_VERSION — no manual edit needed when the version is bumped.
+export KUBEBUILDER_ASSETS=$(bin/setup-envtest use 1.34.0 --bin-dir bin -p path)
 export KUBECONFIG=~/.kube/config
 ```
 

--- a/docs/developer_guide/testing.md
+++ b/docs/developer_guide/testing.md
@@ -497,7 +497,7 @@ Tests run automatically in CI with:
 ```bash
 # Environment variables for CI
 export CI=true
-export KUBEBUILDER_ASSETS="$(pwd)/bin/k8s/1.31.0-linux-amd64"
+export KUBEBUILDER_ASSETS="$(pwd)/bin/k8s/1.34.0-linux-amd64"
 export KUBECONFIG=~/.kube/config
 ```
 

--- a/docs/user_guide/getting_started.md
+++ b/docs/user_guide/getting_started.md
@@ -4,7 +4,7 @@ This guide will walk you through the process of deploying your first Neo4j Enter
 
 ## Prerequisites
 
-*   A Kubernetes cluster (v1.30+)
+*   A Kubernetes cluster (v1.32+)
 *   `kubectl` installed and configured
 *   Neo4j Enterprise Edition (evaluation license acceptable for testing)
 *   Go 1.26+ (for building from source)

--- a/docs/user_guide/installation.md
+++ b/docs/user_guide/installation.md
@@ -479,7 +479,7 @@ gh release list --repo neo4j-partners/neo4j-kubernetes-operator
 
 ### Installation Requirements
 
-- **Kubernetes**: Version 1.30 or higher
+- **Kubernetes**: Version 1.32 or higher
 - **Neo4j**: Version 5.26 LTS (the final SemVer release) or any CalVer release (2025.x, 2026.x, and onward)
 - **cert-manager**: Version 1.20+ (optional, only required for TLS-enabled Neo4j deployments)
 - **Permissions**: Cluster-admin access for CRD and RBAC installation

--- a/hack/deploy-dev.sh
+++ b/hack/deploy-dev.sh
@@ -12,7 +12,12 @@ NC='\033[0m' # No Color
 # Configuration
 CLUSTER_NAME="neo4j-operator-dev"
 NAMESPACE="neo4j-operator-system"
-CERT_MANAGER_VERSION="v1.20.0"
+# cert-manager release pinned to match Makefile's CERT_MANAGER_VERSION
+# default. This script is invoked manually (not from `make`), so we keep a
+# fallback rather than erroring out. Bumping should happen in both places —
+# the Makefile is canonical for CI/test paths, this fallback covers direct
+# hack/ invocations.
+CERT_MANAGER_VERSION="${CERT_MANAGER_VERSION:-v1.20.0}"
 # PROMETHEUS_VERSION="v0.68.0"  # Reserved for future Prometheus setup
 
 print_status() {

--- a/hack/deploy-dev.sh
+++ b/hack/deploy-dev.sh
@@ -12,11 +12,16 @@ NC='\033[0m' # No Color
 # Configuration
 CLUSTER_NAME="neo4j-operator-dev"
 NAMESPACE="neo4j-operator-system"
-# cert-manager release pinned to match Makefile's CERT_MANAGER_VERSION
-# default. This script is invoked manually (not from `make`), so we keep a
-# fallback rather than erroring out. Bumping should happen in both places —
-# the Makefile is canonical for CI/test paths, this fallback covers direct
-# hack/ invocations.
+# KIND_NODE_IMAGE pins the K8s version for the dev cluster. Defaults match
+# the Makefile's KIND_NODE_IMAGE so direct `hack/deploy-dev.sh` invocations
+# get the same K8s version as `make dev-cluster` / `make test-cluster` /
+# envtest. Bumping should happen in both places — the Makefile is canonical
+# for CI/test paths, this fallback covers direct hack/ invocations.
+# Without this, `kind create cluster --config hack/kind-config.yaml` would
+# inherit Kind's built-in default node image, which can lag behind the K8s
+# version the rest of the project targets.
+KIND_NODE_IMAGE="${KIND_NODE_IMAGE:-kindest/node:v1.34.0}"
+# cert-manager release — same single-source-of-truth contract.
 CERT_MANAGER_VERSION="${CERT_MANAGER_VERSION:-v1.20.0}"
 # PROMETHEUS_VERSION="v0.68.0"  # Reserved for future Prometheus setup
 
@@ -74,7 +79,7 @@ create_cluster() {
         return 0
     fi
 
-    kind create cluster --name "$CLUSTER_NAME" --config hack/kind-config.yaml
+    kind create cluster --name "$CLUSTER_NAME" --image "$KIND_NODE_IMAGE" --config hack/kind-config.yaml
 
     # Wait for cluster to be ready
     print_status "Waiting for cluster to be ready..."

--- a/hack/kind-config.yaml
+++ b/hack/kind-config.yaml
@@ -1,6 +1,10 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: neo4j-operator-dev
+# K8s node image is passed via `kind create cluster --image $KIND_NODE_IMAGE`
+# (see Makefile :: KIND_NODE_IMAGE and scripts/test-env.sh). That keeps the
+# version in one place — overriding `nodes[].image` here would silently win
+# over the CLI flag and re-introduce drift.
 nodes:
 - role: control-plane
   kubeadmConfigPatches:

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -18,9 +18,7 @@ package controller_test
 
 import (
 	"context"
-	"fmt"
 	"path/filepath"
-	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -80,13 +78,19 @@ var _ = BeforeSuite(func() {
 		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
 
-		// The BinaryAssetsDirectory is only required if you want to run the tests directly
-		// without call the makefile target test. If not informed it will look for the
-		// default path defined in controller-runtime which is /usr/local/kubebuilder/.
-		// Note that you must have the required binaries setup under the bin directory to perform
-		// the tests directly. When we run make test it will be setup and used automatically.
-		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s",
-			fmt.Sprintf("1.31.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
+		// Envtest binary location is resolved via the KUBEBUILDER_ASSETS env
+		// var (set by `make test-unit`, which derives it from
+		// $(ENVTEST) use $(ENVTEST_K8S_VERSION) — see Makefile). We deliberately
+		// do NOT set BinaryAssetsDirectory here because that field overrides
+		// KUBEBUILDER_ASSETS, and pinning a hardcoded version (e.g. "1.31.0")
+		// would silently shadow the Makefile contract whenever
+		// ENVTEST_K8S_VERSION is bumped — fresh CI runners only have the
+		// new version's binaries, so the hardcoded path would point at a
+		// missing directory and envtest startup would fail.
+		//
+		// To run these tests directly (`go test ./internal/controller`), set
+		// KUBEBUILDER_ASSETS yourself, e.g.:
+		//   export KUBEBUILDER_ASSETS=$(bin/setup-envtest use 1.34.0 -p path)
 	}
 
 	var err error

--- a/scripts/setup-operator.sh
+++ b/scripts/setup-operator.sh
@@ -134,13 +134,10 @@ deploy_to_cluster() {
     log "Loading image to cluster: ${cluster_name}"
     kind load docker-image "${operator_image}" --name "${cluster_name}"
 
-    # Build and load MCP image for integration tests
-    if [[ "${cluster_name}" == "${TEST_CLUSTER}" ]]; then
-        log "Building MCP server image for integration tests..."
-        make mcp-docker-build MCP_IMAGE=neo4j-operator-mcp:integration-test || log_warning "MCP image build failed (MCP tests will be skipped)"
-        log "Loading MCP image to cluster: ${cluster_name}"
-        kind load docker-image neo4j-operator-mcp:integration-test --name "${cluster_name}" || log_warning "MCP image load failed"
-    fi
+    # MCP integration tests use the upstream `mcp/neo4j-cypher` Docker Hub
+    # image directly (see CLAUDE.md: "MCP: use the official Docker Hub
+    # image"). The operator no longer builds its own MCP image, so no
+    # mcp-docker-build / kind load step is needed here.
 
     # Deploy operator
     log "Deploying operator to ${cluster_name}..."

--- a/scripts/test-env.sh
+++ b/scripts/test-env.sh
@@ -7,6 +7,12 @@ CLUSTER_NAME="neo4j-operator-test"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
+# Pin Kubernetes version explicitly so dev cluster, integration tests, and
+# unit-test envtest all run on the same K8s. Overridable via env to support
+# forward-compat smoke runs. Kept in sync with KIND_NODE_IMAGE in Makefile
+# and ENVTEST_K8S_VERSION (which controls the envtest API server).
+KIND_NODE_IMAGE="${KIND_NODE_IMAGE:-kindest/node:v1.34.0}"
+
 log() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"
 }
@@ -21,8 +27,8 @@ cluster() {
     fi
 
     # Create new cluster
-    log "Creating cluster: ${CLUSTER_NAME}"
-    kind create cluster --name "${CLUSTER_NAME}" --wait 10m
+    log "Creating cluster: ${CLUSTER_NAME} (image: ${KIND_NODE_IMAGE})"
+    kind create cluster --name "${CLUSTER_NAME}" --image "${KIND_NODE_IMAGE}" --wait 10m
 
     # Export kubeconfig
     kind export kubeconfig --name "${CLUSTER_NAME}"

--- a/scripts/test-env.sh
+++ b/scripts/test-env.sh
@@ -15,6 +15,12 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 # fast with a clear message if invoked directly without the env set.
 : "${KIND_NODE_IMAGE:?KIND_NODE_IMAGE must be set (e.g. via 'make test-cluster' or 'KIND_NODE_IMAGE=kindest/node:v1.34.0 scripts/test-env.sh ...')}"
 
+# CERT_MANAGER_VERSION pins the cert-manager release applied to the test
+# cluster. Same single-source-of-truth contract as KIND_NODE_IMAGE — the
+# Makefile passes the value via `make test-cluster`; direct invocation
+# must export the env var. No fallback here on purpose.
+: "${CERT_MANAGER_VERSION:?CERT_MANAGER_VERSION must be set (e.g. via 'make test-cluster' or 'CERT_MANAGER_VERSION=v1.20.0 scripts/test-env.sh ...')}"
+
 log() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"
 }
@@ -36,8 +42,8 @@ cluster() {
     kind export kubeconfig --name "${CLUSTER_NAME}"
 
     # Install cert-manager
-    log "Installing cert-manager..."
-    kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.20.0/cert-manager.yaml
+    log "Installing cert-manager ${CERT_MANAGER_VERSION}..."
+    kubectl apply -f "https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml"
     kubectl wait --for=condition=ready pod -l app.kubernetes.io/instance=cert-manager -n cert-manager --timeout=300s
 
     # Create self-signed ClusterIssuer for testing

--- a/scripts/test-env.sh
+++ b/scripts/test-env.sh
@@ -7,11 +7,13 @@ CLUSTER_NAME="neo4j-operator-test"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
-# Pin Kubernetes version explicitly so dev cluster, integration tests, and
-# unit-test envtest all run on the same K8s. Overridable via env to support
-# forward-compat smoke runs. Kept in sync with KIND_NODE_IMAGE in Makefile
-# and ENVTEST_K8S_VERSION (which controls the envtest API server).
-KIND_NODE_IMAGE="${KIND_NODE_IMAGE:-kindest/node:v1.34.0}"
+# KIND_NODE_IMAGE pins the K8s version for the test cluster. Required —
+# this script has no fallback so the Makefile (KIND_NODE_IMAGE variable,
+# passed via `make test-cluster`) is the single source of truth. Setting a
+# default here would silently shadow Makefile bumps and let test clusters
+# drift from dev clusters / CI / envtest. The `${VAR:?msg}` form errors
+# fast with a clear message if invoked directly without the env set.
+: "${KIND_NODE_IMAGE:?KIND_NODE_IMAGE must be set (e.g. via 'make test-cluster' or 'KIND_NODE_IMAGE=kindest/node:v1.34.0 scripts/test-env.sh ...')}"
 
 log() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"

--- a/scripts/test-env.sh
+++ b/scripts/test-env.sh
@@ -7,25 +7,37 @@ CLUSTER_NAME="neo4j-operator-test"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
-# KIND_NODE_IMAGE pins the K8s version for the test cluster. Required —
-# this script has no fallback so the Makefile (KIND_NODE_IMAGE variable,
-# passed via `make test-cluster`) is the single source of truth. Setting a
-# default here would silently shadow Makefile bumps and let test clusters
-# drift from dev clusters / CI / envtest. The `${VAR:?msg}` form errors
-# fast with a clear message if invoked directly without the env set.
-: "${KIND_NODE_IMAGE:?KIND_NODE_IMAGE must be set (e.g. via 'make test-cluster' or 'KIND_NODE_IMAGE=kindest/node:v1.34.0 scripts/test-env.sh ...')}"
+# Required-env validator. Called by cluster() — the only subcommand that
+# actually creates a Kind cluster and installs cert-manager. setup() and
+# cleanup() must NOT require these vars because `make test-setup` /
+# `test-cleanup` / `test-destroy` invoke the script without passing them
+# (they don't create clusters; setup just makes directories + runs
+# manifests, cleanup just deletes directories + tears down any existing
+# cluster). Putting the `${VAR:?msg}` checks at script-top would block
+# those harmless paths.
+require_cluster_env() {
+    # KIND_NODE_IMAGE pins the K8s version. Single source of truth = the
+    # Makefile (`KIND_NODE_IMAGE` variable, passed via `make
+    # test-cluster`). No fallback default here on purpose — a default
+    # would silently shadow Makefile bumps and let test clusters drift
+    # from dev clusters / CI / envtest.
+    : "${KIND_NODE_IMAGE:?KIND_NODE_IMAGE must be set (e.g. via 'make test-cluster' or 'KIND_NODE_IMAGE=kindest/node:v1.34.0 scripts/test-env.sh cluster')}"
 
-# CERT_MANAGER_VERSION pins the cert-manager release applied to the test
-# cluster. Same single-source-of-truth contract as KIND_NODE_IMAGE — the
-# Makefile passes the value via `make test-cluster`; direct invocation
-# must export the env var. No fallback here on purpose.
-: "${CERT_MANAGER_VERSION:?CERT_MANAGER_VERSION must be set (e.g. via 'make test-cluster' or 'CERT_MANAGER_VERSION=v1.20.0 scripts/test-env.sh ...')}"
+    # CERT_MANAGER_VERSION pins the cert-manager release applied to the
+    # test cluster. Same single-source-of-truth contract as KIND_NODE_IMAGE.
+    : "${CERT_MANAGER_VERSION:?CERT_MANAGER_VERSION must be set (e.g. via 'make test-cluster' or 'CERT_MANAGER_VERSION=v1.20.0 scripts/test-env.sh cluster')}"
+}
 
 log() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"
 }
 
 cluster() {
+    # Validate required env BEFORE any side effects (cluster create, etc).
+    # Other subcommands (setup, cleanup, clean_cluster) don't call this —
+    # they don't need the K8s / cert-manager pins.
+    require_cluster_env
+
     log "Setting up test cluster..."
 
     # Clean up any existing cluster

--- a/scripts/update-alm-examples/main.go
+++ b/scripts/update-alm-examples/main.go
@@ -89,7 +89,7 @@ func updateCSV(path string, almValue string) (bool, error) {
 		return false, nil
 	}
 
-	lines = setMinKubeVersion(lines, "1.30.0")
+	lines = setMinKubeVersion(lines, "1.32.0")
 	output := strings.Join(lines, "\n") + "\n"
 	return true, os.WriteFile(path, []byte(output), 0o644)
 }


### PR DESCRIPTION
## Summary

Realign the project's Kubernetes version stance with the upstream support window and what cloud providers offer in June 2026.

| Stage | Was | Now |
|---|---|---|
| **User-facing minimum** (README, Helm `kubeVersion`, OLM `minKubeVersion`) | 1.30 | **1.32** |
| **envtest / dev / integration test cluster** | 1.31 (envtest) / Kind default (cluster) | **1.34** (centralized via `KIND_NODE_IMAGE`) |

## Why

The old floor had drifted into unsupported territory:

| Version | Upstream | EKS | GKE | AKS |
|---|---|---|---|---|
| 1.30 (old min) | EOL Jun 2025 — ~12mo ago | Extended only, ends 23 Jul 2026 | **Gone** since Sep 2025 | LTS only, ends Jul 2026 |
| 1.31 (old test) | EOL Oct 2025 — ~8mo ago | Extended | Extended | LTS only |
| 1.32 (new min) | EOL Feb 2026 | Extended | **Standard** | LTS to Mar 2027 |
| 1.34 (new test) | **Supported** (N-2) | **Standard** | **Standard** | **Standard** |

Realistic floor for "still on cloud standard tiers" is now 1.33; upstream N-2 floor is 1.34. Picking 1.32 as the user-facing minimum covers AKS LTS + EKS extended customers while staying inside GKE standard. Test floor at 1.34 matches the upstream N-2 contract.

## Changes (15 files)

### User-facing minimum (1.30 → 1.32)
- `README.md`
- `charts/neo4j-operator/Chart.yaml` (`kubeVersion: ">=1.32.0-0"`)
- `charts/neo4j-operator/README.md`
- `config/manifests/bases/.../clusterserviceversion.yaml` (`minKubeVersion`)
- `bundle/manifests/.../clusterserviceversion.yaml` (`minKubeVersion`)
- `docs/user_guide/getting_started.md`
- `docs/user_guide/installation.md`
- `scripts/update-alm-examples/main.go` (regenerated CSV `minKubeVersion`)

### Test floor (1.31 → 1.34, centralized)
- `Makefile`: `ENVTEST_K8S_VERSION = 1.34.0` + new `KIND_NODE_IMAGE ?= kindest/node:v1.34.0` variable
- `scripts/test-env.sh`: passes `--image $KIND_NODE_IMAGE` to `kind create cluster` so test + dev + CI all run the same K8s
- `hack/kind-config.yaml`: removed embedded `nodes[].image` to avoid double source of truth (CLI flag is authoritative)
- `docs/developer_guide/{development,testing,makefile_reference}.md`
- `CONTRIBUTING.md`: kubectl pin reference synced with `.tool-versions` (was stale at 1.31.0; actually pinned at 1.36.0)

## Verified

- ✅ `helm lint` clean
- ✅ `helm template --kube-version 1.32.0` renders
- ✅ `helm template --kube-version 1.31.0` **rejected** with `chart requires kubeVersion: >=1.32.0-0 which is incompatible with Kubernetes v1.31.0`
- ✅ `make test-unit` passes against envtest 1.34.0
- ✅ `make sync-all bundle` is a no-op (generated artifacts in sync)

## Not changed

- `client-go v0.36.1` / `controller-runtime v0.24.1` — already current
- `.tool-versions` `kubectl 1.36.0` — intentionally ahead, no need to rebase
- `KIND_VERSION: v0.27.0` (GitHub Actions) — Kind release version, not K8s version
- CRD `apiextensions.k8s.io/v1` — stable since K8s 1.16

## Test plan

- [x] Local unit tests pass against envtest 1.34
- [x] Helm chart kubeVersion constraint enforces the new floor
- [ ] CI unit tests pass
- [ ] CI integration tests pass against Kind 1.34 cluster
- [ ] OperatorHub bundle validation passes (`make bundle` → `operator-sdk bundle validate ./bundle`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Raises the supported Kubernetes minimum (install/upgrade impact for clusters below 1.32) and changes CI/local cluster versions; test-only fixes reduce envtest drift risk but integration CI must pass on the new Kind image.
> 
> **Overview**
> Raises the **documented and packaged Kubernetes floor from 1.30 to 1.32** across README, user guides, Helm `kubeVersion`, OLM `minKubeVersion`, and the ALM example updater.
> 
> Moves the **test/dev Kubernetes target to 1.34** via `ENVTEST_K8S_VERSION`, new Makefile knobs `KIND_NODE_IMAGE` and `CERT_MANAGER_VERSION`, and threads them through `make dev-cluster` / `make test-cluster`, `scripts/test-env.sh`, and `hack/deploy-dev.sh`. Kind config no longer embeds a node image so the CLI `--image` flag stays authoritative.
> 
> **Test pipeline fixes:** `test-integration` now depends on `manifests generate`; `test-coverage` sets `KUBEBUILDER_ASSETS` like `test-unit`. Controller `suite_test.go` drops the hardcoded envtest binary path so bumps follow the Makefile.
> 
> **Tooling:** Ginkgo 2.29.0 in `.tool-versions`; release workflow pins Helm **3.16.0**. Integration setup stops building/loading a custom MCP image (uses upstream `mcp/neo4j-cypher`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68203b59ed9050c7ab7f5d36d71a8d61b03c6c38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->