### PR TITLE
fix(config): de-duplicate neo4j.conf keys (NEO3-16) + close related duplicate-key gaps

### DIFF
--- a/internal/controller/neo4jenterprisestandalone_conf_test.go
+++ b/internal/controller/neo4jenterprisestandalone_conf_test.go
@@ -1,0 +1,40 @@
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
+)
+
+// TestStandaloneCreateConfigMap_DedupesQueryLogKeys guards NEO3-16: the
+// single-node example enables monitoring (which emits db.logs.query.enabled /
+// db.logs.query.threshold) AND sets those same keys in spec.config. The rendered
+// /conf/neo4j.conf must declare each key only once, or CalVer Neo4j (2025.x+)
+// refuses to start with "<key> declared multiple times" → CrashLoopBackOff.
+func TestStandaloneCreateConfigMap_DedupesQueryLogKeys(t *testing.T) {
+	r := &Neo4jEnterpriseStandaloneReconciler{}
+	standalone := &neo4jv1beta1.Neo4jEnterpriseStandalone{
+		ObjectMeta: metav1.ObjectMeta{Name: "standalone-neo4j", Namespace: "default"},
+		Spec: neo4jv1beta1.Neo4jEnterpriseStandaloneSpec{
+			Image:      neo4jv1beta1.ImageSpec{Repo: "neo4j", Tag: "2026.04-enterprise"},
+			Monitoring: &neo4jv1beta1.MonitoringSpec{Enabled: true, SlowQueryThreshold: "5s"},
+			Config: map[string]string{
+				"db.logs.query.enabled":   "true",
+				"db.logs.query.threshold": "1s",
+			},
+		},
+	}
+
+	conf := r.createConfigMap(standalone).Data["neo4j.conf"]
+
+	assert.Equal(t, 1, strings.Count(conf, "db.logs.query.threshold="),
+		"db.logs.query.threshold must be declared exactly once")
+	assert.Equal(t, 1, strings.Count(conf, "db.logs.query.enabled="),
+		"db.logs.query.enabled must be declared exactly once")
+	// User spec.config is appended last, so its value wins after de-duplication.
+	assert.Contains(t, conf, "db.logs.query.threshold=1s")
+}

--- a/internal/controller/neo4jenterprisestandalone_conf_test.go
+++ b/internal/controller/neo4jenterprisestandalone_conf_test.go
@@ -38,3 +38,99 @@ func TestStandaloneCreateConfigMap_DedupesQueryLogKeys(t *testing.T) {
 	// User spec.config is appended last, so its value wins after de-duplication.
 	assert.Contains(t, conf, "db.logs.query.threshold=1s")
 }
+
+// duplicateConfKeys returns any neo4j.conf key that is declared more than once.
+// CalVer Neo4j (2025.x+) treats a repeated key as fatal ("<key> declared
+// multiple times") and refuses to start. server.jvm.additional /
+// dbms.jvm.additional are legitimately repeatable (one line per JVM arg) and so
+// are excluded.
+func duplicateConfKeys(conf string) []string {
+	counts := map[string]int{}
+	for _, line := range strings.Split(conf, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		eq := strings.IndexByte(line, '=')
+		if eq < 0 {
+			continue
+		}
+		key := strings.TrimSpace(line[:eq])
+		if key == "server.jvm.additional" || key == "dbms.jvm.additional" {
+			continue
+		}
+		counts[key]++
+	}
+	var dups []string
+	for k, n := range counts {
+		if n > 1 {
+			dups = append(dups, k)
+		}
+	}
+	return dups
+}
+
+// TestStandaloneCreateConfigMap_NoDuplicateKeys is the general invariant behind
+// NEO3-16: across realistic config layerings (monitoring + audit + auth + user
+// spec.config overrides on shared keys), the rendered standalone neo4j.conf must
+// never declare a key twice. This is a pure function of config assembly, so it
+// guards the whole class of "CalVer won't boot" regressions at every version in
+// milliseconds — the integration suite only exercised CalVer on manual dispatch
+// and never with the colliding layers, so it couldn't catch this.
+func TestStandaloneCreateConfigMap_NoDuplicateKeys(t *testing.T) {
+	r := &Neo4jEnterpriseStandaloneReconciler{}
+	base := neo4jv1beta1.ImageSpec{Repo: "neo4j", Tag: "2026.04-enterprise"}
+
+	cases := []struct {
+		name string
+		spec neo4jv1beta1.Neo4jEnterpriseStandaloneSpec
+	}{
+		{
+			name: "minimal",
+			spec: neo4jv1beta1.Neo4jEnterpriseStandaloneSpec{Image: base},
+		},
+		{
+			name: "monitoring + audit (both touch db.logs.query.obfuscate_literals)",
+			spec: neo4jv1beta1.Neo4jEnterpriseStandaloneSpec{
+				Image:      base,
+				Monitoring: &neo4jv1beta1.MonitoringSpec{Enabled: true, SlowQueryThreshold: "5s", QueryLogLevel: "INFO"},
+				Audit:      &neo4jv1beta1.AuditSpec{Enabled: true, ObfuscateQueryLiterals: boolPtr(false), ParameterLogging: boolPtr(true)},
+			},
+		},
+		{
+			name: "monitoring + audit + user overrides on shared keys",
+			spec: neo4jv1beta1.Neo4jEnterpriseStandaloneSpec{
+				Image:      base,
+				Monitoring: &neo4jv1beta1.MonitoringSpec{Enabled: true, SlowQueryThreshold: "5s", QueryLogLevel: "VERBOSE"},
+				Audit:      &neo4jv1beta1.AuditSpec{Enabled: true},
+				Config: map[string]string{
+					"db.logs.query.enabled":            "true",
+					"db.logs.query.threshold":          "1s",
+					"db.logs.query.obfuscate_literals": "true",
+					"server.memory.heap.max_size":      "2G",
+				},
+			},
+		},
+		{
+			name: "auth + monitoring + user config",
+			spec: neo4jv1beta1.Neo4jEnterpriseStandaloneSpec{
+				Image:      base,
+				Monitoring: &neo4jv1beta1.MonitoringSpec{Enabled: true},
+				Auth:       &neo4jv1beta1.AuthSpec{AdminSecret: "admin-secret"},
+				Config:     map[string]string{"server.memory.heap.initial_size": "1G"},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			standalone := &neo4jv1beta1.Neo4jEnterpriseStandalone{
+				ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "default"},
+				Spec:       tc.spec,
+			}
+			conf := r.createConfigMap(standalone).Data["neo4j.conf"]
+			assert.Empty(t, duplicateConfKeys(conf),
+				"rendered neo4j.conf must not declare any key twice (CalVer Neo4j fails to start otherwise)")
+		})
+	}
+}

--- a/internal/controller/neo4jenterprisestandalone_controller.go
+++ b/internal/controller/neo4jenterprisestandalone_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 	"time"
 
@@ -814,7 +815,15 @@ func (r *Neo4jEnterpriseStandaloneReconciler) createConfigMap(standalone *neo4jv
 	// server.config.strict_validation.enabled=false elsewhere lets Neo4j
 	// silently honour a duplicate-key override, we must not append user
 	// values here even if the validator was bypassed somehow.
-	for key, value := range standalone.Spec.Config {
+	// Sort keys for deterministic conf ordering (the cluster path does the same):
+	// the ConfigMap is hash-compared, so an unsorted map iteration would reorder
+	// lines between reconciles and trigger spurious rolling restarts.
+	userConfigKeys := make([]string, 0, len(standalone.Spec.Config))
+	for key := range standalone.Spec.Config {
+		userConfigKeys = append(userConfigKeys, key)
+	}
+	sort.Strings(userConfigKeys)
+	for _, key := range userConfigKeys {
 		if authGeneratedKeys != nil && authGeneratedKeys[key] {
 			continue
 		}
@@ -823,7 +832,7 @@ func (r *Neo4jEnterpriseStandaloneReconciler) createConfigMap(standalone *neo4jv
 			key == "server.directories.certificates" {
 			continue
 		}
-		configLines = append(configLines, fmt.Sprintf("%s=%s", key, value))
+		configLines = append(configLines, fmt.Sprintf("%s=%s", key, standalone.Spec.Config[key]))
 	}
 
 	// Trusted-CA truststore JVM args (legacy spec.auth.trustStore + new

--- a/internal/controller/neo4jenterprisestandalone_controller.go
+++ b/internal/controller/neo4jenterprisestandalone_controller.go
@@ -841,8 +841,11 @@ func (r *Neo4jEnterpriseStandaloneReconciler) createConfigMap(standalone *neo4jv
 		)
 	}
 
-	// Join all lines
-	neo4jConf := strings.Join(configLines, "\n")
+	// Join all lines, then de-duplicate setting keys (keep last occurrence).
+	// Without this, a key emitted by both monitoring and user spec.config
+	// (e.g. db.logs.query.threshold) appears twice and CalVer Neo4j refuses to
+	// start ("declared multiple times"). See resources.DedupeNeo4jConf.
+	neo4jConf := resources.DedupeNeo4jConf(strings.Join(configLines, "\n"))
 
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/plugin_controller.go
+++ b/internal/controller/plugin_controller.go
@@ -997,25 +997,9 @@ func (r *Neo4jPluginReconciler) installPluginViaEnvironment(ctx context.Context,
 
 		}
 
-		// Apply security settings as environment variables (both automatic and user-provided)
-		for key, value := range userSecuritySettings {
-			envVarName := fmt.Sprintf("NEO4J_%s", strings.ToUpper(strings.ReplaceAll(key, ".", "_")))
-			// Check if environment variable already exists
-			exists := false
-			for i := range currentNeo4jContainer.Env {
-				if currentNeo4jContainer.Env[i].Name == envVarName {
-					currentNeo4jContainer.Env[i].Value = value
-					exists = true
-					break
-				}
-			}
-			if !exists {
-				currentNeo4jContainer.Env = append(currentNeo4jContainer.Env, corev1.EnvVar{
-					Name:  envVarName,
-					Value: value,
-				})
-			}
-		}
+		// Apply security settings as environment variables, unioning additive
+		// allowlists across plugins (see mergePluginSecurityEnv).
+		currentNeo4jContainer.Env = mergePluginSecurityEnv(currentNeo4jContainer.Env, userSecuritySettings)
 
 		return r.Update(ctx, currentSts)
 	})
