### PR TITLE
fix(helm): make a vanilla install work — pre-install hook RBAC, optional cert-manager, non-colliding repo alias

### DIFF
--- a/.github/release-notes-template.md
+++ b/.github/release-notes-template.md
@@ -17,10 +17,10 @@ kubectl apply -f https://github.com/neo4j-partners/neo4j-kubernetes-operator/rel
 ### Helm chart repository (recommended, available from v1.8.0 onwards)
 
 ```bash
-helm repo add neo4j https://neo4j-partners.github.io/neo4j-kubernetes-operator/charts
+helm repo add neo4j-operator https://neo4j-partners.github.io/neo4j-kubernetes-operator/charts
 helm repo update
 
-helm install neo4j-operator neo4j/neo4j-operator \
+helm install neo4j-operator neo4j-operator/neo4j-operator \
   --version __VERSION__ \
   --namespace neo4j-operator-system \
   --create-namespace

--- a/.github/workflows/pages-helm.yml
+++ b/.github/workflows/pages-helm.yml
@@ -5,8 +5,8 @@ name: Pages — Helm Repo
 # gh-pages branch.
 #
 # Users consume the repo via:
-#   helm repo add neo4j https://neo4j-partners.github.io/neo4j-kubernetes-operator/charts
-#   helm install neo4j-operator neo4j/neo4j-operator
+#   helm repo add neo4j-operator https://neo4j-partners.github.io/neo4j-kubernetes-operator/charts
+#   helm install neo4j-operator neo4j-operator/neo4j-operator
 #
 # The docs workflow (pages-docs.yml) writes to /, /latest/, /vX.Y/, /main/ on the
 # same gh-pages branch; concurrency: gh-pages serialises pushes so they cannot race.

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ A Kubernetes operator for Neo4j Enterprise — declarative clusters, databases, 
 Install the operator via Helm:
 
 ```bash
-helm repo add neo4j https://neo4j-partners.github.io/neo4j-kubernetes-operator/charts
+helm repo add neo4j-operator https://neo4j-partners.github.io/neo4j-kubernetes-operator/charts
 helm repo update
-helm install neo4j-operator neo4j/neo4j-operator \
+helm install neo4j-operator neo4j-operator/neo4j-operator \
   --namespace neo4j-operator-system --create-namespace
 ```
 

--- a/charts/neo4j-operator/README.md
+++ b/charts/neo4j-operator/README.md
@@ -15,10 +15,10 @@ This Helm chart deploys the Neo4j Enterprise Operator for Kubernetes, which mana
 ### From the Helm chart repository (recommended, available from v1.8.0 onwards)
 
 ```bash
-helm repo add neo4j https://neo4j-partners.github.io/neo4j-kubernetes-operator/charts
+helm repo add neo4j-operator https://neo4j-partners.github.io/neo4j-kubernetes-operator/charts
 helm repo update
 
