### PR TITLE
docs(install): from-clone Helm needs image.tag (NEO3-4); verify NEO3-6 PVC cleanup

### DIFF
--- a/docs/user_guide/installation.md
+++ b/docs/user_guide/installation.md
@@ -106,8 +106,20 @@ git checkout $LATEST_TAG    # or omit to test main
 
 helm install neo4j-operator ./charts/neo4j-operator \
   --namespace neo4j-operator-system \
-  --create-namespace
+  --create-namespace \
+  --set image.tag="${LATEST_TAG#v}"   # e.g. 1.11.0 — see note below
 ```
+
+> **You must set `image.tag` for a from-clone install.** In the repository,
+> `Chart.yaml`'s `version`/`appVersion` are a `0.0.1` placeholder that the
+> release pipeline stamps from the git tag at publish time. Without
+> `--set image.tag`, the chart resolves the image to
+> `ghcr.io/neo4j-partners/neo4j-kubernetes-operator:0.0.1`, which doesn't exist
+> (`ImagePullBackOff`). Set it to a released version (the `LATEST_TAG` above with
+> the `v` stripped), or build and load a local image and point `image.repository`
+> / `image.tag` at it — see the [developer guide](../developer_guide/development.md).
+> (Installing the *published* chart via Methods 1–2 doesn't need this — the
+> released chart already carries the real version.)
 
 ### Method 5: Git Clone with Make Targets
 


### PR DESCRIPTION
## Summary

- **NEO3-4** — `helm install ./charts/neo4j-operator` from a clone failed with `ImagePullBackOff` because `Chart.yaml` carries the `0.0.1` release placeholder, so the image resolved to `…:0.0.1` (nonexistent). Method 4 now documents `--set image.tag=<released>` (or building a local image), and notes the published-chart methods don't need it.
- **NEO3-6** — investigated; **no code change needed**. The PVC-cleanup selector was already fixed in v1.11.0 (`18cfd92`, Apr 2026). A live deploy→delete test on Kind removes the data PVC cleanly in **both** the bound case **and** the reporter's Pending/unbound case (unschedulable pod, `WaitForFirstConsumer`) — no orphan, no StatefulSet recreation.

## Type of change
- [x] Documentation

## Testing
- [x] `make test-unit` unaffected (docs-only change)
- Live verification on Kind (published v1.11.0 operator): standalone delete removes `neo4j-data-standalone-neo4j-0` in ~2–10s, bound and Pending scenarios.

Closes NEO3-4.
Verifies/closes NEO3-6 (already fixed in v1.11.0).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the installation guide; no runtime or chart behavior changes.
> 
> **Overview**
> **Method 4 (Helm from clone)** now requires setting **`image.tag`** in the install example (e.g. from `LATEST_TAG` with the `v` stripped), because the in-repo chart still uses **`0.0.1`** placeholders until the release pipeline stamps real versions.
> 
> A new callout explains that omitting **`image.tag`** pulls **`…:0.0.1`** and causes **`ImagePullBackOff`**, and points readers to a released tag, a local build via the developer guide, or Methods 1–2 where the published chart already has the correct version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33235c9c45cb00f281347c04e3da1e15788545eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->