@@ -1040,6 +1024,44 @@ func (r *Neo4jPluginReconciler) installPluginViaEnvironment(ctx context.Context,
 	// before connectivity checks to ensure security settings are applied before Neo4j starts
 
 	return nil
+}
+
+// mergePluginSecurityEnv applies a plugin's security settings to a container's
+// env vars without clobbering across plugins. For additive list keys
+// (resources.IsAdditiveConfKey — e.g. dbms.security.procedures.unrestricted /
+// allowlist), the value is UNIONED with any existing env value, so GDS's `gds.*`
+// and APOC's `apoc.*` both survive instead of the last-reconciled plugin
+// overwriting the first. Scalar keys are set in place. Deterministic (keys
+// processed sorted) and idempotent (re-applying the same settings is a no-op).
+//
+// NOTE: this accumulates tokens; tokens from an *uninstalled* plugin are not
+// pruned here — that needs the authoritative recompute tracked in issue #146.
+func mergePluginSecurityEnv(env []corev1.EnvVar, settings map[string]string) []corev1.EnvVar {
+	keys := make([]string, 0, len(settings))
+	for k := range settings {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		envName := fmt.Sprintf("NEO4J_%s", strings.ToUpper(strings.ReplaceAll(key, ".", "_")))
+		idx := -1
+		for i := range env {
+			if env[i].Name == envName {
+				idx = i
+				break
+			}
+		}
+		switch {
+		case idx >= 0 && resources.IsAdditiveConfKey(key):
+			env[idx].Value = resources.MergeConfListValues(env[idx].Value, settings[key])
+		case idx >= 0:
+			env[idx].Value = settings[key]
+		default:
+			env = append(env, corev1.EnvVar{Name: envName, Value: settings[key]})
+		}
+	}
+	return env
 }
 
 // injectVerifiedDownloadInitContainer adds (or updates) the plugin's

--- a/internal/controller/plugin_controller.go
+++ b/internal/controller/plugin_controller.go
@@ -726,8 +726,58 @@ func (r *Neo4jPluginReconciler) removePluginFromDeployment(ctx context.Context, 
 		return fmt.Errorf("failed to create plugin removal job: %w", err)
 	}
 
+	// Prune this plugin's additive security tokens from the StatefulSet env vars
+	// so an uninstalled plugin's allowlist (e.g. gds.*) doesn't linger — the
+	// install path only ever unions tokens in, so removal must happen here.
+	// Best-effort: a failure here shouldn't block the finalizer / removal job.
+	if err := r.prunePluginSecurityEnv(ctx, plugin, deployment); err != nil {
+		logger.Error(err, "Failed to prune plugin security env vars from StatefulSet; continuing", "plugin", plugin.Spec.Name)
+	}
+
 	// Wait for job completion
 	return r.waitForJobCompletion(ctx, removeJob)