-helm install neo4j-operator neo4j/neo4j-operator \
+helm install neo4j-operator neo4j-operator/neo4j-operator \
   --namespace neo4j-operator-system \
   --create-namespace
 ```

--- a/charts/neo4j-operator/README.md
+++ b/charts/neo4j-operator/README.md
@@ -8,7 +8,9 @@ This Helm chart deploys the Neo4j Enterprise Operator for Kubernetes, which mana
 - Helm 3.8+
 - kubectl configured to access your cluster
 - (Optional) cert-manager for TLS certificate management
-- (Optional) Prometheus Operator for metrics collection
+- (Optional) Prometheus Operator for metrics collection (required only if you set `metrics.serviceMonitor.enabled=true`)
+
+> **cert-manager install order**: The operator runs without cert-manager and only needs it for clusters using cert-manager TLS (`spec.tls.mode: cert-manager`). It picks up the cert-manager CRDs at startup, so if you install cert-manager *after* the operator, restart it (`kubectl rollout restart deployment/neo4j-operator-controller-manager -n <ns>`) to activate the Certificate watch.
 
 ## Installation
 

--- a/charts/neo4j-operator/templates/pre-install-check.yaml
+++ b/charts/neo4j-operator/templates/pre-install-check.yaml
@@ -34,13 +34,15 @@ spec:
           echo "Checking prerequisites for Neo4j Operator..."
           FAILED=0
 
-          # Check cert-manager CRDs
+          # cert-manager is OPTIONAL — required only for deployments that use
+          # cert-manager TLS (spec.tls.mode: cert-manager). The operator runs
+          # fine without it, so this is a WARNING, not a hard failure.
           if kubectl get crd certificates.cert-manager.io > /dev/null 2>&1; then
             echo "✓ cert-manager CRDs found"
           else
-            echo "✗ cert-manager CRDs not found — install cert-manager before deploying the operator"
-            echo "  See: https://cert-manager.io/docs/installation/"
-            FAILED=1
+            echo "⚠ cert-manager CRDs not found — the operator will still install and run."
+            echo "  Install cert-manager only if you plan to use cert-manager TLS"
+            echo "  (spec.tls.mode: cert-manager). See: https://cert-manager.io/docs/installation/"
           fi
 
           if [ "$FAILED" -eq 1 ]; then
@@ -50,5 +52,5 @@ spec:
           fi
 
           echo ""
-          echo "All pre-install checks passed."
+          echo "All required pre-install checks passed."
 {{- end }}

--- a/charts/neo4j-operator/templates/pre-install-check.yaml
+++ b/charts/neo4j-operator/templates/pre-install-check.yaml
@@ -19,7 +19,11 @@ spec:
         app.kubernetes.io/component: pre-install-check
     spec:
       restartPolicy: Never
-      serviceAccountName: {{ include "neo4j-operator.serviceAccountName" . }}
+      # Dedicated pre-install hook SA (see pre-install-rbac.yaml). The operator
+      # ServiceAccount isn't created until the main install phase, so the hook
+      # Job can't use it — doing so wedges `helm install` at the pre-install
+      # phase with `serviceaccount not found`.
+      serviceAccountName: {{ include "neo4j-operator.fullname" . }}-pre-install
       containers:
       - name: check
         image: {{ .Values.preInstallChecks.image }}

--- a/charts/neo4j-operator/templates/pre-install-rbac.yaml
+++ b/charts/neo4j-operator/templates/pre-install-rbac.yaml
@@ -1,0 +1,62 @@
+{{- if .Values.preInstallChecks.enabled -}}
+# Dedicated RBAC for the pre-install check Job (pre-install-check.yaml).
+#
+# The check runs during Helm's pre-install hook phase, which executes BEFORE
+# the chart's main resources (the operator ServiceAccount + its RBAC) are
+# created. The Job therefore cannot use the operator ServiceAccount — at hook
+# time it does not exist yet, and the Job's pod fails to schedule with
+# `serviceaccount "<name>" not found`, hanging the install. These hook
+# resources are created at weight -10 (ahead of the Job at -5) so the SA and
+# the CRD-read permission it needs are present when the Job runs, and are
+# cleaned up automatically once the hook succeeds.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "neo4j-operator.fullname" . }}-pre-install
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "neo4j-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: pre-install-check
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "neo4j-operator.fullname" . }}-pre-install
+  labels:
+    {{- include "neo4j-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: pre-install-check
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+# The check reads cluster-scoped CRDs (e.g. certificates.cert-manager.io) to
+# verify prerequisites before the operator is installed.
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "neo4j-operator.fullname" . }}-pre-install
+  labels:
+    {{- include "neo4j-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: pre-install-check
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "neo4j-operator.fullname" . }}-pre-install
+subjects:
+- kind: ServiceAccount
+  name: {{ include "neo4j-operator.fullname" . }}-pre-install
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/neo4j-operator/templates/servicemonitor.yaml
+++ b/charts/neo4j-operator/templates/servicemonitor.yaml
@@ -1,4 +1,7 @@
 {{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled -}}
+{{- if not (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") -}}
+{{- fail "metrics.serviceMonitor.enabled=true but the Prometheus Operator CRD (monitoring.coreos.com/v1) is not installed in this cluster. Install the Prometheus Operator first, or set metrics.serviceMonitor.enabled=false." -}}
+{{- end -}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/neo4j-operator/values.yaml
+++ b/charts/neo4j-operator/values.yaml
@@ -284,7 +284,11 @@ extraManifests: []
 #   data:
 #     key: value
 
-# Pre-install checks — validates prerequisites before deploying the operator
+# Pre-install checks — validates prerequisites before deploying the operator.
+# Image needs a shell (the check runs `/bin/sh -c`) + kubectl. Pinned to a
+# specific version for reproducibility/air-gap; alpine/k8s is alpine-based (has
+# a shell), unlike the distroless registry.k8s.io/kubectl and rancher/kubectl.
+# (bitnami/kubectl was dropped — its versioned tags are no longer published.)
 preInstallChecks:
   enabled: true
-  image: bitnami/kubectl:latest
+  image: alpine/k8s:1.32.0

--- a/docs/index.md
+++ b/docs/index.md
@@ -80,8 +80,8 @@ client + Prometheus ports open.
 ## Installation
 
 ```bash
