### PR TITLE
docs: apply Neo4j brand palette to mkdocs site

### DIFF
--- a/docs/stylesheets/neo4j.css
+++ b/docs/stylesheets/neo4j.css
@@ -1,0 +1,54 @@
+/* Neo4j brand palette overrides for Material for MkDocs.
+   Activated by setting theme.palette.primary/accent to "custom" in mkdocs.yml. */
+
+/* Hide Material's default library/book logo in the header. */
+.md-header__button.md-logo {
+  display: none;
+}
+
+/* Light mode: scoped to [data-md-color-scheme="default"] so it overrides
+   Material's own light-scheme block (higher specificity than :root). */
+[data-md-color-scheme="default"] {
+  /* Neo4j Logo Blue — deep navy from dist.neo4j.com Logo_FullColor_RGB */
+  --md-primary-fg-color:        #014063;
+  --md-primary-fg-color--light: #2A6A8F;
+  --md-primary-fg-color--dark:  #002A45;
+  --md-primary-bg-color:        #FFFFFF;
+  --md-primary-bg-color--light: rgba(255, 255, 255, 0.7);
+
+  /* Neo4j Teal — accent (links, hover, active) */
+  --md-accent-fg-color:        #00A39C;
+  --md-accent-fg-color--transparent: rgba(0, 163, 156, 0.1);
+  --md-accent-bg-color:        #FFFFFF;
+  --md-accent-bg-color--light: rgba(255, 255, 255, 0.7);
+
+  /* Page background: subtle teal tint so the brand carries through the body */
+  --md-default-bg-color:       #EAF6F5;
+  --md-typeset-a-color:        #00736E;
+
+  /* Code blocks: clean white card so they pop against the teal page bg,
+     instead of Material's default gray which clashes. */
+  --md-code-bg-color:          #FFFFFF;
+  --md-code-fg-color:          #1A2D33;
+  --md-typeset-mark-color:     rgba(0, 163, 156, 0.25);
+}
+
+/* Dark mode: keep the logo navy on the header for brand consistency,
+   lift only the accent (teal) so links/hover read on the deep teal bg. */
+[data-md-color-scheme="slate"] {
+  --md-primary-fg-color:        #014063;
+  --md-primary-fg-color--light: #2A6A8F;
+  --md-primary-fg-color--dark:  #002A45;
+
+  --md-accent-fg-color:        #3DD9D0;
+  --md-accent-fg-color--transparent: rgba(61, 217, 208, 0.15);
+
+  /* Deep teal-tinted slate for dark mode */
+  --md-default-bg-color:       #0B2A2C;
+  --md-typeset-a-color:        #3DD9D0;
+
+  /* Code blocks darker than page bg so they read as recessed panels */
+  --md-code-bg-color:          #051618;
+  --md-code-fg-color:          #D5E8E6;
+  --md-typeset-mark-color:     rgba(61, 217, 208, 0.25);
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,15 +22,15 @@ theme:
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default
-      primary: blue
-      accent: blue
+      primary: custom
+      accent: custom
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
-      primary: blue
-      accent: blue
+      primary: custom
+      accent: custom
       toggle:
         icon: material/brightness-4
         name: Switch to light mode
@@ -54,6 +54,9 @@ theme:
   font:
     text: Inter
     code: JetBrains Mono
+
+extra_css:
+  - stylesheets/neo4j.css
 
 plugins:
   - search


### PR DESCRIPTION
## Summary

Switch the documentation site from Material's default Material-blue palette to Neo4j's brand colors:

- **Header / primary** — deep navy `#014063` (pulled from the Neo4j full-color logo SVG); same in light and dark mode for brand consistency
- **Accent (links / hover)** — Neo4j teal (`#00A39C` light, `#3DD9D0` dark)
- **Page background** — subtle teal tint in light mode (`#EAF6F5`), deep teal-slate in dark mode (`#0B2A2C`)
- **Code blocks** — clean white card (light) / recessed dark-teal panel (dark) instead of Material's default gray, which clashed with the new page bg
- **Inline mark/highlight** — teal tint instead of the default yellow
- **Header book/library icon** — hidden (the default Material logo placeholder)

Wired via `theme.palette.primary/accent: custom` + a new `docs/stylesheets/neo4j.css` referenced from `extra_css`. No theme switch — Material features (instant nav, content tabs, code annotations, mike versioning, etc.) all retained.

## Test plan

- [x] `mkdocs build --strict` passes
- [x] Manually verified light + dark mode locally via `mkdocs serve`
- [ ] Verify the gh-pages workflow publishes correctly after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only CSS and mkdocs.yml theme wiring with no runtime or security impact.
> 
> **Overview**
> Replaces Material for MkDocs’ default blue theme with **Neo4j brand styling** for the documentation site.
> 
> `mkdocs.yml` sets light and dark palette `primary` and `accent` to **`custom`** and loads **`docs/stylesheets/neo4j.css`** via `extra_css`. The new stylesheet defines CSS variables for navy header/primary (`#014063`), teal accents and links, teal-tinted page backgrounds, white/recessed code blocks, teal inline marks, and hides Material’s default header book logo.
> 
> No application or operator code changes; existing MkDocs features and nav stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a5d6c67382ca54a48f90b3d199bd0632a48bbc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->