### PR TITLE
ci(release): stop publishing OperatorHub bundle as a release asset

### DIFF
--- a/.github/release-notes-template.md
+++ b/.github/release-notes-template.md
@@ -68,7 +68,6 @@ cosign verify ghcr.io/neo4j-partners/neo4j-kubernetes-operator:__TAG__ \
 |-------|-------------|
 | `neo4j-kubernetes-operator-complete.yaml` | Complete operator install (CRDs + RBAC + Deployment) |
 | `neo4j-kubernetes-operator.yaml` | CRDs only |
-| `operatorhub-bundle-__VERSION__.tar.gz` | OperatorHub bundle |
 
 ## Documentation
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,12 +223,15 @@ jobs:
         fi
 
         mkdir -p release-artifacts
+        mkdir -p bundle-artifact
 
         # CRD-only manifest (concatenated from all CRD bases)
         cat config/crd/bases/*.yaml > release-artifacts/neo4j-kubernetes-operator.yaml
 
-        # OperatorHub bundle (single tarball, not individual files)
-        tar -czf "release-artifacts/operatorhub-bundle-${CLEAN_TAG}.tar.gz" bundle/
+        # OperatorHub bundle for inter-job transfer to submit-operatorhub.
+        # Written outside release-artifacts/ so it is NOT uploaded as a
+        # public release asset — it is a workflow internal, not a user artifact.
+        tar -czf "bundle-artifact/operatorhub-bundle-${CLEAN_TAG}.tar.gz" bundle/
 
         # Complete operator manifest (CRDs + RBAC + Deployment) with OPERATOR_VERSION
         # stamped to the release tag via a kustomize strategic merge patch overlay.
@@ -263,6 +266,18 @@ jobs:
         ./bin/kustomize build config/overlays/release-temp \
           > release-artifacts/neo4j-kubernetes-operator-complete.yaml
         rm -rf config/overlays/release-temp
+
+    # Hand the OperatorHub bundle off to the submit-operatorhub job via the
+    # GHA artifact store. The two jobs run on separate runners with no shared
+    # filesystem; this is the idiomatic transfer mechanism. Short retention
+    # because nothing outside this workflow consumes it.
+    - name: Upload OperatorHub bundle for submission job
+      uses: actions/upload-artifact@v7
+      with:
+        name: operatorhub-bundle
+        path: bundle-artifact/operatorhub-bundle-*.tar.gz
+        retention-days: 1
+        if-no-files-found: error
 
     - name: Generate release notes
       id: release-notes
@@ -316,15 +331,11 @@ jobs:
       contents: read
 
     steps:
-    - name: Download OperatorHub bundle from release
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        CLEAN_TAG: ${{ needs.determine-tag.outputs.clean_tag }}
-      run: |
-        gh release download "v${CLEAN_TAG}" \
-          --repo "${{ github.repository }}" \
-          --pattern "operatorhub-bundle-${CLEAN_TAG}.tar.gz" \
-          --dir /tmp
+    - name: Download OperatorHub bundle from create-release job
+      uses: actions/download-artifact@v8
+      with:
+        name: operatorhub-bundle
+        path: /tmp
 
     - name: Clone community-operators fork
       env:


### PR DESCRIPTION
## Summary

- The OperatorHub bundle tarball was being uploaded as a public release asset just so the `submit-operatorhub` job could pull it back down via `gh release download`. Users never consumed it directly — OperatorHub submission is fully automated.
- Switch the inter-job hand-off to the idiomatic `actions/upload-artifact@v7` + `actions/download-artifact@v8` pair. Bundle is now written to `bundle-artifact/` instead of `release-artifacts/`, so it's no longer captured by the `release-artifacts/*` files glob on `softprops/action-gh-release`.
- Drop the `operatorhub-bundle-__VERSION__.tar.gz` row from `.github/release-notes-template.md`.

Result: release pages carry only what users install (`neo4j-kubernetes-operator.yaml`, `neo4j-kubernetes-operator-complete.yaml`), not workflow internals.

## Test plan

- [ ] Workflow YAML is valid (yamllint passed on pre-commit)
- [ ] Verify on next release tag: GitHub Release page has 2 assets (no `operatorhub-bundle-*.tar.gz`)
- [ ] Verify `submit-operatorhub` job succeeds at downloading and extracting the bundle
- [ ] Confirm community-operators PR still opens with the correct bundle contents

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/release packaging only; user-facing release assets and OperatorHub submission path stay the same aside from the internal hand-off mechanism.
> 
> **Overview**
> Stops publishing the **OperatorHub bundle tarball** as a public GitHub Release asset. The bundle is only needed for the automated `submit-operatorhub` job, not for end-user installs.
> 
> **Release workflow:** The tarball is written under `bundle-artifact/` (not `release-artifacts/`), so `softprops/action-gh-release` still uploads only the two YAML manifests. `create-release` uploads the bundle with `actions/upload-artifact@v7` (1-day retention); `submit-operatorhub` fetches it with `actions/download-artifact@v8` instead of `gh release download`.
> 
> **Release notes template:** Removes the `operatorhub-bundle-__VERSION__.tar.gz` row from the Release Assets table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bf5f007eb3a35da65ada2ac7e2a8a42e3fe55bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->