-helm repo add neo4j https://neo4j-partners.github.io/neo4j-kubernetes-operator/charts
-helm install neo4j-operator neo4j/neo4j-operator \
+helm repo add neo4j-operator https://neo4j-partners.github.io/neo4j-kubernetes-operator/charts
+helm install neo4j-operator neo4j-operator/neo4j-operator \
   --namespace neo4j-operator-system --create-namespace
 ```
 

--- a/docs/user_guide/getting_started.md
+++ b/docs/user_guide/getting_started.md
@@ -15,10 +15,10 @@ This guide will walk you through the process of deploying your first Neo4j Enter
 The recommended path is the Helm chart repository (available from v1.8.0 onwards):
 
 ```bash
-helm repo add neo4j https://neo4j-partners.github.io/neo4j-kubernetes-operator/charts
+helm repo add neo4j-operator https://neo4j-partners.github.io/neo4j-kubernetes-operator/charts
 helm repo update
 
-helm install neo4j-operator neo4j/neo4j-operator \
+helm install neo4j-operator neo4j-operator/neo4j-operator \
   --namespace neo4j-operator-system \
   --create-namespace
 ```

--- a/docs/user_guide/installation.md
+++ b/docs/user_guide/installation.md
@@ -378,8 +378,14 @@ gh release list --repo neo4j-partners/neo4j-kubernetes-operator
 
 - **Kubernetes**: Version 1.32 or higher
 - **Neo4j**: Version 5.26 LTS (the final SemVer release) or any CalVer release (2025.x, 2026.x, and onward)
-- **cert-manager**: Version 1.20+ (optional, only required for TLS-enabled Neo4j deployments)
+- **cert-manager**: Version 1.20+ (optional, only required for Neo4j deployments that use cert-manager TLS, i.e. `spec.tls.mode: cert-manager`)
 - **Permissions**: Cluster-admin access for CRD and RBAC installation
+
+> **cert-manager install order**: The operator installs and runs fine without cert-manager. It only watches cert-manager `Certificate` resources when the cert-manager CRDs are present *at operator startup*. If you install cert-manager **after** the operator, restart the operator so the watch becomes active:
+> ```
+> kubectl rollout restart deployment/neo4j-operator-controller-manager -n neo4j-operator-system
+> ```
+> If you know you'll use cert-manager TLS, install cert-manager **before** the operator to avoid the restart.
 
 > **OpenShift note**: Clusters enforcing SCCs with allocated UID/FSGroup ranges should disable the chart’s pod security context so SCC can inject IDs, then bind an appropriate SCC (e.g., `restricted`) to the operator service account:
 > ```

--- a/docs/user_guide/installation.md
+++ b/docs/user_guide/installation.md
@@ -11,17 +11,17 @@ This guide provides detailed instructions for installing the Neo4j Enterprise Op
 > updated automatically on every operator release.
 
 ```bash
-helm repo add neo4j https://neo4j-partners.github.io/neo4j-kubernetes-operator/charts
+helm repo add neo4j-operator https://neo4j-partners.github.io/neo4j-kubernetes-operator/charts
 helm repo update
 
-helm install neo4j-operator neo4j/neo4j-operator \
+helm install neo4j-operator neo4j-operator/neo4j-operator \
   --namespace neo4j-operator-system \
   --create-namespace
 ```
 
 **Pin to a specific version**:
 ```bash
-helm install neo4j-operator neo4j/neo4j-operator \
+helm install neo4j-operator neo4j-operator/neo4j-operator \
   --version 1.8.0 \
   --namespace neo4j-operator-system \
   --create-namespace
@@ -30,9 +30,9 @@ helm install neo4j-operator neo4j/neo4j-operator \
 **Customise installation values**:
 ```bash
 # View available configuration options