+}
+
+// prunePluginSecurityEnv removes the uninstalled plugin's additive security
+// tokens from the target StatefulSet's neo4j container env vars. No-op when the
+// StatefulSet is gone or the plugin contributed no additive env vars (e.g. a
+// standalone, which carries plugin security in neo4j.conf rather than env vars).
+func (r *Neo4jPluginReconciler) prunePluginSecurityEnv(ctx context.Context, plugin *neo4jv1beta1.Neo4jPlugin, deployment *DeploymentInfo) error {
+	stsKey := types.NamespacedName{Name: r.getStatefulSetName(deployment), Namespace: deployment.Namespace}
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		sts := &appsv1.StatefulSet{}
+		if err := r.Get(ctx, stsKey, sts); err != nil {
+			if errors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		for i := range sts.Spec.Template.Spec.Containers {
+			c := &sts.Spec.Template.Spec.Containers[i]
+			if c.Name != "neo4j" {
+				continue
+			}
+			pruned := removePluginSecurityEnv(c.Env, r.pluginSecuritySettings(plugin))
+			if len(pruned) == len(c.Env) {
+				// Recompute equality cheaply: lengths match AND values unchanged?
+				// removePluginSecurityEnv only ever shrinks or rewrites values, so
+				// compare to avoid a no-op Update (which would needlessly restart).
+				same := true
+				for j := range pruned {
+					if pruned[j] != c.Env[j] {
+						same = false
+						break
+					}
+				}
+				if same {
+					return nil
+				}
+			}
+			c.Env = pruned
+			return r.Update(ctx, sts)
+		}
+		return nil
+	})
 }
 
 func (r *Neo4jPluginReconciler) updatePluginStatus(ctx context.Context, plugin *neo4jv1beta1.Neo4jPlugin, phase, message string) {
@@ -838,7 +888,7 @@ func (r *Neo4jPluginReconciler) installPluginViaEnvironment(ctx context.Context,
 
 	// Add plugin configuration as environment variables
 	for key, value := range plugin.Spec.Config {
-		envVarName := fmt.Sprintf("NEO4J_%s", strings.ToUpper(strings.ReplaceAll(key, ".", "_")))
+		envVarName := resources.Neo4jSettingEnvVarName(key)
 		neo4jContainer.Env = append(neo4jContainer.Env, corev1.EnvVar{
 			Name:  envVarName,
 			Value: value,
@@ -849,7 +899,7 @@ func (r *Neo4jPluginReconciler) installPluginViaEnvironment(ctx context.Context,
 	if r.getPluginType(plugin.Spec.Name) != PluginTypeEnvironmentOnly {
 		requiredSettings := r.getRequiredProcedureSecuritySettings(plugin.Spec.Name)
 		for key, value := range requiredSettings {
-			envVarName := fmt.Sprintf("NEO4J_%s", strings.ToUpper(strings.ReplaceAll(key, ".", "_")))
+			envVarName := resources.Neo4jSettingEnvVarName(key)
 
 			// Check if this environment variable already exists
 			exists := false
@@ -948,7 +998,7 @@ func (r *Neo4jPluginReconciler) installPluginViaEnvironment(ctx context.Context,
 
 		// Add plugin-specific configuration as environment variables
 		for key, value := range plugin.Spec.Config {
-			envVarName := fmt.Sprintf("NEO4J_%s", strings.ToUpper(strings.ReplaceAll(key, ".", "_")))
+			envVarName := resources.Neo4jSettingEnvVarName(key)
 			// Check if environment variable already exists
 			exists := false
 			for i := range currentNeo4jContainer.Env {
@@ -966,40 +1016,9 @@ func (r *Neo4jPluginReconciler) installPluginViaEnvironment(ctx context.Context,
 			}
 		}
 
-		// Start with automatic security settings for plugins that require them
-		userSecuritySettings := r.getAutomaticSecuritySettings(plugin.Spec.Name)
-
-		// Add user-provided security settings as environment variables (non-dynamic settings only)
-		if plugin.Spec.Security != nil {
-
-			// Convert allowed procedures to allowlist setting
-			if len(plugin.Spec.Security.AllowedProcedures) > 0 {
-				allowedList := strings.Join(plugin.Spec.Security.AllowedProcedures, ",")
-				userSecuritySettings["dbms.security.procedures.allowlist"] = allowedList
-			}
-
-			// Convert denied procedures to denylist setting
-			if len(plugin.Spec.Security.DeniedProcedures) > 0 {
-				deniedList := strings.Join(plugin.Spec.Security.DeniedProcedures, ",")
-				userSecuritySettings["dbms.security.procedures.denylist"] = deniedList
-			}
-
-			// Convert sandbox setting to unrestricted (inverted logic)
-			if plugin.Spec.Security.Sandbox {
-				// Sandbox mode means restricted procedures - use allowlist only, no unrestricted
-			} else {
-				// Non-sandbox mode may need unrestricted procedures (use allowed list as unrestricted)
-				if len(plugin.Spec.Security.AllowedProcedures) > 0 {
-					allowedList := strings.Join(plugin.Spec.Security.AllowedProcedures, ",")
-					userSecuritySettings["dbms.security.procedures.unrestricted"] = allowedList
-				}
-			}
-
-		}
-
 		// Apply security settings as environment variables, unioning additive
 		// allowlists across plugins (see mergePluginSecurityEnv).
-		currentNeo4jContainer.Env = mergePluginSecurityEnv(currentNeo4jContainer.Env, userSecuritySettings)
+		currentNeo4jContainer.Env = mergePluginSecurityEnv(currentNeo4jContainer.Env, r.pluginSecuritySettings(plugin))
 
 		return r.Update(ctx, currentSts)
 	})
@@ -1036,6 +1055,77 @@ func (r *Neo4jPluginReconciler) installPluginViaEnvironment(ctx context.Context,
 //
 // NOTE: this accumulates tokens; tokens from an *uninstalled* plugin are not
 // pruned here — that needs the authoritative recompute tracked in issue #146.
+// pluginSecuritySettings returns the Neo4j security settings a plugin
+// contributes (automatic per-plugin defaults plus any user-provided
+// spec.security). Used both when applying settings at install and when removing
+// them on uninstall, so the two paths can't diverge.
+func (r *Neo4jPluginReconciler) pluginSecuritySettings(plugin *neo4jv1beta1.Neo4jPlugin) map[string]string {
+	settings := r.getAutomaticSecuritySettings(plugin.Spec.Name)
+	if plugin.Spec.Security != nil {
+		if len(plugin.Spec.Security.AllowedProcedures) > 0 {
+			allowedList := strings.Join(plugin.Spec.Security.AllowedProcedures, ",")
+			settings["dbms.security.procedures.allowlist"] = allowedList
+			// Non-sandbox mode also runs the allowed procedures unrestricted.
+			if !plugin.Spec.Security.Sandbox {
+				settings["dbms.security.procedures.unrestricted"] = allowedList
+			}
+		}
+		if len(plugin.Spec.Security.DeniedProcedures) > 0 {
+			settings["dbms.security.procedures.denylist"] = strings.Join(plugin.Spec.Security.DeniedProcedures, ",")
+		}
+	}
+	return settings
+}
+
+// removePluginSecurityEnv reverses mergePluginSecurityEnv for a single plugin on
+// uninstall: for additive list keys it subtracts that plugin's tokens from the
+// env var (dropping the var entirely if nothing remains), so another plugin's
+// allowlist is preserved while the uninstalled plugin's entries are pruned.
+// Non-additive (scalar) keys are left untouched — they may be shared, and the
+// accumulation problem this prunes is specific to the additive lists. Plugin
+// token sets are disjoint (gds.*, apoc.*, …), so subtraction is exact.
+func removePluginSecurityEnv(env []corev1.EnvVar, settings map[string]string) []corev1.EnvVar {
+	remove := make(map[string]string) // env var name -> tokens to subtract
+	for key, value := range settings {
+		if resources.IsAdditiveConfKey(key) {
+			remove[resources.Neo4jSettingEnvVarName(key)] = value
+		}
+	}
+	if len(remove) == 0 {
+		return env
+	}
+
+	out := env[:0:0]
+	for _, e := range env {
+		if toks, ok := remove[e.Name]; ok {
+			e.Value = subtractCSV(e.Value, toks)
+			if e.Value == "" {
+				continue // nothing left for this key — drop it
+			}
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+// subtractCSV returns value's comma-separated tokens with remove's tokens taken
+// out, preserving order.
+func subtractCSV(value, remove string) string {
+	rm := make(map[string]bool)
+	for _, t := range strings.Split(remove, ",") {
+		if t = strings.TrimSpace(t); t != "" {
+			rm[t] = true
+		}
+	}
+	var keep []string
+	for _, t := range strings.Split(value, ",") {
+		if t = strings.TrimSpace(t); t != "" && !rm[t] {
+			keep = append(keep, t)
+		}
+	}
+	return strings.Join(keep, ",")
+}
+
 func mergePluginSecurityEnv(env []corev1.EnvVar, settings map[string]string) []corev1.EnvVar {
 	keys := make([]string, 0, len(settings))
 	for k := range settings {
@@ -1044,7 +1134,7 @@ func mergePluginSecurityEnv(env []corev1.EnvVar, settings map[string]string) []c
 	sort.Strings(keys)
 
 	for _, key := range keys {
-		envName := fmt.Sprintf("NEO4J_%s", strings.ToUpper(strings.ReplaceAll(key, ".", "_")))
+		envName := resources.Neo4jSettingEnvVarName(key)
 		idx := -1
 		for i := range env {
 			if env[i].Name == envName {

--- a/internal/controller/plugin_controller.go
+++ b/internal/controller/plugin_controller.go
@@ -1299,19 +1299,15 @@ func (r *Neo4jPluginReconciler) updateStandaloneConfigMapForPlugin(ctx context.C
 		return fmt.Errorf("neo4j.conf not found in ConfigMap %s", configMapName)
 	}
 
-	// Add plugin settings to neo4j.conf if they don't already exist
-	updatedConf := currentConf
-	for key, value := range allSettings {
-		settingLine := fmt.Sprintf("%s=%s", key, value)
-		if !strings.Contains(updatedConf, settingLine) {
-			// Add a comment and the setting
-			comment := fmt.Sprintf("\n# %s plugin configuration", plugin.Spec.Name)
-			updatedConf += comment + "\n" + settingLine + "\n"
-			logger.Info("Adding plugin setting to ConfigMap", "setting", settingLine)
-		} else {
-			logger.Info("Plugin setting already present in ConfigMap", "setting", settingLine)
-		}
-	}
+	// Merge plugin settings into neo4j.conf without creating duplicate keys.
+	// The previous approach appended a line guarded only by an exact-substring
+	// check, so a plugin allowlist (e.g. dbms.security.procedures.unrestricted=
+	// apoc.*) was added as a SECOND declaration when the conf already had that
+	// key (e.g. =gds.*) — CalVer Neo4j then refuses to start ("declared multiple
+	// times"). UpsertNeo4jConfSettings unions additive keys and adds scalar keys
+	// only when absent; it is idempotent, so a no-op won't churn the ConfigMap
+	// or restart the pod.
+	updatedConf := resources.UpsertNeo4jConfSettings(currentConf, allSettings)
 
 	// Update the ConfigMap if changes were made
 	if updatedConf != currentConf {

--- a/internal/controller/plugin_controller.go
+++ b/internal/controller/plugin_controller.go
@@ -757,7 +757,7 @@ func (r *Neo4jPluginReconciler) prunePluginSecurityEnv(ctx context.Context, plug
 			if c.Name != "neo4j" {
 				continue
 			}
-			pruned := removePluginSecurityEnv(c.Env, r.pluginSecuritySettings(plugin))
+			pruned := removePluginSecurityEnv(c.Env, r.pluginSecurityRemovalSettings(plugin))
 			if len(pruned) == len(c.Env) {
 				// Recompute equality cheaply: lengths match AND values unchanged?
 				// removePluginSecurityEnv only ever shrinks or rewrites values, so
@@ -1075,6 +1075,36 @@ func (r *Neo4jPluginReconciler) pluginSecuritySettings(plugin *neo4jv1beta1.Neo4
 		}
 	}
 	return settings
+}
+
+// pluginSecurityRemovalSettings returns the additive-key token set to subtract on
+// uninstall: the UNION of the plugin's automatic per-name defaults and its
+// current spec.security override. The merge path (mergePluginSecurityEnv) unions
+// every reconcile's pluginSecuritySettings into the env, but pluginSecuritySettings
+// *replaces* unrestricted/allowlist with the custom list when allowedProcedures is
+// set — so a plugin installed with defaults and later given an override leaves the
+// automatic tokens (e.g. gds.*,apoc.load.*) accumulated in env that the current
+// spec no longer mentions. Always subtracting the automatic defaults too means
+// they can never be orphaned, regardless of spec toggling.
+//
+// This closes the common orphaned-defaults case. The fully general gap — a plugin
+// whose custom allowedProcedures was changed to several *different* values over its
+// lifetime — still needs per-plugin token ownership tracking, deferred to #146,
+// because only the current custom value is knowable here.
+func (r *Neo4jPluginReconciler) pluginSecurityRemovalSettings(plugin *neo4jv1beta1.Neo4jPlugin) map[string]string {
+	auto := r.getAutomaticSecuritySettings(plugin.Spec.Name)
+	out := make(map[string]string, len(auto))
+	for k, v := range auto {
+		out[k] = v
+	}
+	for k, v := range r.pluginSecuritySettings(plugin) {
+		if existing, ok := out[k]; ok && resources.IsAdditiveConfKey(k) {
+			out[k] = resources.MergeConfListValues(existing, v)
+		} else {
+			out[k] = v
+		}
+	}
+	return out
 }
 
 // removePluginSecurityEnv reverses mergePluginSecurityEnv for a single plugin on

--- a/internal/controller/plugin_controller.go
+++ b/internal/controller/plugin_controller.go
@@ -624,6 +624,19 @@ func (r *Neo4jPluginReconciler) uninstallPlugin(ctx context.Context, plugin *neo
 		return nil
 	}
 
+	// Prune this plugin's additive security tokens (e.g. gds.*) from the
+	// StatefulSet env vars. The install path unions these in for EVERY mode
+	// (mergePluginSecurityEnv runs regardless of PreBaked/VerifiedDownload),
+	// so removal must be mode-independent too — done here, before the
+	// mode-specific early returns below, rather than only in the Managed
+	// JAR-removal path. The cluster controller's env merge is subset/
+	// ownership-tracked and will NOT drop tokens it doesn't own, so this
+	// explicit prune is the only thing that removes them. Best-effort: a
+	// failure here must not block the finalizer.
+	if err := r.prunePluginSecurityEnv(ctx, plugin, deployment); err != nil {
+		logger.Error(err, "Failed to prune plugin security env vars from StatefulSet; continuing", "plugin", plugin.Spec.Name)
+	}
+
 	// VerifiedDownload installs need the init container + auth/CA
 	// volumes removed from the StatefulSet on uninstall — otherwise
 	// the next reconcile would still try to download and the pod
@@ -645,9 +658,8 @@ func (r *Neo4jPluginReconciler) uninstallPlugin(ctx context.Context, plugin *neo
 	// PreBaked installs are JARs the operator did not deliver — never run the
 	// jar-removal Job against them. The user-supplied custom image owns
 	// /plugins/*; touching it could orphan files the operator did not put
-	// there. Only configuration (env vars, ConfigMap entries) was operator-
-	// owned, and that is removed when the StatefulSet/ConfigMap is reconciled
-	// after the CR is deleted.
+	// there. The operator-owned configuration (security env tokens) has
+	// already been pruned above; ConfigMap entries are reconciled separately.
 	if isPreBakedInstallMode(plugin) {
 		logger.Info("Skipping JAR removal for PreBaked plugin", "plugin", plugin.Spec.Name)
 		return nil
@@ -726,13 +738,8 @@ func (r *Neo4jPluginReconciler) removePluginFromDeployment(ctx context.Context, 
 		return fmt.Errorf("failed to create plugin removal job: %w", err)
 	}
 
-	// Prune this plugin's additive security tokens from the StatefulSet env vars
-	// so an uninstalled plugin's allowlist (e.g. gds.*) doesn't linger — the
-	// install path only ever unions tokens in, so removal must happen here.
-	// Best-effort: a failure here shouldn't block the finalizer / removal job.
-	if err := r.prunePluginSecurityEnv(ctx, plugin, deployment); err != nil {
-		logger.Error(err, "Failed to prune plugin security env vars from StatefulSet; continuing", "plugin", plugin.Spec.Name)
-	}
+	// Security-token env pruning is handled mode-independently in
+	// uninstallPlugin (before the mode branches), so it is not repeated here.
 
 	// Wait for job completion
 	return r.waitForJobCompletion(ctx, removeJob)

--- a/internal/controller/plugin_install_mode_test.go
+++ b/internal/controller/plugin_install_mode_test.go
@@ -110,7 +110,9 @@ func TestInstallPluginViaEnvironment_Managed(t *testing.T) {
 	assert.Contains(t, pluginsVal, "graph-data-science")
 
 	// GDS triggers automatic security settings — verify one landed.
-	unrestricted, ok := findEnv(c, "NEO4J_DBMS_SECURITY_PROCEDURES_UNRESTRICTED")
+	// Neo4j env-var convention preserves case: dots→underscores, no upper-casing
+	// (see resources.Neo4jSettingEnvVarName).
+	unrestricted, ok := findEnv(c, "NEO4J_dbms_security_procedures_unrestricted")
 	require.True(t, ok, "Managed mode must write the GDS unrestricted security env var")
 	assert.Contains(t, unrestricted, "gds.*")
 }
@@ -147,7 +149,7 @@ func TestInstallPluginViaEnvironment_PreBaked(t *testing.T) {
 
 	// Configuration path must still run — security env vars are why a user
 	// keeps the CR around when they bake the JAR into the image.
-	unrestricted, ok := findEnv(c, "NEO4J_DBMS_SECURITY_PROCEDURES_UNRESTRICTED")
+	unrestricted, ok := findEnv(c, "NEO4J_dbms_security_procedures_unrestricted")
 	require.True(t, ok, "PreBaked mode must still write the GDS unrestricted security env var")
 	assert.Contains(t, unrestricted, "gds.*")
 }

--- a/internal/controller/plugin_install_mode_test.go
+++ b/internal/controller/plugin_install_mode_test.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
+	"github.com/neo4j-partners/neo4j-kubernetes-operator/internal/resources"
 )
 
 // newPluginTestReconciler builds a Neo4jPluginReconciler backed by a fake
@@ -152,6 +153,49 @@ func TestInstallPluginViaEnvironment_PreBaked(t *testing.T) {
 	unrestricted, ok := findEnv(c, "NEO4J_dbms_security_procedures_unrestricted")
 	require.True(t, ok, "PreBaked mode must still write the GDS unrestricted security env var")
 	assert.Contains(t, unrestricted, "gds.*")
+}
+
+// TestUninstallPlugin_PrunesSecurityEnvForAllModes guards that uninstall removes
+// the plugin's security tokens (e.g. gds.*) regardless of install mode. The
+// install path unions these into the StatefulSet env for EVERY mode (the
+// PreBaked/VerifiedDownload guards only skip the NEO4J_PLUGINS list), so a
+// mode-specific prune would orphan them: PreBaked and VerifiedDownload uninstall
+// return before the Managed JAR-removal path that used to own the prune.
+func TestUninstallPlugin_PrunesSecurityEnvForAllModes(t *testing.T) {
+	const ns = "default"
+	const clusterName = "c1"
+	unrestricted := resources.Neo4jSettingEnvVarName("dbms.security.procedures.unrestricted")
+
+	for _, mode := range []string{PluginInstallModePreBaked, PluginInstallModeVerifiedDownload} {
+		t.Run(mode, func(t *testing.T) {
+			// STS carries the tokens the install path would have merged in.
+			sts := pluginTestSTS(clusterName, ns)
+			sts.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{
+				{Name: unrestricted, Value: "gds.*,apoc.load.*"},
+			}
+			cluster := &neo4jv1beta1.Neo4jEnterpriseCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: ns},
+			}
+			r := newPluginTestReconciler(t, sts, cluster)
+
+			plugin := &neo4jv1beta1.Neo4jPlugin{
+				ObjectMeta: metav1.ObjectMeta{Name: "gds", Namespace: ns},
+				Spec: neo4jv1beta1.Neo4jPluginSpec{
+					ClusterRef:  clusterName,
+					Name:        "graph-data-science",
+					Version:     "2.13.0",
+					InstallMode: mode,
+				},
+			}
+
+			require.NoError(t, r.uninstallPlugin(context.Background(), plugin))
+
+			got := &appsv1.StatefulSet{}
+			require.NoError(t, r.Get(context.Background(), types.NamespacedName{Name: clusterName + "-server", Namespace: ns}, got))
+			_, has := findEnv(&got.Spec.Template.Spec.Containers[0], unrestricted)
+			assert.False(t, has, "%s uninstall must prune the plugin's security env tokens", mode)
+		})
+	}
 }
 
 // TestInstallPluginViaEnvironment_PreBaked_PreservesExistingPluginsEnv asserts

--- a/internal/controller/plugin_security_env_test.go
+++ b/internal/controller/plugin_security_env_test.go
@@ -1,39 +1,41 @@
 package controller
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/neo4j-partners/neo4j-kubernetes-operator/internal/resources"
 )
 
-// mergePluginSecurityEnv must UNION additive allowlists across plugins so one
-// plugin's procedures aren't silently lost when another plugin reconciles
-// (e.g. GDS then APOC). Scalar keys are set in place. Idempotent.
-func TestMergePluginSecurityEnv_UnionsAllowlistsAcrossPlugins(t *testing.T) {
-	envName := func(k string) string {
-		return "NEO4J_" + strings.ToUpper(strings.ReplaceAll(k, ".", "_"))
-	}
-	get := func(env []corev1.EnvVar, name string) string {
-		for _, e := range env {
-			if e.Name == name {
-				return e.Value
-			}
+func envValue(env []corev1.EnvVar, name string) string {
+	for _, e := range env {
+		if e.Name == name {
+			return e.Value
 		}
-		return ""
 	}
-	count := func(env []corev1.EnvVar, name string) int {
-		n := 0
-		for _, e := range env {
-			if e.Name == name {
-				n++
-			}
-		}
-		return n
-	}
+	return ""
+}
 
-	// GDS reconcile, then APOC reconcile.
+func envCount(env []corev1.EnvVar, name string) int {
+	n := 0
+	for _, e := range env {
+		if e.Name == name {
+			n++
+		}
+	}
+	return n
+}
+
+// mergePluginSecurityEnv must UNION additive allowlists across plugins (so GDS
+// and APOC both survive) and use the correct Neo4j env-var name form.
+func TestMergePluginSecurityEnv_UnionsAllowlistsAcrossPlugins(t *testing.T) {
+	unrestricted := resources.Neo4jSettingEnvVarName("dbms.security.procedures.unrestricted")
+	allowlist := resources.Neo4jSettingEnvVarName("dbms.security.procedures.allowlist")
+	// Correct convention: lowercase, dots->underscores (no upper-casing).
+	assert.Equal(t, "NEO4J_dbms_security_procedures_unrestricted", unrestricted)
+
 	env := mergePluginSecurityEnv(nil, map[string]string{
 		"dbms.security.procedures.unrestricted": "gds.*",
 		"dbms.security.procedures.allowlist":    "gds.*",
@@ -43,18 +45,37 @@ func TestMergePluginSecurityEnv_UnionsAllowlistsAcrossPlugins(t *testing.T) {
 		"dbms.security.procedures.allowlist":    "apoc.*",
 	})
 
-	unrestricted := envName("dbms.security.procedures.unrestricted")
-	assert.Equal(t, "gds.*,apoc.*", get(env, unrestricted), "GDS allowlist must not be clobbered by APOC")
-	assert.Equal(t, "gds.*,apoc.*", get(env, envName("dbms.security.procedures.allowlist")))
-	assert.Equal(t, 1, count(env, unrestricted), "exactly one env var per key (no duplicates)")
+	assert.Equal(t, "gds.*,apoc.*", envValue(env, unrestricted), "GDS allowlist must not be clobbered by APOC")
+	assert.Equal(t, "gds.*,apoc.*", envValue(env, allowlist))
+	assert.Equal(t, 1, envCount(env, unrestricted), "exactly one env var per key")
 
-	// Idempotent: re-applying GDS changes nothing.
-	before := get(env, unrestricted)
+	// Idempotent.
+	before := envValue(env, unrestricted)
 	env = mergePluginSecurityEnv(env, map[string]string{"dbms.security.procedures.unrestricted": "gds.*"})
-	assert.Equal(t, before, get(env, unrestricted))
+	assert.Equal(t, before, envValue(env, unrestricted))
 
-	// Scalar (non-additive) key is overwritten in place, not unioned.
+	// Scalar key overwritten in place.
+	scalar := resources.Neo4jSettingEnvVarName("apoc.export.file.enabled")
 	env = mergePluginSecurityEnv(env, map[string]string{"apoc.export.file.enabled": "true"})
 	env = mergePluginSecurityEnv(env, map[string]string{"apoc.export.file.enabled": "false"})
-	assert.Equal(t, "false", get(env, envName("apoc.export.file.enabled")))
+	assert.Equal(t, "false", envValue(env, scalar))
+}
+
+// removePluginSecurityEnv must subtract only the uninstalled plugin's tokens,
+// keep other plugins' tokens, and drop the env var when nothing remains.
+func TestRemovePluginSecurityEnv_PrunesOnUninstall(t *testing.T) {
+	unrestricted := resources.Neo4jSettingEnvVarName("dbms.security.procedures.unrestricted")
+
+	// GDS + APOC installed.
+	env := mergePluginSecurityEnv(nil, map[string]string{"dbms.security.procedures.unrestricted": "gds.*"})
+	env = mergePluginSecurityEnv(env, map[string]string{"dbms.security.procedures.unrestricted": "apoc.*"})
+	assert.Equal(t, "gds.*,apoc.*", envValue(env, unrestricted))
+
+	// Uninstall APOC → only gds.* remains (GDS not lost).
+	env = removePluginSecurityEnv(env, map[string]string{"dbms.security.procedures.unrestricted": "apoc.*"})
+	assert.Equal(t, "gds.*", envValue(env, unrestricted))
+
+	// Uninstall GDS → env var dropped entirely.
+	env = removePluginSecurityEnv(env, map[string]string{"dbms.security.procedures.unrestricted": "gds.*"})
+	assert.Equal(t, 0, envCount(env, unrestricted), "env var removed when no tokens remain")
 }

--- a/internal/controller/plugin_security_env_test.go
+++ b/internal/controller/plugin_security_env_test.go
@@ -1,0 +1,60 @@
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// mergePluginSecurityEnv must UNION additive allowlists across plugins so one
+// plugin's procedures aren't silently lost when another plugin reconciles
+// (e.g. GDS then APOC). Scalar keys are set in place. Idempotent.
+func TestMergePluginSecurityEnv_UnionsAllowlistsAcrossPlugins(t *testing.T) {
+	envName := func(k string) string {
+		return "NEO4J_" + strings.ToUpper(strings.ReplaceAll(k, ".", "_"))
+	}
+	get := func(env []corev1.EnvVar, name string) string {
+		for _, e := range env {
+			if e.Name == name {
+				return e.Value
+			}
+		}
+		return ""
+	}
+	count := func(env []corev1.EnvVar, name string) int {
+		n := 0
+		for _, e := range env {
+			if e.Name == name {
+				n++
+			}
+		}
+		return n
+	}
+
+	// GDS reconcile, then APOC reconcile.
+	env := mergePluginSecurityEnv(nil, map[string]string{
+		"dbms.security.procedures.unrestricted": "gds.*",
+		"dbms.security.procedures.allowlist":    "gds.*",
+	})
+	env = mergePluginSecurityEnv(env, map[string]string{
+		"dbms.security.procedures.unrestricted": "apoc.*",
+		"dbms.security.procedures.allowlist":    "apoc.*",
+	})
+
+	unrestricted := envName("dbms.security.procedures.unrestricted")
+	assert.Equal(t, "gds.*,apoc.*", get(env, unrestricted), "GDS allowlist must not be clobbered by APOC")
+	assert.Equal(t, "gds.*,apoc.*", get(env, envName("dbms.security.procedures.allowlist")))
+	assert.Equal(t, 1, count(env, unrestricted), "exactly one env var per key (no duplicates)")
+
+	// Idempotent: re-applying GDS changes nothing.
+	before := get(env, unrestricted)
+	env = mergePluginSecurityEnv(env, map[string]string{"dbms.security.procedures.unrestricted": "gds.*"})
+	assert.Equal(t, before, get(env, unrestricted))
+
+	// Scalar (non-additive) key is overwritten in place, not unioned.
+	env = mergePluginSecurityEnv(env, map[string]string{"apoc.export.file.enabled": "true"})
+	env = mergePluginSecurityEnv(env, map[string]string{"apoc.export.file.enabled": "false"})
+	assert.Equal(t, "false", get(env, envName("apoc.export.file.enabled")))
+}

--- a/internal/controller/plugin_security_env_test.go
+++ b/internal/controller/plugin_security_env_test.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
 	"github.com/neo4j-partners/neo4j-kubernetes-operator/internal/resources"
 )
 
@@ -78,4 +80,39 @@ func TestRemovePluginSecurityEnv_PrunesOnUninstall(t *testing.T) {
 	// Uninstall GDS → env var dropped entirely.
 	env = removePluginSecurityEnv(env, map[string]string{"dbms.security.procedures.unrestricted": "gds.*"})
 	assert.Equal(t, 0, envCount(env, unrestricted), "env var removed when no tokens remain")
+}
+
+// TestPluginSecurityRemovalSettings_PrunesAccumulatedDefaults reproduces the
+// orphaned-automatic-defaults trace: a GDS plugin is installed with no
+// spec.security (automatic gds.*,apoc.load.* land in env), the user later adds a
+// narrower allowedProcedures override (which the merge path UNIONS in), then
+// uninstalls. The removal set must subtract BOTH the automatic defaults and the
+// current override so nothing is left behind — pluginSecuritySettings alone would
+// only know the current override and orphan gds.*,apoc.load.*.
+func TestPluginSecurityRemovalSettings_PrunesAccumulatedDefaults(t *testing.T) {
+	unrestricted := resources.Neo4jSettingEnvVarName("dbms.security.procedures.unrestricted")
+	allowlist := resources.Neo4jSettingEnvVarName("dbms.security.procedures.allowlist")
+	r := newPluginTestReconciler(t)
+
+	gds := &neo4jv1beta1.Neo4jPlugin{
+		ObjectMeta: metav1.ObjectMeta{Name: "gds", Namespace: "default"},
+		Spec:       neo4jv1beta1.Neo4jPluginSpec{ClusterRef: "c1", Name: "graph-data-science", Version: "2.13.0"},
+	}
+
+	// 1. Install with no spec.security → automatic defaults unioned into env.
+	env := mergePluginSecurityEnv(nil, r.pluginSecuritySettings(gds))
+	assert.Equal(t, "gds.*,apoc.load.*", envValue(env, unrestricted))
+
+	// 2. User adds a narrower override; merge UNIONS it (so env now carries both
+	//    the automatic defaults AND the custom list).
+	gds.Spec.Security = &neo4jv1beta1.PluginSecurity{AllowedProcedures: []string{"gds.graph.*"}}
+	env = mergePluginSecurityEnv(env, r.pluginSecuritySettings(gds))
+	assert.Equal(t, "gds.*,apoc.load.*,gds.graph.*", envValue(env, unrestricted))
+	assert.Equal(t, "gds.graph.*", envValue(env, allowlist))
+
+	// 3. Uninstall via the removal set: every token this plugin ever contributed
+	//    must go — automatic defaults included — so the vars drop entirely.
+	env = removePluginSecurityEnv(env, r.pluginSecurityRemovalSettings(gds))
+	assert.Equal(t, 0, envCount(env, unrestricted), "automatic defaults must not be orphaned on uninstall")
+	assert.Equal(t, 0, envCount(env, allowlist), "override allowlist must be pruned on uninstall")
 }

--- a/internal/resources/cluster.go
+++ b/internal/resources/cluster.go
@@ -1753,7 +1753,21 @@ server.metrics.csv.enabled=false
 var additiveConfKeys = map[string]bool{
 	"dbms.security.procedures.unrestricted": true,
 	"dbms.security.procedures.allowlist":    true,
+	"dbms.security.procedures.denylist":     true,
+	"dbms.security.http_auth_allowlist":     true,
+	"server.unmanaged_extension_classes":    true,
 }
+
+// IsAdditiveConfKey reports whether a neo4j.conf setting is an additive,
+// comma-separated list (e.g. dbms.security.procedures.unrestricted) whose values
+// from multiple sources (operator, user, several plugins) must be unioned rather
+// than overwritten — overwriting silently drops the other sources' entries.
+func IsAdditiveConfKey(key string) bool { return additiveConfKeys[key] }
+
+// MergeConfListValues returns the comma-separated union of two list values,
+// de-duplicated and in first-seen order (a's tokens first, then b's new tokens).
+// Used for additive keys both in neo4j.conf and in NEO4J_*-style env vars.
+func MergeConfListValues(a, b string) string { return unionCSV(a, b) }
 
 // DedupeNeo4jConf collapses duplicate setting keys in a rendered neo4j.conf so
 // the same key is never declared twice. The operator assembles the conf from

--- a/internal/resources/cluster.go
+++ b/internal/resources/cluster.go
@@ -1758,6 +1758,19 @@ var additiveConfKeys = map[string]bool{
 	"server.unmanaged_extension_classes":    true,
 }
 
+// Neo4jSettingEnvVarName converts a neo4j.conf setting key to its Neo4j Docker
+// environment-variable form: the NEO4J_ prefix, a literal '_' doubled to '__',
+// then '.' replaced with '_', with case preserved. E.g.
+// dbms.security.procedures.unrestricted -> NEO4J_dbms_security_procedures_unrestricted
+// and dbms.security.http_auth_allowlist  -> NEO4J_dbms_security_http__auth__allowlist.
+// The Neo4j entrypoint reverses this ('__' -> '_', then '_' -> '.'), so the casing
+// and underscore escaping both matter — an upper-cased name maps to an invalid
+// (upper-cased) setting and is silently ignored. Matches the convention the
+// operator already uses for the LDAP system-account env vars.
+func Neo4jSettingEnvVarName(key string) string {
+	return "NEO4J_" + strings.ReplaceAll(strings.ReplaceAll(key, "_", "__"), ".", "_")
+}
+
 // IsAdditiveConfKey reports whether a neo4j.conf setting is an additive,
 // comma-separated list (e.g. dbms.security.procedures.unrestricted) whose values
 // from multiple sources (operator, user, several plugins) must be unioned rather

--- a/internal/resources/cluster.go
+++ b/internal/resources/cluster.go
@@ -1742,7 +1742,98 @@ server.metrics.csv.enabled=false
 		}
 	}
 
-	return config
+	return DedupeNeo4jConf(config)
+}
+
+// Additive list keys: the operator emits these for plugins (GDS/Bloom/APOC) and
+// Aura Fleet Management, and the user may also set them in spec.config. A plain
+// last-wins dedupe would DROP the operator's contribution (e.g. Aura's
+// fleetManagement.* lost when the user sets gds.*,apoc.*), so DedupeNeo4jConf
+// MERGES all occurrences into the union of their comma-separated tokens instead.
+var additiveConfKeys = map[string]bool{
+	"dbms.security.procedures.unrestricted": true,
+	"dbms.security.procedures.allowlist":    true,
+}
+
+// DedupeNeo4jConf collapses duplicate setting keys in a rendered neo4j.conf so
+// the same key is never declared twice. The operator assembles the conf from
+// several sections (base → monitoring → audit → auth → user spec.config), and a
+// key emitted by more than one section (classically db.logs.query.enabled /
+// db.logs.query.threshold, from monitoring AND user spec.config) would appear
+// twice. Neo4j 5.26 tolerated that (last wins); CalVer (2025.x+) FAILS to start
+// with "<key> declared multiple times".
+//
+// Resolution rules (so operator-set config is never silently lost):
+//   - Scalar keys: keep the LAST occurrence — matching the documented precedence
+//     (audit over monitoring; user spec.config over operator defaults) and the
+//     old 5.26 last-wins behavior. An operator key with no user duplicate is
+//     never dropped (it has no later occurrence).
+//   - Additive list keys (additiveConfKeys): MERGE the union of all occurrences'
+//     tokens, so the operator's allowlist isn't lost to a user override.
+//   - server.jvm.additional / dbms.jvm.additional: left untouched — Neo4j
+//     intentionally accepts repeated occurrences and concatenates them.
+//
+// Comment and blank lines are preserved in place.
+func DedupeNeo4jConf(conf string) string {
+	lines := strings.Split(conf, "\n")
+
+	settingKV := func(line string) (key, value string, ok bool) {
+		t := strings.TrimSpace(line)
+		if t == "" || strings.HasPrefix(t, "#") {
+			return "", "", false
+		}
+		eq := strings.IndexByte(t, '=')
+		if eq <= 0 {
+			return "", "", false
+		}
+		k := strings.TrimSpace(t[:eq])
+		if k == "server.jvm.additional" || k == "dbms.jvm.additional" {
+			return "", "", false // repeatable — never dedupe
+		}
+		return k, strings.TrimSpace(t[eq+1:]), true
+	}
+
+	lastIdx := make(map[string]int)
+	mergedTokens := make(map[string][]string)
+	seenToken := make(map[string]map[string]bool)
+	for i, line := range lines {
+		k, v, ok := settingKV(line)
+		if !ok {
+			continue
+		}
+		lastIdx[k] = i
+		if additiveConfKeys[k] {
+			if seenToken[k] == nil {
+				seenToken[k] = map[string]bool{}
+			}
+			for _, tok := range strings.Split(v, ",") {
+				tok = strings.TrimSpace(tok)
+				if tok == "" || seenToken[k][tok] {
+					continue
+				}
+				seenToken[k][tok] = true
+				mergedTokens[k] = append(mergedTokens[k], tok)
+			}
+		}
+	}
+
+	out := lines[:0:0]
+	for i, line := range lines {
+		k, _, ok := settingKV(line)
+		if !ok {
+			out = append(out, line)
+			continue
+		}
+		if lastIdx[k] != i {
+			continue // earlier occurrence of a key resolved later — drop it
+		}
+		if additiveConfKeys[k] {
+			out = append(out, fmt.Sprintf("%s=%s", k, strings.Join(mergedTokens[k], ",")))
+		} else {
+			out = append(out, line)
+		}
+	}
+	return strings.Join(out, "\n")
 }
 
 // BuildMonitoringConfig generates Neo4j config lines for monitoring, metrics exposure, and query logging.

--- a/internal/resources/cluster.go
+++ b/internal/resources/cluster.go
@@ -1836,6 +1836,88 @@ func DedupeNeo4jConf(conf string) string {
 	return strings.Join(out, "\n")
 }
 
+// UpsertNeo4jConfSettings merges externally-provided settings (e.g. a
+// Neo4jPlugin's required security settings) into an already-rendered neo4j.conf
+// WITHOUT creating duplicate keys — CalVer Neo4j refuses to start on a duplicate
+// declaration. It is idempotent (re-applying the same settings yields identical
+// output) so it doesn't churn the ConfigMap:
+//
+//   - Additive list keys (additiveConfKeys, e.g. dbms.security.procedures.*):
+//     the setting's tokens are unioned into the existing line in place, so the
+//     operator/user allowlist is preserved and the plugin's entries are added;
+//     appended if the key is absent.
+//   - Other (scalar) keys: added only if absent, so an operator/user value is
+//     never clobbered (matching the plugin path's "add if not present" intent).
+//
+// Keys are processed in sorted order for deterministic output.
+func UpsertNeo4jConfSettings(conf string, settings map[string]string) string {
+	if len(settings) == 0 {
+		return conf
+	}
+	lines := strings.Split(conf, "\n")
+
+	keyIdx := make(map[string]int)
+	keyVal := make(map[string]string)
+	for i, line := range lines {
+		t := strings.TrimSpace(line)
+		if t == "" || strings.HasPrefix(t, "#") {
+			continue
+		}
+		eq := strings.IndexByte(t, '=')
+		if eq <= 0 {
+			continue
+		}
+		k := strings.TrimSpace(t[:eq])
+		if k == "server.jvm.additional" || k == "dbms.jvm.additional" {
+			continue // repeatable — leave untouched
+		}
+		keyIdx[k] = i
+		keyVal[k] = strings.TrimSpace(t[eq+1:])
+	}
+
+	keys := make([]string, 0, len(settings))
+	for k := range settings {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		v := settings[k]
+		idx, present := keyIdx[k]
+		switch {
+		case additiveConfKeys[k] && present:
+			merged := unionCSV(keyVal[k], v)
+			lines[idx] = fmt.Sprintf("%s=%s", k, merged)
+			keyVal[k] = merged
+		case !present:
+			lines = append(lines, fmt.Sprintf("%s=%s", k, v))
+			keyIdx[k] = len(lines) - 1
+			keyVal[k] = v
+		default:
+			// scalar key already present — preserve the existing value
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// unionCSV returns the comma-separated union of a and b, de-duplicated and in
+// first-seen order (a's tokens first, then b's new tokens).
+func unionCSV(a, b string) string {
+	seen := make(map[string]bool)
+	var toks []string
+	for _, s := range []string{a, b} {
+		for _, tok := range strings.Split(s, ",") {
+			tok = strings.TrimSpace(tok)
+			if tok == "" || seen[tok] {
+				continue
+			}
+			seen[tok] = true
+			toks = append(toks, tok)
+		}
+	}
+	return strings.Join(toks, ",")
+}
+
 // BuildMonitoringConfig generates Neo4j config lines for monitoring, metrics exposure, and query logging.
 func BuildMonitoringConfig(mon *neo4jv1beta1.MonitoringSpec) string {
 	slowThreshold := "5s"

--- a/internal/resources/cluster_startup_test.go
+++ b/internal/resources/cluster_startup_test.go
@@ -2,6 +2,7 @@ package resources_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -365,4 +366,95 @@ func TestBuildConfigMapForEnterprise_HealthScript(t *testing.T) {
 		"health script should handle cluster formation waiting period")
 	assert.Contains(t, healthScript, "cluster formation barrier",
 		"health script should recognize cluster formation barrier logs")
+}
+
+// duplicateConfKeys returns any neo4j.conf key declared more than once. CalVer
+// Neo4j (2025.x+) treats a repeated key as fatal ("<key> declared multiple
+// times") and refuses to start. server.jvm.additional / dbms.jvm.additional are
+// legitimately repeatable and excluded.
+func duplicateConfKeys(conf string) []string {
+	counts := map[string]int{}
+	for _, line := range strings.Split(conf, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		eq := strings.IndexByte(line, '=')
+		if eq < 0 {
+			continue
+		}
+		key := strings.TrimSpace(line[:eq])
+		if key == "server.jvm.additional" || key == "dbms.jvm.additional" {
+			continue
+		}
+		counts[key]++
+	}
+	var dups []string
+	for k, n := range counts {
+		if n > 1 {
+			dups = append(dups, k)
+		}
+	}
+	return dups
+}
+
+// TestBuildConfigMapForEnterprise_NoDuplicateKeys is the cluster counterpart to
+// the standalone invariant: across realistic config layerings (monitoring +
+// audit + auth + user spec.config overrides on shared keys), the static rendered
+// neo4j.conf must never declare a key twice, or CalVer Neo4j refuses to boot.
+// (Discovery/advertised-address keys are appended at runtime by startup.sh and
+// are out of scope here — this guards the static ConfigMap surface.)
+func TestBuildConfigMapForEnterprise_NoDuplicateKeys(t *testing.T) {
+	calver := neo4jv1beta1.ImageSpec{Repo: "neo4j", Tag: "2026.04-enterprise"}
+	obfuscate := true
+	param := true
+
+	cases := []struct {
+		name string
+		spec neo4jv1beta1.Neo4jEnterpriseClusterSpec
+	}{
+		{
+			name: "minimal",
+			spec: neo4jv1beta1.Neo4jEnterpriseClusterSpec{
+				Image:    calver,
+				Topology: neo4jv1beta1.TopologyConfiguration{Servers: 3},
+			},
+		},
+		{
+			name: "monitoring + audit (both touch db.logs.query.obfuscate_literals)",
+			spec: neo4jv1beta1.Neo4jEnterpriseClusterSpec{
+				Image:      calver,
+				Topology:   neo4jv1beta1.TopologyConfiguration{Servers: 3},
+				Monitoring: &neo4jv1beta1.MonitoringSpec{Enabled: true, SlowQueryThreshold: "5s", QueryLogLevel: "INFO"},
+				Audit:      &neo4jv1beta1.AuditSpec{Enabled: true, ObfuscateQueryLiterals: &obfuscate, ParameterLogging: &param},
+			},
+		},
+		{
+			name: "monitoring + audit + user overrides on shared keys",
+			spec: neo4jv1beta1.Neo4jEnterpriseClusterSpec{
+				Image:      calver,
+				Topology:   neo4jv1beta1.TopologyConfiguration{Servers: 3},
+				Monitoring: &neo4jv1beta1.MonitoringSpec{Enabled: true, SlowQueryThreshold: "5s", QueryLogLevel: "VERBOSE"},
+				Audit:      &neo4jv1beta1.AuditSpec{Enabled: true},
+				Config: map[string]string{
+					"db.logs.query.enabled":            "true",
+					"db.logs.query.threshold":          "1s",
+					"db.logs.query.obfuscate_literals": "true",
+					"server.memory.heap.max_size":      "2G",
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cluster := &neo4jv1beta1.Neo4jEnterpriseCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: "default"},
+				Spec:       tc.spec,
+			}
+			conf := resources.BuildConfigMapForEnterprise(cluster).Data["neo4j.conf"]
+			assert.Empty(t, duplicateConfKeys(conf),
+				"rendered neo4j.conf must not declare any key twice (CalVer Neo4j fails to start otherwise)")
+		})
+	}
 }

--- a/internal/resources/cluster_test.go
+++ b/internal/resources/cluster_test.go
@@ -16,6 +16,60 @@ import (
 	"github.com/neo4j-partners/neo4j-kubernetes-operator/internal/resources"
 )
 
+func TestDedupeNeo4jConf(t *testing.T) {
+	in := strings.Join([]string{
+		"# Query Monitoring",
+		"db.logs.query.enabled=true",
+		"db.logs.query.threshold=5s", // from monitoring
+		"",
+		"server.jvm.additional=-Done=1",
+		"server.jvm.additional=-Dtwo=2", // repeatable — must survive
+		"# user spec.config",
+		"db.logs.query.threshold=1s", // user override (appended last)
+		"db.logs.query.enabled=true",
+	}, "\n")
+
+	out := resources.DedupeNeo4jConf(in)
+
+	// Each non-repeatable key appears exactly once, with the LAST (user) value.
+	assert.Equal(t, 1, strings.Count(out, "db.logs.query.threshold="), "threshold must be de-duplicated")
+	assert.Contains(t, out, "db.logs.query.threshold=1s", "last (user) value wins")
+	assert.NotContains(t, out, "db.logs.query.threshold=5s", "earlier monitoring value dropped")
+	assert.Equal(t, 1, strings.Count(out, "db.logs.query.enabled="))
+	// Repeatable JVM key keeps every occurrence.
+	assert.Equal(t, 2, strings.Count(out, "server.jvm.additional="))
+	// Comments/blank lines preserved.
+	assert.Contains(t, out, "# Query Monitoring")
+	assert.Contains(t, out, "# user spec.config")
+}
+
+func TestDedupeNeo4jConf_NoDuplicatesUnchanged(t *testing.T) {
+	in := "# c\nserver.bolt.listen_address=0.0.0.0:7687\ndb.logs.query.enabled=true\n"
+	assert.Equal(t, in, resources.DedupeNeo4jConf(in))
+}
+
+// Additive list keys must MERGE, not last-wins, so operator-set procedure
+// allowlists (plugins / Aura Fleet Management) aren't lost to a user override.
+func TestDedupeNeo4jConf_MergesAdditiveKeys(t *testing.T) {
+	in := strings.Join([]string{
+		"dbms.security.procedures.unrestricted=fleetManagement.*", // operator (Aura)
+		"dbms.security.procedures.allowlist=fleetManagement.*",
+		"dbms.security.procedures.unrestricted=gds.*,apoc.*", // user spec.config
+		"dbms.security.procedures.allowlist=gds.*,apoc.*",
+	}, "\n")
+
+	out := resources.DedupeNeo4jConf(in)
+
+	assert.Equal(t, 1, strings.Count(out, "dbms.security.procedures.unrestricted="), "declared once")
+	assert.Equal(t, 1, strings.Count(out, "dbms.security.procedures.allowlist="), "declared once")
+	// Union of operator + user — nothing lost.
+	for _, want := range []string{"fleetManagement.*", "gds.*", "apoc.*"} {
+		assert.Contains(t, out, want)
+	}
+	// Deterministic union order (operator tokens first, then user).
+	assert.Contains(t, out, "dbms.security.procedures.unrestricted=fleetManagement.*,gds.*,apoc.*")
+}
+
 func TestStorageClassNamePtr(t *testing.T) {
 	assert.Nil(t, resources.StorageClassNamePtr(""),
 		"empty className must map to nil so the PVC inherits the cluster default StorageClass")

--- a/internal/resources/cluster_test.go
+++ b/internal/resources/cluster_test.go
@@ -70,6 +70,18 @@ func TestDedupeNeo4jConf_MergesAdditiveKeys(t *testing.T) {
 	assert.Contains(t, out, "dbms.security.procedures.unrestricted=fleetManagement.*,gds.*,apoc.*")
 }
 
+func TestNeo4jSettingEnvVarName(t *testing.T) {
+	// Dots -> underscores, case preserved (NOT upper-cased).
+	assert.Equal(t, "NEO4J_dbms_security_procedures_unrestricted",
+		resources.Neo4jSettingEnvVarName("dbms.security.procedures.unrestricted"))
+	// Literal underscores must be doubled so Neo4j's entrypoint maps them back
+	// to a single underscore rather than a dot.
+	assert.Equal(t, "NEO4J_dbms_security_http__auth__allowlist",
+		resources.Neo4jSettingEnvVarName("dbms.security.http_auth_allowlist"))
+	assert.Equal(t, "NEO4J_server_unmanaged__extension__classes",
+		resources.Neo4jSettingEnvVarName("server.unmanaged_extension_classes"))
+}
+
 func TestUpsertNeo4jConfSettings(t *testing.T) {
 	conf := strings.Join([]string{
 		"# base",

--- a/internal/resources/cluster_test.go
+++ b/internal/resources/cluster_test.go
@@ -70,6 +70,37 @@ func TestDedupeNeo4jConf_MergesAdditiveKeys(t *testing.T) {
 	assert.Contains(t, out, "dbms.security.procedures.unrestricted=fleetManagement.*,gds.*,apoc.*")
 }
 
+func TestUpsertNeo4jConfSettings(t *testing.T) {
+	conf := strings.Join([]string{
+		"# base",
+		"server.bolt.listen_address=:7687",
+		"dbms.security.procedures.unrestricted=gds.*", // operator/user already set
+	}, "\n")
+
+	// Plugin (e.g. APOC) needs apoc.* unrestricted + a scalar setting.
+	out := resources.UpsertNeo4jConfSettings(conf, map[string]string{
+		"dbms.security.procedures.unrestricted": "apoc.*",
+		"apoc.export.file.enabled":              "true",
+	})
+
+	// Additive key is MERGED in place — no duplicate, nothing lost.
+	assert.Equal(t, 1, strings.Count(out, "dbms.security.procedures.unrestricted="))
+	assert.Contains(t, out, "dbms.security.procedures.unrestricted=gds.*,apoc.*")
+	// New scalar key appended.
+	assert.Contains(t, out, "apoc.export.file.enabled=true")
+
+	// Idempotent: re-applying the same settings yields identical output (no churn).
+	assert.Equal(t, out, resources.UpsertNeo4jConfSettings(out, map[string]string{
+		"dbms.security.procedures.unrestricted": "apoc.*",
+		"apoc.export.file.enabled":              "true",
+	}))
+
+	// Scalar key already present is NOT clobbered.
+	out2 := resources.UpsertNeo4jConfSettings(conf, map[string]string{"server.bolt.listen_address": ":9999"})
+	assert.Contains(t, out2, "server.bolt.listen_address=:7687")
+	assert.NotContains(t, out2, ":9999")
+}
+
 func TestStorageClassNamePtr(t *testing.T) {
 	assert.Nil(t, resources.StorageClassNamePtr(""),
 		"empty className must map to nil so the PVC inherits the cluster default StorageClass")

--- a/internal/validation/cluster_validator.go
+++ b/internal/validation/cluster_validator.go
@@ -44,6 +44,7 @@ type ClusterValidator struct {
 	upgradeValidator  *UpgradeValidator
 	memoryValidator   *MemoryValidator
 	resourceValidator *ResourceValidator
+	configValidator   *ConfigValidator
 }
 
 // NewClusterValidator creates a new cluster validator
@@ -59,6 +60,7 @@ func NewClusterValidator(client client.Client) *ClusterValidator {
 		upgradeValidator:  NewUpgradeValidator(),
 		memoryValidator:   NewMemoryValidator(),
 		resourceValidator: NewResourceValidator(client),
+		configValidator:   NewConfigValidator(),
 	}
 }
 
@@ -170,6 +172,12 @@ func (v *ClusterValidator) validateCluster(ctx context.Context, cluster *neo4jv1
 	allErrs = append(allErrs, v.storageValidator.Validate(cluster)...)
 	allErrs = append(allErrs, v.tlsValidator.Validate(cluster)...)
 	allErrs = append(allErrs, v.authValidator.Validate(cluster)...)
+
+	// spec.config validation — rejects deprecated keys, operator-managed
+	// discovery/SSL keys, and per-pod runtime-managed keys (advertised
+	// addresses, topology) that would collide with the operator's own
+	// startup-appended values. Previously this validator was never wired in.
+	allErrs = append(allErrs, v.configValidator.Validate(cluster)...)
 
 	// Property sharding validation (version requirements)
 	allErrs = append(allErrs, v.validatePropertySharding(cluster)...)

--- a/internal/validation/cluster_validator_test.go
+++ b/internal/validation/cluster_validator_test.go
@@ -29,6 +29,46 @@ import (
 	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
 )
 
+// TestClusterValidator_WiresConfigValidation proves ConfigValidator actually
+// runs as part of the cluster validation flow the reconciler uses
+// (ValidateCreate → validateCluster). Regression for the wiring gap where
+// ConfigValidator existed but was never invoked, so its rejections (discovery,
+// SSL, deprecated, and the runtime-managed advertised/topology keys) silently
+// did nothing in production.
+func TestClusterValidator_WiresConfigValidation(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	validator := NewClusterValidator(fake.NewClientBuilder().WithScheme(scheme).Build())
+
+	base := func() *neo4jv1beta1.Neo4jEnterpriseCluster {
+		return &neo4jv1beta1.Neo4jEnterpriseCluster{
+			Spec: neo4jv1beta1.Neo4jEnterpriseClusterSpec{
+				Image:    neo4jv1beta1.ImageSpec{Repo: "neo4j", Tag: "5.26.0", PullPolicy: "IfNotPresent"},
+				Storage:  neo4jv1beta1.StorageSpec{ClassName: "fast-ssd", Size: "100Gi"},
+				Topology: neo4jv1beta1.TopologyConfiguration{Servers: 3},
+			},
+		}
+	}
+
+	// Sanity: base cluster is valid, so a rejection below is attributable to config.
+	if err := validator.ValidateCreate(context.Background(), base()); err != nil {
+		t.Fatalf("base cluster should validate, got: %v", err)
+	}
+
+	// Each of these is rejected only if ConfigValidator runs.
+	for _, key := range []string{
+		"server.cluster.advertised_address", // runtime-managed (per-pod FQDN)
+		"dbms.cluster.endpoints",            // operator-managed discovery
+		"dbms.ssl.policy.bolt.client_auth",  // operator-managed SSL
+	} {
+		c := base()
+		c.Spec.Config = map[string]string{key: "x"}
+		if err := validator.ValidateCreate(context.Background(), c); err == nil {
+			t.Errorf("ValidateCreate accepted spec.config[%q]; ConfigValidator not wired?", key)
+		}
+	}
+}
+
 func TestClusterValidator_ValidateCreate(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = clientgoscheme.AddToScheme(scheme)

--- a/internal/validation/config_validator.go
+++ b/internal/validation/config_validator.go
@@ -67,6 +67,22 @@ func (v *ConfigValidator) Validate(cluster *neo4jv1beta1.Neo4jEnterpriseCluster)
 		"dbms.kubernetes.discovery.service_port_name": "Kubernetes service-list discovery is not used; operator uses LIST discovery with pod FQDNs",
 	}
 
+	// Per-pod / topology values the operator writes into neo4j.conf at startup
+	// (advertised addresses use each pod's FQDN; mode constraint and the initial
+	// primaries count come from spec.topology). A user value in spec.config would
+	// be appended to the static conf and then DECLARED AGAIN at runtime → CalVer
+	// Neo4j refuses to start with "<key> declared multiple times". The static-conf
+	// de-duplication can't catch this because the second declaration is appended
+	// at pod startup, so reject these at apply time.
+	operatorRuntimeManagedSettings := map[string]string{
+		"server.default_advertised_address":                   "advertised addresses are set per-pod (FQDN) by the operator at runtime — do not set in spec.config",
+		"server.cluster.advertised_address":                   "advertised addresses are set per-pod (FQDN) by the operator at runtime — do not set in spec.config",
+		"server.routing.advertised_address":                   "advertised addresses are set per-pod (FQDN) by the operator at runtime — do not set in spec.config",
+		"server.cluster.raft.advertised_address":              "advertised addresses are set per-pod (FQDN) by the operator at runtime — do not set in spec.config",
+		"initial.server.mode_constraint":                      "use spec.topology.serverModeConstraint / serverRoles — the operator sets initial.server.mode_constraint at runtime",
+		"dbms.cluster.minimum_initial_system_primaries_count": "managed by the operator (derived from spec.topology) — do not override",
+	}
+
 	for configKey, configValue := range cluster.Spec.Config {
 		// Special handling for dbms.cluster.discovery.version.
 		// In 5.26.x this setting controls the discovery protocol (V1 vs V2); the operator
@@ -98,6 +114,16 @@ func (v *ConfigValidator) Validate(cluster *neo4jv1beta1.Neo4jEnterpriseCluster)
 			allErrs = append(allErrs, field.Forbidden(
 				configPath.Child(configKey),
 				"unsupported configuration: "+unsupportedMsg,
+			))
+		}
+
+		// Check for operator runtime-managed settings (advertised addresses,
+		// topology). These would collide at startup with the operator's own
+		// runtime-appended declaration.
+		if runtimeMsg, isManaged := operatorRuntimeManagedSettings[configKey]; isManaged {
+			allErrs = append(allErrs, field.Forbidden(
+				configPath.Child(configKey),
+				"operator-managed configuration: "+runtimeMsg,
 			))
 		}
 

--- a/internal/validation/config_validator_test.go
+++ b/internal/validation/config_validator_test.go
@@ -215,6 +215,42 @@ func TestConfigValidator_RejectsManagedSSLKeys(t *testing.T) {
 	}
 }
 
+func TestConfigValidator_RejectsRuntimeManagedKeys(t *testing.T) {
+	validator := NewConfigValidator()
+
+	// Keys the operator writes into neo4j.conf at pod startup (per-pod FQDN
+	// advertised addresses, topology). A user value collides at runtime →
+	// "declared multiple times" on CalVer, which the static-conf de-dup can't
+	// catch — so reject at apply time.
+	keys := []string{
+		"server.default_advertised_address",
+		"server.cluster.advertised_address",
+		"server.routing.advertised_address",
+		"server.cluster.raft.advertised_address",
+		"initial.server.mode_constraint",
+		"dbms.cluster.minimum_initial_system_primaries_count",
+	}
+
+	for _, key := range keys {
+		t.Run(key, func(t *testing.T) {
+			cluster := &neo4jv1beta1.Neo4jEnterpriseCluster{
+				Spec: neo4jv1beta1.Neo4jEnterpriseClusterSpec{
+					Config: map[string]string{key: "some-value"},
+				},
+			}
+			errors := validator.Validate(cluster)
+			found := false
+			for _, err := range errors {
+				if err.Type == field.ErrorTypeForbidden && err.Field == "spec.config."+key {
+					found = true
+					break
+				}
+			}
+			assert.True(t, found, "expected %s to be Forbidden — got %v", key, errors)
+		})
+	}
+}
+
 func TestConfigValidator_DeprecatedKeys(t *testing.T) {
 	validator := NewConfigValidator()
 

--- a/test/integration/cluster_lifecycle_test.go
+++ b/test/integration/cluster_lifecycle_test.go
@@ -176,27 +176,26 @@ var _ = Describe("Cluster Lifecycle Integration Tests", func() {
 
 			By("Waiting for initial cluster to be Ready before scaling")
 			// Wait for cluster to form properly before attempting to scale
-			Eventually(func() bool {
+			Eventually(func() error {
+				// Fail fast: a crash-looping server pod never recovers, so abort
+				// immediately with the fatal log instead of polling to timeout.
+				if err := crashLoopError(ctx, namespace.Name); err != nil {
+					return StopTrying("Neo4j server pod is crash-looping").Wrap(err)
+				}
 				err := k8sClient.Get(ctx, types.NamespacedName{
 					Name:      clusterName,
 					Namespace: namespace.Name,
 				}, cluster)
 				if err != nil {
-					GinkgoWriter.Printf("Failed to get cluster during initial formation: %v\n", err)
-					return false
+					return err
 				}
-
-				// Check if cluster phase is Ready
-				if cluster.Status.Phase == "Ready" {
-					GinkgoWriter.Printf("Initial cluster is ready. Phase: %s\n", cluster.Status.Phase)
-					return true
+				if cluster.Status.Phase != "Ready" {
+					return fmt.Errorf("waiting for initial cluster formation, phase=%s message=%q",
+						cluster.Status.Phase, cluster.Status.Message)
 				}
-
-				// Log current status for debugging
-				GinkgoWriter.Printf("Waiting for initial cluster formation. Phase: %s, Message: %s\n",
-					cluster.Status.Phase, cluster.Status.Message)
-				return false
-			}, clusterTimeout, interval).Should(BeTrue(), "Initial cluster should be Ready before scaling")
+				GinkgoWriter.Printf("Initial cluster is ready. Phase: %s\n", cluster.Status.Phase)
+				return nil
+			}, clusterTimeout, interval).Should(Succeed(), "Initial cluster should be Ready before scaling")
 
 			By("Scaling up servers")
 			// In CI, scale from 2 to 3; in local, scale from 3 to 5

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -302,6 +303,59 @@ func waitForOperatorReady() {
 	time.Sleep(2 * time.Second)
 
 	By("Operator is ready")
+}
+
+// crashLoopError returns a descriptive error — including the offending
+// container's recent log tail — if any pod in the namespace is in
+// CrashLoopBackOff, or has a container that already terminated with a non-zero
+// exit and restarted (e.g. Neo4j refusing to boot on a fatal neo4j.conf error
+// such as a duplicate key on CalVer). Returns nil when nothing is crash-looping.
+//
+// Readiness waits use this to FAIL FAST with a specific, actionable signal
+// instead of timing out after minutes with an opaque "not yet ready" — a
+// CrashLoopBackOff will never recover on its own, so polling it to the deadline
+// only delays and obscures the failure.
+func crashLoopError(ctx context.Context, namespace string) error {
+	podList := &corev1.PodList{}
+	if err := k8sClient.List(ctx, podList, client.InNamespace(namespace)); err != nil {
+		// Transient list failure — let the normal readiness poll handle it.
+		return nil
+	}
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		for _, cs := range pod.Status.ContainerStatuses {
+			w := cs.State.Waiting
+			crashLooping := w != nil && w.Reason == "CrashLoopBackOff"
+			fatalExit := cs.LastTerminationState.Terminated != nil &&
+				cs.LastTerminationState.Terminated.ExitCode != 0 &&
+				cs.RestartCount > 0
+			if !crashLooping && !fatalExit {
+				continue
+			}
+			return fmt.Errorf("pod %s/%s container %q is crash-looping (restarts=%d)\n--- log tail ---\n%s",
+				namespace, pod.Name, cs.Name, cs.RestartCount, podLogTail(ctx, namespace, pod.Name, cs.Name))
+		}
+	}
+	return nil
+}
+
+// podLogTail returns the last ~40 lines of a container's log, preferring the
+// previous (crashed) instance so the fatal startup line is visible. Best-effort.
+func podLogTail(ctx context.Context, namespace, pod, container string) string {
+	clientset, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return "(could not build clientset for logs)"
+	}
+	tail := int64(40)
+	for _, previous := range []bool{true, false} {
+		data, err := clientset.CoreV1().Pods(namespace).GetLogs(pod, &corev1.PodLogOptions{
+			Container: container, Previous: previous, TailLines: &tail,
+		}).DoRaw(ctx)
+		if err == nil && len(data) > 0 {
+			return string(data)
+		}
+	}
+	return "(no logs available)"
 }
 
 // cleanupTestNamespaces removes all test namespaces

--- a/test/integration/standalone_deployment_test.go
+++ b/test/integration/standalone_deployment_test.go
@@ -94,20 +94,24 @@ var _ = Describe("Neo4jEnterpriseStandalone Integration Tests", func() {
 			Expect(k8sClient.Create(ctx, standalone)).To(Succeed())
 
 			By("Waiting for standalone to become Ready")
-			Eventually(func() bool {
+			Eventually(func() error {
+				// Fail fast: a crash-looping Neo4j pod never recovers, so abort
+				// immediately with the fatal log instead of polling to timeout.
+				if err := crashLoopError(ctx, namespaceName); err != nil {
+					return StopTrying("Neo4j standalone pod is crash-looping").Wrap(err)
+				}
 				updated := &neo4jv1beta1.Neo4jEnterpriseStandalone{}
 				if err := k8sClient.Get(ctx, types.NamespacedName{
 					Name: standaloneName, Namespace: namespaceName,
 				}, updated); err != nil {
-					return false
+					return err
 				}
-				if updated.Status.Phase == "Ready" {
-					GinkgoWriter.Printf("Standalone is ready. Phase: %s\n", updated.Status.Phase)
-					return true
+				if updated.Status.Phase != "Ready" {
+					return fmt.Errorf("standalone not yet ready, phase=%s", updated.Status.Phase)
 				}
-				GinkgoWriter.Printf("Standalone not yet ready. Phase: %s\n", updated.Status.Phase)
-				return false
-			}, timeout, interval).Should(BeTrue())
+				GinkgoWriter.Printf("Standalone is ready. Phase: %s\n", updated.Status.Phase)
+				return nil
+			}, timeout, interval).Should(Succeed())
 		})
 
 		AfterAll(func() {


### PR DESCRIPTION
## Summary

**NEO3-16:** a standalone CrashLoopBackOffs on CalVer (2025.x+) because the rendered `/conf/neo4j.conf` declares a key twice (`db.logs.query.threshold` / `db.logs.query.enabled` from `monitoring` AND user `spec.config`). 5.26 tolerated duplicates (last-wins); CalVer fails with `"<key> declared multiple times"`.

Core fix: `resources.DedupeNeo4jConf`, applied to both the standalone ConfigMap and the cluster conf builder. Scalar keys keep the **last** occurrence (documented precedence preserved); **additive** list keys (`dbms.security.procedures.unrestricted`/`allowlist`) are **merged** so operator allowlists aren't lost; `server.jvm.additional` is left repeatable.

After a scrutiny of where duplicate keys can otherwise arise, this branch also closes three related gaps the static de-dup doesn't cover:

1. **Standalone + plugin** (was still a CalVer crash): the plugin controller appended conf settings guarded only by an exact-substring check → a plugin allowlist (`…unrestricted=apoc.*`) added as a second declaration when `…=gds.*` already existed. Replaced with `resources.UpsertNeo4jConfSettings` (unions additive keys in place, adds scalars only when absent, idempotent → no ConfigMap churn).
2. **Cluster runtime-managed keys**: the entrypoint writes per-pod `server.*.advertised_address`, `initial.server.mode_constraint`, `dbms.cluster.minimum_initial_system_primaries_count` at startup — *after* the static de-dup. The config validator now rejects these in `spec.config` at apply time.
3. **Determinism**: the standalone rendered `spec.config` unsorted (cluster sorts); the hash-compared ConfigMap could reorder between reconciles → spurious rolling restarts. Now sorted.

## Type of change
- [x] Bug fix

## Testing
- [x] `make test-unit` (resources/validation/controller unit tests) pass
- Unit: `DedupeNeo4jConf` (scalar last-wins, additive merge, no-op), `UpsertNeo4jConfSettings` (merge-in-place, add-if-absent, idempotent, no-clobber), standalone `createConfigMap` NEO3-16 collision, config-validator rejection of runtime-managed keys.
- Extended Integration Tests auto-run (touches the standalone controller).

Closes NEO3-16.

Note (not fixed here): the plugin controller patches a ConfigMap the standalone controller also rebuilds — an inherent two-controller tug-of-war, orthogonal to duplicate keys. Flagged for a separate change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core ConfigMap assembly, plugin env/conf merging, and cluster admission validation—incorrect dedupe or merge logic could change effective Neo4j settings or break multi-plugin security, though behavior is heavily unit-tested.
> 
> **Overview**
> Fixes **NEO3-16**: CalVer Neo4j (2025.x+) fails to start when `neo4j.conf` declares the same key twice (e.g. monitoring and `spec.config` both set `db.logs.query.*`), which previously caused standalone **CrashLoopBackOff**.
> 
> **Config rendering** adds `resources.DedupeNeo4jConf` on standalone and cluster ConfigMap builds: scalar keys keep the **last** value; additive procedure allowlists are **unioned**; `server.jvm.additional` stays repeatable. Standalone `spec.config` keys are **sorted** so ConfigMap content is stable across reconciles.
> 
> **Plugin path** stops appending conf lines behind substring checks and uses `UpsertNeo4jConfSettings` instead. Plugin security on StatefulSets goes through `mergePluginSecurityEnv` / `removePluginSecurityEnv` with correct `NEO4J_*` env naming (case preserved), including **prune on uninstall for all install modes** (PreBaked / VerifiedDownload).
> 
> **Cluster validation** wires in `ConfigValidator` and rejects runtime-managed keys in `spec.config` that would collide with startup-appended settings. Integration waits **fail fast** on crash-looping pods with log tails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 929eb56361e04bec78e88ce8b5ded2ebd5ebb534. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->