### PR TITLE
Update README by removing warning and support sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,6 @@ A Kubernetes operator for Neo4j Enterprise — declarative clusters, databases, 
 > [!TIP]
 > 📖 **Documentation site**: [neo4j-partners.github.io/neo4j-kubernetes-operator](https://neo4j-partners.github.io/neo4j-kubernetes-operator/) — searchable, versioned, with a release dropdown. Every link in this README also resolves on the docs site.
 
-> [!WARNING]
-> Development is LLM-driven, not merely LLM-assisted, so expect bugs — including subtle, non-obvious ones. **Independent validation is required before production use.** APIs may change between releases. Contributors are welcome — real-world usage is what will carry the project forward to an acceptable maturity level. Issues and PRs are handled best-effort via [GitHub Issues](https://github.com/neo4j-partners/neo4j-kubernetes-operator/issues).
-
 ## Requirements
 
 - **Neo4j**: Enterprise 5.26 LTS or any CalVer release (2025.x+)
@@ -93,7 +90,7 @@ Each has examples under [`examples/`](examples/) and a dedicated guide on the [d
 
 ## Contributing
 
-This project exclusively uses **Kind** for development, testing, and CI workflows.
+This project uses **Kind** for development, testing, and CI workflows.
 
 ```bash
 git clone https://github.com/neo4j-partners/neo4j-kubernetes-operator.git
@@ -104,11 +101,3 @@ make test-unit          # Run unit tests
 ```
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) and the [developer guide](https://neo4j-partners.github.io/neo4j-kubernetes-operator/main/developer_guide/development/) for the full inner-loop workflow, test layout, and PR process.
-
-## License
-
-[Apache License 2.0](LICENSE)
-
-## Support
-
-Best-effort via [GitHub Issues](https://github.com/neo4j-partners/neo4j-kubernetes-operator/issues). This is a personal-capacity project, not an officially supported Neo4j product.


### PR DESCRIPTION
Removed warning about LLM-driven development and license/support sections.

## Summary

<!-- What does this PR change, and why? Link any issue: Closes #123 -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore / CI

## Testing

<!-- How did you verify this? -->

- [ ] `make test-unit` passes locally
- [ ] `make lint` passes locally
- [ ] Extended Integration Tests run (add the `run-integration-tests` label or
      `[run-integration]` in a commit) — required if you changed the cluster,
      standalone, backup, or restore controllers

## Checklist

- [ ] Conventional Commit title (`feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`, `ci:`)
- [ ] Ran `make sync-all` and committed regenerated artifacts if I changed Go API
      types, kubebuilder/RBAC markers, or CRDs (CI's `check-drift` gate fails otherwise)
- [ ] Updated docs (API reference / user guides) if behavior or fields changed
- [ ] Respected the project invariants in `CLAUDE.md` (no admission webhooks,
      KIND-only dev, V2 discovery, server-based architecture, …)
