### PR TITLE
test(backup): bump Neo4jBackup controller spec timeout 30s→60s (CI flake)

### DIFF
--- a/internal/controller/neo4jbackup_controller_test.go
+++ b/internal/controller/neo4jbackup_controller_test.go
@@ -35,7 +35,14 @@ import (
 
 var _ = Describe("Neo4jBackup Controller", func() {
 	const (
-		timeout  = time.Second * 30
+		// 60s (not 30s): these specs share one envtest manager with the
+		// cluster/standalone/restore suites, whose reconcilers continuously
+		// retry Neo4j connectivity (there's no real Neo4j in envtest) and
+		// saturate the shared work queue. Under that load a reconcile that
+		// normally creates e.g. neo4j-backup-sa in <1s can miss a 30s window
+		// — a CI-only flake, never a logic failure. 60s absorbs the queue
+		// contention while staying well under the suite's per-test budget.
+		timeout  = time.Second * 60
 		interval = time.Millisecond * 250
 	)
 


### PR DESCRIPTION
## Problem

`TestControllers` failed on `main` with one flaky spec — **Neo4jBackup Controller › When creating a PVC backup › Should create the backup ServiceAccount automatically** (`neo4jbackup_controller_test.go:179`), *timed out after 30s*. ([failing run](https://github.com/neo4j-partners/neo4j-kubernetes-operator/actions/runs/27130893456))

## Root cause: envtest queue saturation, not a logic bug

The spec creates a `Neo4jBackup` and waits ≤30s for the operator to create `neo4j-backup-sa`. That SA is created early in the backup reconcile (before any Neo4j connectivity), so a timeout means the **shared manager's reconcile queue was backed up** — this suite shares one envtest manager with the cluster/standalone/restore suites, whose reconcilers continuously retry Neo4j connectivity (there's no real Neo4j in envtest). The CI log is wall-to-wall with `server misbehaving` DNS errors and `object has been modified` conflicts from that churn. Under that load an SA that normally appears in <1s can miss the 30s window.

Evidence it's a flake:
- The suite **passes locally** on the same `main` commit (`ok internal/controller`).
- The backup-SA logic (`ensureBackupServiceAccount`) is unchanged.
- Not related to the recent Helm pre-install SA work (that's a Helm install-time hook resource — `<release>-pre-install` — never exercised by envtest; the test asserts the operator's *runtime* `neo4j-backup-sa`).

## Fix

Raise the file's shared `timeout` constant (used by 16 `Eventually` blocks here) from 30s → 60s to absorb the queue contention, well within the suite's per-test budget. Test-only; no production code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test timing and comments only; no production or controller logic changes.
> 
> **Overview**
> Raises the shared **`timeout`** used by Neo4jBackup controller envtest **`Eventually`** waits from **30s to 60s**, and documents that the suite shares one envtest manager with cluster/standalone/restore reconcilers, which can saturate the work queue in CI and cause timing flakes (e.g. `neo4j-backup-sa` creation).
> 
> **Test-only** change; operator behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fc0dd6557c09695333a7e73efb5dbaa8133fc01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->