-helm show values neo4j/neo4j-operator
+helm show values neo4j-operator/neo4j-operator
 
-helm install neo4j-operator neo4j/neo4j-operator \
+helm install neo4j-operator neo4j-operator/neo4j-operator \
   --namespace neo4j-operator-system \
   --create-namespace \
   --set resources.limits.memory=512Mi
@@ -41,7 +41,7 @@ helm install neo4j-operator neo4j/neo4j-operator \
 **Upgrade**:
 ```bash
 helm repo update
-helm upgrade neo4j-operator neo4j/neo4j-operator \
+helm upgrade neo4j-operator neo4j-operator/neo4j-operator \
   --namespace neo4j-operator-system
 ```
 

--- a/docs/user_guide/operator-modes.md
+++ b/docs/user_guide/operator-modes.md
@@ -74,22 +74,22 @@ export GOMAXPROCS=4
 The examples below use the Helm chart repository. See the [Installation Guide](installation.md) for the full set of installation methods (chart repo, OCI registry, kubectl-apply bundle, source clone).
 
 ```bash
-helm repo add neo4j https://neo4j-partners.github.io/neo4j-kubernetes-operator/charts
+helm repo add neo4j-operator https://neo4j-partners.github.io/neo4j-kubernetes-operator/charts
 helm repo update
 
 # Cluster scope (default)
-helm install neo4j-operator neo4j/neo4j-operator \
+helm install neo4j-operator neo4j-operator/neo4j-operator \
   --namespace neo4j-operator-system \
   --create-namespace
 
 # Namespace scope
-helm install neo4j-operator neo4j/neo4j-operator \
+helm install neo4j-operator neo4j-operator/neo4j-operator \
   --namespace team-a \
   --create-namespace \
   --set operatorMode=namespace
 
 # Multi-namespace scope
-helm install neo4j-operator neo4j/neo4j-operator \
+helm install neo4j-operator neo4j-operator/neo4j-operator \
   --namespace neo4j-operator-system \
   --create-namespace \
   --set operatorMode=namespaces \
@@ -231,14 +231,14 @@ Examples:
 
 ```bash
 # Development mode + cluster scope
-helm upgrade --install neo4j-operator neo4j/neo4j-operator \
+helm upgrade --install neo4j-operator neo4j-operator/neo4j-operator \
   --namespace neo4j-operator-dev \
   --create-namespace \
   --set developmentMode=true \
   --set logLevel=debug
 
 # Multi-namespace scope
-helm upgrade --install neo4j-operator neo4j/neo4j-operator \
+helm upgrade --install neo4j-operator neo4j-operator/neo4j-operator \
   --namespace neo4j-operator-system \
   --create-namespace \
   --set operatorMode=namespaces \

--- a/internal/controller/neo4jenterprisestandalone_controller.go
+++ b/internal/controller/neo4jenterprisestandalone_controller.go
@@ -1876,9 +1876,16 @@ func (r *Neo4jEnterpriseStandaloneReconciler) SetupWithManager(mgr ctrl.Manager)
 		Owns(&corev1.ConfigMap{}).
 		Owns(&networkingv1.Ingress{})
 
-	// Only watch Certificate resources if cert-manager is available
-	// This allows tests to run without cert-manager CRDs
-	if mgr.GetScheme().Recognizes(certmanagerv1.SchemeGroupVersion.WithKind("Certificate")) {
+	// Only watch Certificate resources if cert-manager is actually installed
+	// in the cluster. We check the REST mapper (real CRD presence) rather than
+	// the scheme — the cert-manager types are always registered in the scheme
+	// (cmd/main.go), so a scheme check (`Recognizes`) is always true and would
+	// start a Certificate informer even when the CRD is absent, crashing the
+	// manager at cache-sync. This makes cert-manager an OPTIONAL dependency,
+	// required only for clusters that use cert-manager TLS. Mirrors the Route
+	// guard below.
+	certGVK := certmanagerv1.SchemeGroupVersion.WithKind("Certificate")
+	if _, err := mgr.GetRESTMapper().RESTMapping(certGVK.GroupKind(), certGVK.Version); err == nil {
 		builder = builder.Owns(&certmanagerv1.Certificate{})
 	}
 


### PR DESCRIPTION
Hardening so a fresh `helm install` of the operator chart works out of the box and degrades gracefully. Reproduced and verified end-to-end on fresh Kind clusters with the published v1.10.2 chart/image.

## 1. Pre-install hook can't schedule → dedicated hook RBAC
The `pre-install` check Job ran as the operator ServiceAccount, but that SA (and its ClusterRoleBinding) are created in the **main** install phase — *after* pre-install hooks. So the Job's pod failed (`serviceaccount "neo4j-operator" not found`) and `helm install` hung/failed (`context deadline exceeded`). Affects 1.10.0/1.10.1/1.10.2.
**Fix:** dedicated pre-install hook RBAC (`templates/pre-install-rbac.yaml`) — SA + minimal ClusterRole (`get`/`list` on `customresourcedefinitions`) + binding, at hook-weight **-10** (ahead of the Job at **-5**), cleaned up on success. Job repointed to it.

## 2. cert-manager is now optional (was an implicit hard requirement)
The standalone controller watched `Certificate` gated on `Recognizes(...)`, which is **always true** (type registered in the scheme), so the manager started a `Certificate` informer even without the CRD → cache-sync failure → **crashloop**.
**Fix:** guard the watch on `mgr.GetRESTMapper().RESTMapping(...)` (actual CRD presence) — mirrors the OpenShift Route guard. Relaxed the pre-install check from hard-fail to a **warning** when cert-manager is absent. cert-manager is now required only for clusters using cert-manager TLS (`spec.tls.mode: cert-manager`).

## 3. Non-colliding Helm repo alias in install docs
`helm repo add neo4j …` collides with the official `neo4j` repo (`helm.neo4j.com`) → silent no-op → `helm install neo4j/neo4j-operator` resolves against the wrong repo. Renamed the alias to **`neo4j-operator`** across README, chart README, `docs/`, and `.github/release-notes-template.md` (fixes future release pages).

## 4. ServiceMonitor guarded on the Prometheus Operator CRD
`serviceMonitor.enabled=true` without `monitoring.coreos.com/v1` failed mid-install with a cryptic `no matches for kind "ServiceMonitor"`.
**Fix:** `.Capabilities.APIVersions.Has` guard that `fail`s with an actionable message ("install the Prometheus Operator, or set serviceMonitor.enabled=false").

## 5. Pinned the pre-install check image
Was `bitnami/kubectl:latest` — unpinned and fragile (Bitnami stopped publishing versioned `kubectl` tags; only `:latest` remains). Switched to **`alpine/k8s:1.32.0`** (alpine-based → has the `/bin/sh` the check needs; the distroless `registry.k8s.io/kubectl` and `rancher/kubectl` don't).

## Docs
`installation.md` + chart README: cert-manager is optional (only for cert-manager TLS); if installed **after** the operator, `kubectl rollout restart` to activate the Certificate watch (install before to avoid it). Prometheus Operator noted as required only when `serviceMonitor.enabled=true`.

## Verification (fresh Kind clusters, real published image)
- **With cert-manager:** install → `deployed`, Deployment 1/1, hook RBAC cleaned up.
- **Without cert-manager:** install → succeeds (check warns), operator **1/1, 0 restarts** (no crashloop) — cert-manager confirmed optional.
- **New hook image:** fresh install → pre-install hook runs under `alpine/k8s:1.32.0`, operator 1/1.
- **ServiceMonitor guard:** `helm template` fails with the message when the CRD is absent; renders the ServiceMonitor when present.
- `helm lint` clean; `go build`, `make test-unit` (7/7), `make sync-all`/`make bundle` leave the working tree clean (no generated-artifact conflicts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)