### PR TITLE
fix(standalone): single-owner plugin config + apply StatefulSet template on update (#146)

### DIFF
--- a/internal/controller/neo4jenterprisestandalone_configmap_test.go
+++ b/internal/controller/neo4jenterprisestandalone_configmap_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -12,6 +13,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
 )
@@ -298,5 +300,65 @@ func TestReconcileConfigMap_PluginUnionRenderedAndPruned(t *testing.T) {
 	}
 	if !strings.Contains(conf2, "bloom.*") {
 		t.Errorf("bloom.* should remain after GDS uninstall; conf:\n%s", conf2)
+	}
+}
+
+// TestReconcileConfigMap_PluginListFailureIsFatal: if listing Neo4jPlugin fails,
+// reconcileConfigMap must error (→ requeue) rather than render a plugin-pruned
+// conf and roll the pod with security settings stripped. Regression for Bugbot
+// "Plugin list failure prunes config".
+func TestReconcileConfigMap_PluginListFailureIsFatal(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("scheme: %v", err)
+	}
+	if err := neo4jv1beta1.AddToScheme(scheme); err != nil {
+		t.Fatalf("scheme: %v", err)
+	}
+	listErr := errors.New("apiserver unavailable")
+	c := fake.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
+		List: func(ctx context.Context, cl client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+			if _, ok := list.(*neo4jv1beta1.Neo4jPluginList); ok {
+				return listErr
+			}
+			return cl.List(ctx, list, opts...)
+		},
+	}).Build()
+	r := &Neo4jEnterpriseStandaloneReconciler{Client: c, Scheme: scheme}
+
+	sa := standaloneForConf(map[string]string{"db.transaction.timeout": "30s"})
+	if err := r.reconcileConfigMap(context.Background(), sa); err == nil {
+		t.Fatal("expected reconcileConfigMap to fail when the plugin List fails, got nil")
+	}
+}
+
+// TestReconcileConfigMap_SameNamedClusterPluginsNotFolded: a Neo4jPlugin whose
+// clusterRef matches a Neo4jEnterpriseCluster of the same name targets the
+// CLUSTER (plugin controller resolves cluster-first), so its settings must NOT
+// be folded into a same-named standalone's neo4j.conf. Regression for Bugbot
+// "Cluster plugins merged into standalone".
+func TestReconcileConfigMap_SameNamedClusterPluginsNotFolded(t *testing.T) {
+	r, c := standaloneCMTestReconciler(t)
+	ctx := context.Background()
+
+	// A cluster shares the standalone's name "sa".
+	cluster := &neo4jv1beta1.Neo4jEnterpriseCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "sa", Namespace: "default"},
+	}
+	if err := c.Create(ctx, cluster); err != nil {
+		t.Fatalf("create cluster: %v", err)
+	}
+	// A GDS plugin referencing "sa" — intended for the cluster.
+	if err := c.Create(ctx, pluginCR("gds", "gds", "sa", true, nil)); err != nil {
+		t.Fatalf("create plugin: %v", err)
+	}
+
+	sa := standaloneForConf(map[string]string{"db.transaction.timeout": "30s"})
+	if err := r.reconcileConfigMap(ctx, sa); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	conf := renderedConf(t, c)
+	if strings.Contains(conf, "gds.*") {
+		t.Errorf("cluster-targeted plugin must not be folded into the same-named standalone; conf:\n%s", conf)
 	}
 }

--- a/internal/controller/neo4jenterprisestandalone_configmap_test.go
+++ b/internal/controller/neo4jenterprisestandalone_configmap_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -360,5 +361,82 @@ func TestReconcileConfigMap_SameNamedClusterPluginsNotFolded(t *testing.T) {
 	conf := renderedConf(t, c)
 	if strings.Contains(conf, "gds.*") {
 		t.Errorf("cluster-targeted plugin must not be folded into the same-named standalone; conf:\n%s", conf)
+	}
+}
+
+// TestReconcileConfigMap_RollsPodOnConfChangeIdempotently: a neo4j.conf change
+// must roll the pod (stamp the config-hash annotation), and an unchanged conf
+// must NOT churn the StatefulSet. The hash-based roll is what makes a failed
+// roll retryable (see PodRollFailureReturnsError).
+func TestReconcileConfigMap_RollsPodOnConfChangeIdempotently(t *testing.T) {
+	r, _ := standaloneCMTestReconciler(t)
+	ctx := context.Background()
+
+	sa := standaloneForSTS("5.26.0-enterprise")
+	sa.Spec.Config = map[string]string{"db.transaction.timeout": "30s"}
+	if err := r.reconcileStatefulSet(ctx, sa); err != nil {
+		t.Fatalf("create STS: %v", err)
+	}
+	if err := r.reconcileConfigMap(ctx, sa); err != nil {
+		t.Fatalf("reconcile conf 1: %v", err)
+	}
+	h1 := getSTS(t, r).Spec.Template.Annotations[standaloneConfigHashAnnotation]
+	if h1 == "" {
+		t.Fatal("expected config-hash annotation to be stamped after conf reconcile")
+	}
+
+	// Same conf again → no StatefulSet churn.
+	rv := getSTS(t, r).ResourceVersion
+	if err := r.reconcileConfigMap(ctx, sa); err != nil {
+		t.Fatalf("reconcile conf 2 (idempotent): %v", err)
+	}
+	if getSTS(t, r).ResourceVersion != rv {
+		t.Errorf("unchanged conf should not churn the StatefulSet (rv changed from %s)", rv)
+	}
+
+	// Change conf → config-hash changes (pod rolls).
+	sa.Spec.Config["db.transaction.timeout"] = "90s"
+	if err := r.reconcileConfigMap(ctx, sa); err != nil {
+		t.Fatalf("reconcile conf 3 (changed): %v", err)
+	}
+	if h2 := getSTS(t, r).Spec.Template.Annotations[standaloneConfigHashAnnotation]; h2 == h1 {
+		t.Errorf("config-hash should change when neo4j.conf changes; still %s", h2)
+	}
+}
+
+// TestReconcileConfigMap_PodRollFailureReturnsError: if the pod roll (StatefulSet
+// update) fails, reconcileConfigMap must return the error (→ requeue) rather than
+// log-and-succeed, which would leave Neo4j on stale conf. Regression for Bugbot
+// "Config restart failures never retried".
+func TestReconcileConfigMap_PodRollFailureReturnsError(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("scheme: %v", err)
+	}
+	if err := neo4jv1beta1.AddToScheme(scheme); err != nil {
+		t.Fatalf("scheme: %v", err)
+	}
+	rollErr := errors.New("statefulset update boom")
+	c := fake.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
+		Update: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			if _, ok := obj.(*appsv1.StatefulSet); ok {
+				return rollErr
+			}
+			return cl.Update(ctx, obj, opts...)
+		},
+	}).Build()
+	r := &Neo4jEnterpriseStandaloneReconciler{Client: c, Scheme: scheme}
+	ctx := context.Background()
+
+	// A StatefulSet must exist so the roll attempts (and fails) an Update.
+	if err := c.Create(ctx, &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "sa", Namespace: "default"},
+	}); err != nil {
+		t.Fatalf("pre-create STS: %v", err)
+	}
+
+	sa := standaloneForConf(map[string]string{"db.transaction.timeout": "30s"})
+	if err := r.reconcileConfigMap(ctx, sa); err == nil {
+		t.Fatal("expected reconcileConfigMap to return an error when the pod roll fails")
 	}
 }

--- a/internal/controller/neo4jenterprisestandalone_configmap_test.go
+++ b/internal/controller/neo4jenterprisestandalone_configmap_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -361,82 +360,5 @@ func TestReconcileConfigMap_SameNamedClusterPluginsNotFolded(t *testing.T) {
 	conf := renderedConf(t, c)
 	if strings.Contains(conf, "gds.*") {
 		t.Errorf("cluster-targeted plugin must not be folded into the same-named standalone; conf:\n%s", conf)
-	}
-}
-
-// TestReconcileConfigMap_RollsPodOnConfChangeIdempotently: a neo4j.conf change
-// must roll the pod (stamp the config-hash annotation), and an unchanged conf
-// must NOT churn the StatefulSet. The hash-based roll is what makes a failed
-// roll retryable (see PodRollFailureReturnsError).
-func TestReconcileConfigMap_RollsPodOnConfChangeIdempotently(t *testing.T) {
-	r, _ := standaloneCMTestReconciler(t)
-	ctx := context.Background()
-
-	sa := standaloneForSTS("5.26.0-enterprise")
-	sa.Spec.Config = map[string]string{"db.transaction.timeout": "30s"}
-	if err := r.reconcileStatefulSet(ctx, sa); err != nil {
-		t.Fatalf("create STS: %v", err)
-	}
-	if err := r.reconcileConfigMap(ctx, sa); err != nil {
-		t.Fatalf("reconcile conf 1: %v", err)
-	}
-	h1 := getSTS(t, r).Spec.Template.Annotations[standaloneConfigHashAnnotation]
-	if h1 == "" {
-		t.Fatal("expected config-hash annotation to be stamped after conf reconcile")
-	}
-
-	// Same conf again → no StatefulSet churn.
-	rv := getSTS(t, r).ResourceVersion
-	if err := r.reconcileConfigMap(ctx, sa); err != nil {
-		t.Fatalf("reconcile conf 2 (idempotent): %v", err)
-	}
-	if getSTS(t, r).ResourceVersion != rv {
-		t.Errorf("unchanged conf should not churn the StatefulSet (rv changed from %s)", rv)
-	}
-
-	// Change conf → config-hash changes (pod rolls).
-	sa.Spec.Config["db.transaction.timeout"] = "90s"
-	if err := r.reconcileConfigMap(ctx, sa); err != nil {
-		t.Fatalf("reconcile conf 3 (changed): %v", err)
-	}
-	if h2 := getSTS(t, r).Spec.Template.Annotations[standaloneConfigHashAnnotation]; h2 == h1 {
-		t.Errorf("config-hash should change when neo4j.conf changes; still %s", h2)
-	}
-}
-
-// TestReconcileConfigMap_PodRollFailureReturnsError: if the pod roll (StatefulSet
-// update) fails, reconcileConfigMap must return the error (→ requeue) rather than
-// log-and-succeed, which would leave Neo4j on stale conf. Regression for Bugbot
-// "Config restart failures never retried".
-func TestReconcileConfigMap_PodRollFailureReturnsError(t *testing.T) {
-	scheme := runtime.NewScheme()
-	if err := clientgoscheme.AddToScheme(scheme); err != nil {
-		t.Fatalf("scheme: %v", err)
-	}
-	if err := neo4jv1beta1.AddToScheme(scheme); err != nil {
-		t.Fatalf("scheme: %v", err)
-	}
-	rollErr := errors.New("statefulset update boom")
-	c := fake.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
-		Update: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
-			if _, ok := obj.(*appsv1.StatefulSet); ok {
-				return rollErr
-			}
-			return cl.Update(ctx, obj, opts...)
-		},
-	}).Build()
-	r := &Neo4jEnterpriseStandaloneReconciler{Client: c, Scheme: scheme}
-	ctx := context.Background()
-
-	// A StatefulSet must exist so the roll attempts (and fails) an Update.
-	if err := c.Create(ctx, &appsv1.StatefulSet{
-		ObjectMeta: metav1.ObjectMeta{Name: "sa", Namespace: "default"},
-	}); err != nil {
-		t.Fatalf("pre-create STS: %v", err)
-	}
-
-	sa := standaloneForConf(map[string]string{"db.transaction.timeout": "30s"})
-	if err := r.reconcileConfigMap(ctx, sa); err == nil {
-		t.Fatal("expected reconcileConfigMap to return an error when the pod roll fails")
 	}
 }

--- a/internal/controller/neo4jenterprisestandalone_configmap_test.go
+++ b/internal/controller/neo4jenterprisestandalone_configmap_test.go
@@ -140,40 +140,49 @@ func TestReconcileConfigMap_PreservesForeignKeys(t *testing.T) {
 	}
 }
 
-// TestReconcileConfigMap_AdditiveForeignTokensPreserved: when a plugin unions
-// tokens into an additive key the operator also owns (procedures.unrestricted),
-// both the operator and plugin tokens must survive — and stay stable across
-// reconciles (no tug-of-war / oscillation).
-func TestReconcileConfigMap_AdditiveForeignTokensPreserved(t *testing.T) {
-	r, c := standaloneCMTestReconciler(t)
+// TestReconcileConfigMap_UserAndPluginAdditiveUnioned: a user's spec.config
+// allowlist and a plugin's additive allowlist are BOTH operator-owned and are
+// unioned in the rendered conf (single declaration), and the result is stable
+// across reconciles (no churn). This replaces the old "foreign tokens" case —
+// after #146 plugin tokens flow through the single owner (a plugin CR), not an
+// external patch to the ConfigMap.
+func TestReconcileConfigMap_UserAndPluginAdditiveUnioned(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("scheme: %v", err)
+	}
+	if err := neo4jv1beta1.AddToScheme(scheme); err != nil {
+		t.Fatalf("scheme: %v", err)
+	}
+	gds := pluginCR("gds-plugin", "gds", "sa", true, nil)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gds).Build()
+	r := &Neo4jEnterpriseStandaloneReconciler{Client: c, Scheme: scheme}
 	ctx := context.Background()
 
-	sa := standaloneForConf(map[string]string{"dbms.security.procedures.unrestricted": "gds.*"})
+	sa := standaloneForConf(map[string]string{"dbms.security.procedures.unrestricted": "myapp.*"})
 	if err := r.reconcileConfigMap(ctx, sa); err != nil {
 		t.Fatalf("reconcile 1: %v", err)
 	}
-	// Plugin unions apoc.* into the additive key.
-	cm := &corev1.ConfigMap{}
-	if err := c.Get(ctx, types.NamespacedName{Name: "sa-config", Namespace: "default"}, cm); err != nil {
-		t.Fatalf("get: %v", err)
+	got := renderedConf(t, c)
+	for _, want := range []string{"myapp.*", "gds.*", "apoc.load.*"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected user + plugin token %q unioned; conf:\n%s", want, got)
+		}
 	}
-	cm.Data["neo4j.conf"] = strings.ReplaceAll(cm.Data["neo4j.conf"],
-		"dbms.security.procedures.unrestricted=gds.*",
-		"dbms.security.procedures.unrestricted=gds.*,apoc.*")
-	if err := c.Update(ctx, cm); err != nil {
-		t.Fatalf("simulate plugin union: %v", err)
+	if n := strings.Count(got, "dbms.security.procedures.unrestricted="); n != 1 {
+		t.Errorf("procedures.unrestricted should be declared exactly once, got %d; conf:\n%s", n, got)
 	}
 
+	// Stable across a repeat reconcile (no churn).
+	cm1 := &corev1.ConfigMap{}
+	_ = c.Get(ctx, types.NamespacedName{Name: "sa-config", Namespace: "default"}, cm1)
 	if err := r.reconcileConfigMap(ctx, sa); err != nil {
 		t.Fatalf("reconcile 2: %v", err)
 	}
-	got := renderedConf(t, c)
-	if !strings.Contains(got, "apoc.*") || !strings.Contains(got, "gds.*") {
-		t.Errorf("both operator (gds.*) and plugin (apoc.*) tokens should survive; conf:\n%s", got)
-	}
-	// And the key must still be single-declared (no duplicate line).
-	if n := strings.Count(got, "dbms.security.procedures.unrestricted="); n != 1 {
-		t.Errorf("procedures.unrestricted should be declared exactly once, got %d; conf:\n%s", n, got)
+	cm2 := &corev1.ConfigMap{}
+	_ = c.Get(ctx, types.NamespacedName{Name: "sa-config", Namespace: "default"}, cm2)
+	if cm1.ResourceVersion != cm2.ResourceVersion {
+		t.Errorf("ConfigMap churned on repeat reconcile (rv %s -> %s)", cm1.ResourceVersion, cm2.ResourceVersion)
 	}
 }
 
@@ -211,5 +220,83 @@ func TestReconcileConfigMap_Idempotent(t *testing.T) {
 	if cm1.ResourceVersion != cm2.ResourceVersion {
 		t.Errorf("ConfigMap changed on repeat reconcile (rv %s -> %s) — would churn/restart the pod",
 			cm1.ResourceVersion, cm2.ResourceVersion)
+	}
+}
+
+// --- #146: plugin-derived conf is owned & unioned by the standalone controller ---
+
+func pluginCR(name, pluginName, clusterRef string, enabled bool, config map[string]string) *neo4jv1beta1.Neo4jPlugin {
+	return &neo4jv1beta1.Neo4jPlugin{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec: neo4jv1beta1.Neo4jPluginSpec{
+			Name: pluginName, ClusterRef: clusterRef, Enabled: enabled, Config: config,
+		},
+	}
+}
+
+// TestUnionPluginConfSettings: union across plugins (additive keys merged),
+// honoring clusterRef + enabled filtering.
+func TestUnionPluginConfSettings(t *testing.T) {
+	plugins := []neo4jv1beta1.Neo4jPlugin{
+		*pluginCR("gds", "gds", "sa", true, nil),
+		*pluginCR("bloom", "bloom", "sa", true, nil),
+		*pluginCR("elsewhere", "gds", "other", true, nil),      // different target → ignored
+		*pluginCR("off", "fleet-management", "sa", false, nil), // disabled → ignored
+	}
+	got := unionPluginConfSettings(plugins, "sa")
+
+	u := got["dbms.security.procedures.unrestricted"]
+	if !strings.Contains(u, "gds.*") || !strings.Contains(u, "bloom.*") {
+		t.Errorf("expected gds.* and bloom.* unioned in procedures.unrestricted, got %q", u)
+	}
+	if strings.Contains(u, "fleetManagement.*") {
+		t.Errorf("disabled/other-target plugins must not contribute, got %q", u)
+	}
+	if got["server.unmanaged_extension_classes"] == "" {
+		t.Error("bloom's unmanaged_extension_classes should be present")
+	}
+}
+
+// TestReconcileConfigMap_PluginUnionRenderedAndPruned: the standalone renders the
+// union of its plugins' conf as operator-owned, and prunes a plugin's keys when
+// it's uninstalled (#146 — the missing piece beyond #151's foreign-key preserve).
+func TestReconcileConfigMap_PluginUnionRenderedAndPruned(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("scheme: %v", err)
+	}
+	if err := neo4jv1beta1.AddToScheme(scheme); err != nil {
+		t.Fatalf("scheme: %v", err)
+	}
+	gds := pluginCR("gds-plugin", "gds", "sa", true, nil)
+	bloom := pluginCR("bloom-plugin", "bloom", "sa", true, nil)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gds, bloom).Build()
+	r := &Neo4jEnterpriseStandaloneReconciler{Client: c, Scheme: scheme}
+	ctx := context.Background()
+	sa := standaloneForConf(nil) // name "sa"
+
+	if err := r.reconcileConfigMap(ctx, sa); err != nil {
+		t.Fatalf("reconcile 1: %v", err)
+	}
+	conf := renderedConf(t, c)
+	for _, want := range []string{"gds.*", "bloom.*", "server.unmanaged_extension_classes"} {
+		if !strings.Contains(conf, want) {
+			t.Errorf("expected plugin-derived %q in rendered conf; conf:\n%s", want, conf)
+		}
+	}
+
+	// Uninstall GDS.
+	if err := c.Delete(ctx, gds); err != nil {
+		t.Fatalf("delete gds: %v", err)
+	}
+	if err := r.reconcileConfigMap(ctx, sa); err != nil {
+		t.Fatalf("reconcile 2: %v", err)
+	}
+	conf2 := renderedConf(t, c)
+	if strings.Contains(conf2, "gds.*") {
+		t.Errorf("gds.* should be pruned after GDS uninstall; conf:\n%s", conf2)
+	}
+	if !strings.Contains(conf2, "bloom.*") {
+		t.Errorf("bloom.* should remain after GDS uninstall; conf:\n%s", conf2)
 	}
 }

--- a/internal/controller/neo4jenterprisestandalone_controller.go
+++ b/internal/controller/neo4jenterprisestandalone_controller.go
@@ -367,7 +367,16 @@ func (r *Neo4jEnterpriseStandaloneReconciler) reconcileConfigMap(ctx context.Con
 	// in the annotation below), so an uninstalled plugin's keys are PRUNED on the
 	// next reconcile, and there's no after-the-fact ConfigMap patching by the
 	// plugin controller to fight with.
-	if pluginConf := r.collectPluginConfSettings(ctx, standalone); len(pluginConf) > 0 {
+	//
+	// A LISTING FAILURE MUST BE FATAL here: treating it as "no plugins" would
+	// prune the plugin-owned security keys from neo4j.conf and roll the pod with
+	// those settings stripped. Returning the error requeues without rewriting the
+	// ConfigMap, so the existing (correct) conf is preserved.
+	pluginConf, err := r.collectPluginConfSettings(ctx, standalone)
+	if err != nil {
+		return fmt.Errorf("failed to collect plugin-derived config: %w", err)
+	}
+	if len(pluginConf) > 0 {
 		desiredConf = resources.DedupeNeo4jConf(resources.UpsertNeo4jConfSettings(desiredConf, pluginConf))
 	}
 	desiredKeys := resources.Neo4jConfSettings(desiredConf) // operator-owned keys this reconcile
@@ -378,7 +387,7 @@ func (r *Neo4jEnterpriseStandaloneReconciler) reconcileConfigMap(ctx context.Con
 
 	// Create or update ConfigMap with retry logic to handle resource version conflicts.
 	var opResult controllerutil.OperationResult
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		var err error
 		opResult, err = controllerutil.CreateOrUpdate(ctx, r.Client, configMap, func() error {
 			// controllerutil.CreateOrUpdate's Get overwrites configMap with the
@@ -448,15 +457,28 @@ func (r *Neo4jEnterpriseStandaloneReconciler) reconcileConfigMap(ctx context.Con
 }
 
 // collectPluginConfSettings returns the union of neo4j.conf settings derived from
-// every enabled Neo4jPlugin targeting this standalone (#146). Non-fatal: a list
-// error yields no plugin settings rather than failing the reconcile.
-func (r *Neo4jEnterpriseStandaloneReconciler) collectPluginConfSettings(ctx context.Context, standalone *neo4jv1beta1.Neo4jEnterpriseStandalone) map[string]string {
+// every enabled Neo4jPlugin targeting this standalone (#146). A list error is
+// returned (not swallowed) so the caller can requeue without pruning plugin-owned
+// keys from neo4j.conf.
+func (r *Neo4jEnterpriseStandaloneReconciler) collectPluginConfSettings(ctx context.Context, standalone *neo4jv1beta1.Neo4jEnterpriseStandalone) (map[string]string, error) {
+	// Cluster-first target resolution, mirroring the plugin controller's
+	// getTargetDeployment: a Neo4jPlugin's clusterRef resolves to a same-named
+	// Neo4jEnterpriseCluster when one exists, otherwise to the standalone. So if a
+	// cluster of this name coexists in the namespace, plugins referencing the name
+	// target the CLUSTER — fold none of them into this standalone's neo4j.conf.
+	cluster := &neo4jv1beta1.Neo4jEnterpriseCluster{}
+	switch err := r.Get(ctx, types.NamespacedName{Name: standalone.Name, Namespace: standalone.Namespace}, cluster); {
+	case err == nil:
+		return nil, nil // a same-named cluster owns these plugins
+	case !errors.IsNotFound(err):
+		return nil, fmt.Errorf("checking for a same-named cluster: %w", err)
+	}
+
 	plugins := &neo4jv1beta1.Neo4jPluginList{}
 	if err := r.List(ctx, plugins, client.InNamespace(standalone.Namespace)); err != nil {
-		log.FromContext(ctx).V(1).Info("Unable to list plugins for ConfigMap render; proceeding without plugin-derived config", "error", err)
-		return nil
+		return nil, fmt.Errorf("listing Neo4jPlugins in %s: %w", standalone.Namespace, err)
 	}
-	return unionPluginConfSettings(plugins.Items, standalone.Name)
+	return unionPluginConfSettings(plugins.Items, standalone.Name), nil
 }
 
 // restartStandalonePod rolls the standalone's pod by bumping a restart annotation
@@ -627,6 +649,27 @@ func standalonePodTemplateHash(t corev1.PodTemplateSpec) string {
 	return hex.EncodeToString(sum[:])
 }
 
+// mergeForeignByName returns desired followed by every item in current whose
+// name (per nameOf) is NOT in desired — i.e. desired wins on a name collision
+// and foreign items added by another controller (the plugin controller's
+// VerifiedDownload init container and its auth/CA volumes) are preserved across
+// a template apply. Order is stable: desired first (operator-owned), then
+// preserved foreign items in their existing relative order.
+func mergeForeignByName[T any](current, desired []T, nameOf func(T) string) []T {
+	desiredNames := make(map[string]struct{}, len(desired))
+	for _, d := range desired {
+		desiredNames[nameOf(d)] = struct{}{}
+	}
+	out := make([]T, 0, len(current)+len(desired))
+	out = append(out, desired...)
+	for _, c := range current {
+		if _, ok := desiredNames[nameOf(c)]; !ok {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
 // standaloneEnvVarNames returns the env-var names sorted and comma-joined, for
 // the owned-env-vars annotation (stable so it doesn't churn the StatefulSet).
 func standaloneEnvVarNames(env []corev1.EnvVar) string {
@@ -702,18 +745,26 @@ func (r *Neo4jEnterpriseStandaloneReconciler) reconcileStatefulSet(ctx context.C
 				return nil
 			}
 
-			// Apply the desired template, preserving:
-			//   - foreign env vars (plugin / fleet additions) via mergeEnvVars,
-			//     which also drops vars the operator previously owned but no longer
-			//     does (e.g. a removed spec.config key);
-			//   - foreign pod-template annotations (conf-path config-restart stamp,
-			//     mesh injection) by overlaying the desired annotations onto them.
+			// Apply the desired template, preserving foreign additions that other
+			// controllers patch directly onto the StatefulSet:
+			//   - env vars (plugin / fleet) via mergeEnvVars, which also drops vars
+			//     the operator previously owned but no longer does (a removed
+			//     spec.config key);
+			//   - pod-template annotations (conf-path config-restart stamp, mesh
+			//     injection, the plugin controller's neo4j.com/plugin-init-containers
+			//     ownership annotation) by overlaying desired onto existing;
+			//   - init containers and volumes (the plugin controller's
+			//     VerifiedDownload init container + its auth/CA volumes) by name —
+			//     otherwise an image/resource upgrade would drop them and the pod
+			//     would roll without the verified plugin JAR.
 			previousOwned := splitCSVSet(statefulSet.Annotations[standaloneOwnedEnvVarsAnnotation])
 			currentEnv := []corev1.EnvVar{}
 			if len(statefulSet.Spec.Template.Spec.Containers) > 0 {
 				currentEnv = statefulSet.Spec.Template.Spec.Containers[0].Env
 			}
 			mergedEnv := mergeEnvVars(currentEnv, desiredEnv, previousOwned)
+			currentInit := statefulSet.Spec.Template.Spec.InitContainers
+			currentVolumes := statefulSet.Spec.Template.Spec.Volumes
 
 			mergedAnnotations := map[string]string{}
 			for k, v := range statefulSet.Spec.Template.Annotations {
@@ -723,11 +774,18 @@ func (r *Neo4jEnterpriseStandaloneReconciler) reconcileStatefulSet(ctx context.C
 				mergedAnnotations[k] = v
 			}
 
-			statefulSet.Spec.Template = *desiredSpec.Template.DeepCopy()
+			desiredTemplate := desiredSpec.Template.DeepCopy()
+			statefulSet.Spec.Template = *desiredTemplate
 			statefulSet.Spec.Template.Annotations = mergedAnnotations
 			if len(statefulSet.Spec.Template.Spec.Containers) > 0 {
 				statefulSet.Spec.Template.Spec.Containers[0].Env = mergedEnv
 			}
+			statefulSet.Spec.Template.Spec.InitContainers = mergeForeignByName(
+				currentInit, desiredTemplate.Spec.InitContainers,
+				func(c corev1.Container) string { return c.Name })
+			statefulSet.Spec.Template.Spec.Volumes = mergeForeignByName(
+				currentVolumes, desiredTemplate.Spec.Volumes,
+				func(v corev1.Volume) string { return v.Name })
 
 			r.stampStandaloneStatefulSetTracking(statefulSet, desiredHash, desiredEnv)
 			return nil

--- a/internal/controller/neo4jenterprisestandalone_controller.go
+++ b/internal/controller/neo4jenterprisestandalone_controller.go
@@ -768,6 +768,16 @@ func (r *Neo4jEnterpriseStandaloneReconciler) reconcileStatefulSet(ctx context.C
 
 			mergedAnnotations := map[string]string{}
 			for k, v := range statefulSet.Spec.Template.Annotations {
+				// Operator-managed annotations (the Prometheus scrape hints) are
+				// re-derived from the desired template below — NOT carried forward
+				// — so disabling spec.monitoring actually removes them. Carrying the
+				// existing value would leave stale prometheus.io/* keys scraping a
+				// port that no longer exists. Foreign annotations (conf-restart
+				// stamp, plugin-init-containers, service-mesh injection) are not in
+				// this managed set, so they're preserved.
+				if _, managed := standaloneOperatorManagedPodAnnotations[k]; managed {
+					continue
+				}
 				mergedAnnotations[k] = v
 			}
 			for k, v := range desiredSpec.Template.Annotations {
@@ -1361,14 +1371,37 @@ func (r *Neo4jEnterpriseStandaloneReconciler) createService(standalone *neo4jv1b
 	return svc
 }
 
+// standalonePrometheusAnnotations returns the Prometheus scrape hints the
+// operator adds to the pod template when monitoring is enabled (nil otherwise).
+// Single source of truth for these operator-owned annotations.
+func standalonePrometheusAnnotations(standalone *neo4jv1beta1.Neo4jEnterpriseStandalone) map[string]string {
+	if standalone.Spec.Monitoring == nil || !standalone.Spec.Monitoring.Enabled {
+		return nil
+	}
+	return map[string]string{
+		"prometheus.io/scrape": "true",
+		"prometheus.io/port":   fmt.Sprintf("%d", resources.MetricsPort),
+		"prometheus.io/path":   "/metrics",
+	}
+}
+
+// standaloneOperatorManagedPodAnnotations is the KEY set the operator owns on
+// the pod template (the Prometheus hints above). On a template apply these are
+// re-derived from the desired template — never carried forward from the existing
+// one — so disabling monitoring removes them, while foreign annotations are
+// preserved. Keep in sync with standalonePrometheusAnnotations' keys.
+var standaloneOperatorManagedPodAnnotations = map[string]struct{}{
+	"prometheus.io/scrape": {},
+	"prometheus.io/port":   {},
+	"prometheus.io/path":   {},
+}
+
 // createStatefulSet creates a StatefulSet for the standalone deployment
 func (r *Neo4jEnterpriseStandaloneReconciler) createStatefulSet(standalone *neo4jv1beta1.Neo4jEnterpriseStandalone) *appsv1.StatefulSet {
 	replicas := int32(1)
 	annotations := map[string]string{}
-	if standalone.Spec.Monitoring != nil && standalone.Spec.Monitoring.Enabled {
-		annotations["prometheus.io/scrape"] = "true"
-		annotations["prometheus.io/port"] = fmt.Sprintf("%d", resources.MetricsPort)
-		annotations["prometheus.io/path"] = "/metrics"
+	for k, v := range standalonePrometheusAnnotations(standalone) {
+		annotations[k] = v
 	}
 
 	ports := []corev1.ContainerPort{

--- a/internal/controller/neo4jenterprisestandalone_controller.go
+++ b/internal/controller/neo4jenterprisestandalone_controller.go
@@ -386,10 +386,8 @@ func (r *Neo4jEnterpriseStandaloneReconciler) reconcileConfigMap(ctx context.Con
 	}
 
 	// Create or update ConfigMap with retry logic to handle resource version conflicts.
-	var opResult controllerutil.OperationResult
 	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		var err error
-		opResult, err = controllerutil.CreateOrUpdate(ctx, r.Client, configMap, func() error {
+		_, err := controllerutil.CreateOrUpdate(ctx, r.Client, configMap, func() error {
 			// controllerutil.CreateOrUpdate's Get overwrites configMap with the
 			// EXISTING object, so the desired state MUST be (re)applied here in the
 			// mutate fn — an empty mutate would silently write the stale data back
@@ -443,14 +441,15 @@ func (r *Neo4jEnterpriseStandaloneReconciler) reconcileConfigMap(ctx context.Con
 	}
 	logger.Info("Successfully created or updated ConfigMap", "name", configMap.Name)
 
-	// The rendered conf changed on an already-running standalone — roll the pod
-	// so Neo4j re-reads neo4j.conf. Covers user spec.config edits and any
-	// Neo4jPlugin add/change/remove (which now flows through this single owner).
-	// Skipped on create (the pod hasn't started yet).
-	if opResult == controllerutil.OperationResultUpdated {
-		if err := r.restartStandalonePod(ctx, standalone); err != nil {
-			logger.Error(err, "failed to roll standalone pod after config change")
-		}
+	// Roll the pod when the rendered neo4j.conf changes so Neo4j re-reads it
+	// (it only reads conf at startup). Driven by a hash of the rendered conf
+	// stamped on the pod template — NOT by the ConfigMap's create/update result —
+	// so that a roll which FAILS to apply is retried on the next reconcile
+	// (the hash still differs) instead of leaving Neo4j on stale conf until the
+	// ConfigMap happens to change again. Idempotent: a matching hash is a no-op.
+	// The error is returned (requeue), not swallowed.
+	if err := r.ensureStandalonePodConfigHash(ctx, standalone, standaloneConfHash(configMap.Data["neo4j.conf"])); err != nil {
+		return fmt.Errorf("failed to roll standalone pod after config change: %w", err)
 	}
 
 	return nil
@@ -481,25 +480,43 @@ func (r *Neo4jEnterpriseStandaloneReconciler) collectPluginConfSettings(ctx cont
 	return unionPluginConfSettings(plugins.Items, standalone.Name), nil
 }
 
-// restartStandalonePod rolls the standalone's pod by bumping a restart annotation
-// on the StatefulSet template, so Neo4j re-reads neo4j.conf after a config change.
-// Called only when the rendered conf actually changed (#146 makes config-change
-// restarts the standalone controller's responsibility, replacing the plugin
-// controller's per-plugin restart). Best-effort: a missing StatefulSet (not yet
-// created) is a no-op.
-func (r *Neo4jEnterpriseStandaloneReconciler) restartStandalonePod(ctx context.Context, standalone *neo4jv1beta1.Neo4jEnterpriseStandalone) error {
-	sts := &appsv1.StatefulSet{}
-	if err := r.Get(ctx, types.NamespacedName{Name: standalone.Name, Namespace: standalone.Namespace}, sts); err != nil {
-		if errors.IsNotFound(err) {
+// standaloneConfigHashAnnotation carries a hash of the rendered neo4j.conf on the
+// pod template. Changing it triggers a StatefulSet rolling update (so Neo4j
+// re-reads conf at startup); leaving it unchanged is a no-op. Being a function
+// of the conf content makes the roll idempotent AND retried — a failed roll
+// leaves the hash mismatched, so the next reconcile retries it.
+const standaloneConfigHashAnnotation = "neo4j.com/config-hash"
+
+// standaloneConfHash returns a stable hex hash of the rendered neo4j.conf.
+func standaloneConfHash(conf string) string {
+	sum := sha256.Sum256([]byte(conf))
+	return hex.EncodeToString(sum[:])
+}
+
+// ensureStandalonePodConfigHash rolls the standalone's pod when the rendered conf
+// changes, by stamping confHash on the pod template. Idempotent (matching hash →
+// no-op), so it's safe to call every reconcile; the Update error is returned so a
+// failed roll requeues and is retried (#146 makes config-change rolls the
+// standalone controller's responsibility). A missing StatefulSet (pod not created
+// yet) is a no-op. Wrapped in RetryOnConflict for the read-modify-write.
+func (r *Neo4jEnterpriseStandaloneReconciler) ensureStandalonePodConfigHash(ctx context.Context, standalone *neo4jv1beta1.Neo4jEnterpriseStandalone, confHash string) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		sts := &appsv1.StatefulSet{}
+		if err := r.Get(ctx, types.NamespacedName{Name: standalone.Name, Namespace: standalone.Namespace}, sts); err != nil {
+			if errors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		if sts.Spec.Template.Annotations[standaloneConfigHashAnnotation] == confHash {
 			return nil
 		}
-		return err
-	}
-	if sts.Spec.Template.Annotations == nil {
-		sts.Spec.Template.Annotations = make(map[string]string)
-	}
-	sts.Spec.Template.Annotations["neo4j.com/config-restarted-at"] = time.Now().UTC().Format(time.RFC3339)
-	return r.Update(ctx, sts)
+		if sts.Spec.Template.Annotations == nil {
+			sts.Spec.Template.Annotations = make(map[string]string)
+		}
+		sts.Spec.Template.Annotations[standaloneConfigHashAnnotation] = confHash
+		return r.Update(ctx, sts)
+	})
 }
 
 // splitCSVSet parses a comma-separated annotation value into a set.
@@ -627,6 +644,20 @@ func (r *Neo4jEnterpriseStandaloneReconciler) createHeadlessService(standalone *
 // token, APOC vars). See mergeEnvVars for the merge semantics.
 const standaloneOwnedEnvVarsAnnotation = "neo4j.com/standalone-controller-env-vars"
 
+// standaloneOwnedInitContainersAnnotation / standaloneOwnedVolumesAnnotation
+// record the init-container and volume NAMES the standalone controller rendered
+// on the last reconcile. They play the same role for init containers / volumes
+// that standaloneOwnedEnvVarsAnnotation plays for env vars: on a template apply
+// they let the controller DROP an item it used to own but no longer renders
+// (e.g. the truststore init container + its CA volume once spec.trustedCASecrets
+// is cleared) WITHOUT clobbering foreign items added by another controller (the
+// plugin controller's VerifiedDownload init container + auth/CA volumes). See
+// mergeOwnedByName.
+const (
+	standaloneOwnedInitContainersAnnotation = "neo4j.com/standalone-controller-init-containers"
+	standaloneOwnedVolumesAnnotation        = "neo4j.com/standalone-controller-volumes"
+)
+
 // standaloneTemplateHashAnnotation stores a hash of the operator's DESIRED pod
 // template from the previous reconcile. reconcileStatefulSet applies the
 // desired template (image, resources, probes, env, volumes…) only when this
@@ -649,13 +680,19 @@ func standalonePodTemplateHash(t corev1.PodTemplateSpec) string {
 	return hex.EncodeToString(sum[:])
 }
 
-// mergeForeignByName returns desired followed by every item in current whose
-// name (per nameOf) is NOT in desired — i.e. desired wins on a name collision
-// and foreign items added by another controller (the plugin controller's
-// VerifiedDownload init container and its auth/CA volumes) are preserved across
-// a template apply. Order is stable: desired first (operator-owned), then
-// preserved foreign items in their existing relative order.
-func mergeForeignByName[T any](current, desired []T, nameOf func(T) string) []T {
+// mergeOwnedByName applies the operator's desired items while preserving foreign
+// ones, mirroring mergeEnvVars (which does the same for env vars):
+//   - desired: applied (wins by name).
+//   - previousOwned ∖ desired: DROPPED — an item the operator used to render and
+//     no longer does (e.g. the truststore init container + its CA volume once
+//     spec.trustedCASecrets is cleared). Without this they'd be mistaken for
+//     foreign and re-appended forever.
+//   - current ∖ previousOwned ∖ desired: preserved (genuinely foreign — the
+//     plugin controller's VerifiedDownload init container + auth/CA volumes).
+//
+// Output: desired first (operator-owned), then preserved foreign items in their
+// original relative order.
+func mergeOwnedByName[T any](current, desired []T, previousOwned map[string]struct{}, nameOf func(T) string) []T {
 	desiredNames := make(map[string]struct{}, len(desired))
 	for _, d := range desired {
 		desiredNames[nameOf(d)] = struct{}{}
@@ -663,11 +700,28 @@ func mergeForeignByName[T any](current, desired []T, nameOf func(T) string) []T 
 	out := make([]T, 0, len(current)+len(desired))
 	out = append(out, desired...)
 	for _, c := range current {
-		if _, ok := desiredNames[nameOf(c)]; !ok {
-			out = append(out, c)
+		n := nameOf(c)
+		if _, inDesired := desiredNames[n]; inDesired {
+			continue // desired already holds it
 		}
+		if _, owned := previousOwned[n]; owned {
+			continue // operator-owned but no longer desired → drop
+		}
+		out = append(out, c) // foreign → preserve
 	}
 	return out
+}
+
+// sortedNamesCSV returns the items' names (per nameOf) sorted and comma-joined,
+// for the owned-init-containers / owned-volumes annotations (stable so they
+// don't churn the StatefulSet between reconciles).
+func sortedNamesCSV[T any](items []T, nameOf func(T) string) string {
+	names := make([]string, 0, len(items))
+	for _, it := range items {
+		names = append(names, nameOf(it))
+	}
+	sort.Strings(names)
+	return strings.Join(names, ",")
 }
 
 // standaloneEnvVarNames returns the env-var names sorted and comma-joined, for
@@ -758,6 +812,8 @@ func (r *Neo4jEnterpriseStandaloneReconciler) reconcileStatefulSet(ctx context.C
 			//     otherwise an image/resource upgrade would drop them and the pod
 			//     would roll without the verified plugin JAR.
 			previousOwned := splitCSVSet(statefulSet.Annotations[standaloneOwnedEnvVarsAnnotation])
+			prevOwnedInit := splitCSVSet(statefulSet.Annotations[standaloneOwnedInitContainersAnnotation])
+			prevOwnedVolumes := splitCSVSet(statefulSet.Annotations[standaloneOwnedVolumesAnnotation])
 			currentEnv := []corev1.EnvVar{}
 			if len(statefulSet.Spec.Template.Spec.Containers) > 0 {
 				currentEnv = statefulSet.Spec.Template.Spec.Containers[0].Env
@@ -790,14 +846,14 @@ func (r *Neo4jEnterpriseStandaloneReconciler) reconcileStatefulSet(ctx context.C
 			if len(statefulSet.Spec.Template.Spec.Containers) > 0 {
 				statefulSet.Spec.Template.Spec.Containers[0].Env = mergedEnv
 			}
-			statefulSet.Spec.Template.Spec.InitContainers = mergeForeignByName(
-				currentInit, desiredTemplate.Spec.InitContainers,
+			statefulSet.Spec.Template.Spec.InitContainers = mergeOwnedByName(
+				currentInit, desiredTemplate.Spec.InitContainers, prevOwnedInit,
 				func(c corev1.Container) string { return c.Name })
-			statefulSet.Spec.Template.Spec.Volumes = mergeForeignByName(
-				currentVolumes, desiredTemplate.Spec.Volumes,
+			statefulSet.Spec.Template.Spec.Volumes = mergeOwnedByName(
+				currentVolumes, desiredTemplate.Spec.Volumes, prevOwnedVolumes,
 				func(v corev1.Volume) string { return v.Name })
 
-			r.stampStandaloneStatefulSetTracking(statefulSet, desiredHash, desiredEnv)
+			r.stampStandaloneStatefulSetTracking(statefulSet, desiredHash, desiredSpec.Template)
 			return nil
 		})
 		return err
@@ -811,14 +867,23 @@ func (r *Neo4jEnterpriseStandaloneReconciler) reconcileStatefulSet(ctx context.C
 }
 
 // stampStandaloneStatefulSetTracking records the desired template hash and the
-// operator-owned env-var names on the StatefulSet so the next reconcile can diff
-// against them (template-change detection + foreign-env preservation).
-func (r *Neo4jEnterpriseStandaloneReconciler) stampStandaloneStatefulSetTracking(sts *appsv1.StatefulSet, templateHash string, ownedEnv []corev1.EnvVar) {
+// operator-owned env-var / init-container / volume names on the StatefulSet so
+// the next reconcile can diff against them (template-change detection +
+// foreign-item preservation + owned-item removal). `desired` must be the
+// pristine operator-rendered template (desiredSpec.Template), not the merged
+// one — the annotations track what the operator OWNS, not what's live.
+func (r *Neo4jEnterpriseStandaloneReconciler) stampStandaloneStatefulSetTracking(sts *appsv1.StatefulSet, templateHash string, desired corev1.PodTemplateSpec) {
 	if sts.Annotations == nil {
 		sts.Annotations = map[string]string{}
 	}
+	var ownedEnv []corev1.EnvVar
+	if len(desired.Spec.Containers) > 0 {
+		ownedEnv = desired.Spec.Containers[0].Env
+	}
 	sts.Annotations[standaloneTemplateHashAnnotation] = templateHash
 	sts.Annotations[standaloneOwnedEnvVarsAnnotation] = standaloneEnvVarNames(ownedEnv)
+	sts.Annotations[standaloneOwnedInitContainersAnnotation] = sortedNamesCSV(desired.Spec.InitContainers, func(c corev1.Container) string { return c.Name })
+	sts.Annotations[standaloneOwnedVolumesAnnotation] = sortedNamesCSV(desired.Spec.Volumes, func(v corev1.Volume) string { return v.Name })
 }
 
 // reconcileNetworkPolicy reconciles the NetworkPolicy for the standalone

--- a/internal/controller/neo4jenterprisestandalone_controller.go
+++ b/internal/controller/neo4jenterprisestandalone_controller.go
@@ -18,6 +18,9 @@ package controller
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"sort"
@@ -224,7 +227,9 @@ func (r *Neo4jEnterpriseStandaloneReconciler) reconcileStandalone(ctx context.Co
 		}
 	}
 
-	// Reconcile ConfigMap (always needed for config)
+	// Reconcile ConfigMap (always needed for config). The standalone controller
+	// owns neo4j.conf (incl. plugin-derived settings) and rolls the pod itself
+	// when the rendered conf changes.
 	if err := r.reconcileConfigMap(ctx, standalone); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile ConfigMap: %w", err)
 	}
@@ -342,13 +347,29 @@ func (r *Neo4jEnterpriseStandaloneReconciler) reconcileStandalone(ctx context.Co
 // env-var ownership annotation (neo4j.com/cluster-controller-env-vars).
 const ownedStandaloneConfKeysAnnotation = "neo4j.com/standalone-controller-conf-keys"
 
-// reconcileConfigMap reconciles the ConfigMap for the standalone deployment.
+// reconcileConfigMap reconciles the standalone's ConfigMap. The standalone
+// controller is the single owner of neo4j.conf, folding in the UNION of every
+// Neo4jPlugin's derived settings for this standalone (#146) — so plugin keys are
+// rendered as operator-owned (and pruned when a plugin is uninstalled) rather
+// than patched in afterward by the plugin controller. When the rendered conf
+// actually changes, it rolls the pod (Neo4j only re-reads neo4j.conf at startup,
+// and a ConfigMap-only change doesn't otherwise restart it).
 func (r *Neo4jEnterpriseStandaloneReconciler) reconcileConfigMap(ctx context.Context, standalone *neo4jv1beta1.Neo4jEnterpriseStandalone) error {
 	logger := log.FromContext(ctx)
 
 	// Fully re-render the operator-owned config from spec each reconcile.
 	desired := r.createConfigMap(standalone)
 	desiredConf := desired.Data["neo4j.conf"]
+
+	// Fold in plugin-derived conf — the UNION across every Neo4jPlugin CR
+	// targeting this standalone — so the standalone controller is the single
+	// owner of neo4j.conf (issue #146). These keys become operator-owned (tracked
+	// in the annotation below), so an uninstalled plugin's keys are PRUNED on the
+	// next reconcile, and there's no after-the-fact ConfigMap patching by the
+	// plugin controller to fight with.
+	if pluginConf := r.collectPluginConfSettings(ctx, standalone); len(pluginConf) > 0 {
+		desiredConf = resources.DedupeNeo4jConf(resources.UpsertNeo4jConfSettings(desiredConf, pluginConf))
+	}
 	desiredKeys := resources.Neo4jConfSettings(desiredConf) // operator-owned keys this reconcile
 
 	configMap := &corev1.ConfigMap{
@@ -356,23 +377,33 @@ func (r *Neo4jEnterpriseStandaloneReconciler) reconcileConfigMap(ctx context.Con
 	}
 
 	// Create or update ConfigMap with retry logic to handle resource version conflicts.
+	var opResult controllerutil.OperationResult
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		_, err := controllerutil.CreateOrUpdate(ctx, r.Client, configMap, func() error {
+		var err error
+		opResult, err = controllerutil.CreateOrUpdate(ctx, r.Client, configMap, func() error {
 			// controllerutil.CreateOrUpdate's Get overwrites configMap with the
 			// EXISTING object, so the desired state MUST be (re)applied here in the
 			// mutate fn — an empty mutate would silently write the stale data back
 			// (the cause of stale spec.config keys never clearing on update).
 			prevOwned := splitCSVSet(configMap.Annotations[ownedStandaloneConfKeysAnnotation])
 
-			// Preserve foreign keys (e.g. a Neo4jPlugin's), but drop operator keys
-			// the user removed: a key the operator owned last time and no longer
-			// renders must not be resurrected from the existing ConfigMap.
+			// Decide which EXISTING conf keys to carry forward:
+			//   - operator-owned this reconcile (in desiredKeys): SKIP — desiredConf
+			//     already holds the authoritative value (scalar, or the additive
+			//     UNION computed from spec.config + all plugin CRs). Carrying the
+			//     existing value back would re-introduce stale additive tokens from
+			//     an uninstalled plugin, so the key would never prune.
+			//   - previously operator-owned but no longer (prevOwned ∖ desiredKeys):
+			//     SKIP — the user/plugin removed it; don't resurrect it.
+			//   - everything else: a genuinely FOREIGN key (added by some other
+			//     actor the operator doesn't manage) → preserve it.
 			mergeBack := make(map[string]string)
 			for k, v := range resources.Neo4jConfSettings(configMap.Data["neo4j.conf"]) {
+				if _, owned := desiredKeys[k]; owned {
+					continue
+				}
 				if _, wasOwned := prevOwned[k]; wasOwned {
-					if _, stillDesired := desiredKeys[k]; !stillDesired {
-						continue // operator key the user deleted — let it go
-					}
+					continue
 				}
 				mergeBack[k] = v
 			}
@@ -403,7 +434,50 @@ func (r *Neo4jEnterpriseStandaloneReconciler) reconcileConfigMap(ctx context.Con
 	}
 	logger.Info("Successfully created or updated ConfigMap", "name", configMap.Name)
 
+	// The rendered conf changed on an already-running standalone — roll the pod
+	// so Neo4j re-reads neo4j.conf. Covers user spec.config edits and any
+	// Neo4jPlugin add/change/remove (which now flows through this single owner).
+	// Skipped on create (the pod hasn't started yet).
+	if opResult == controllerutil.OperationResultUpdated {
+		if err := r.restartStandalonePod(ctx, standalone); err != nil {
+			logger.Error(err, "failed to roll standalone pod after config change")
+		}
+	}
+
 	return nil
+}
+
+// collectPluginConfSettings returns the union of neo4j.conf settings derived from
+// every enabled Neo4jPlugin targeting this standalone (#146). Non-fatal: a list
+// error yields no plugin settings rather than failing the reconcile.
+func (r *Neo4jEnterpriseStandaloneReconciler) collectPluginConfSettings(ctx context.Context, standalone *neo4jv1beta1.Neo4jEnterpriseStandalone) map[string]string {
+	plugins := &neo4jv1beta1.Neo4jPluginList{}
+	if err := r.List(ctx, plugins, client.InNamespace(standalone.Namespace)); err != nil {
+		log.FromContext(ctx).V(1).Info("Unable to list plugins for ConfigMap render; proceeding without plugin-derived config", "error", err)
+		return nil
+	}
+	return unionPluginConfSettings(plugins.Items, standalone.Name)
+}
+
+// restartStandalonePod rolls the standalone's pod by bumping a restart annotation
+// on the StatefulSet template, so Neo4j re-reads neo4j.conf after a config change.
+// Called only when the rendered conf actually changed (#146 makes config-change
+// restarts the standalone controller's responsibility, replacing the plugin
+// controller's per-plugin restart). Best-effort: a missing StatefulSet (not yet
+// created) is a no-op.
+func (r *Neo4jEnterpriseStandaloneReconciler) restartStandalonePod(ctx context.Context, standalone *neo4jv1beta1.Neo4jEnterpriseStandalone) error {
+	sts := &appsv1.StatefulSet{}
+	if err := r.Get(ctx, types.NamespacedName{Name: standalone.Name, Namespace: standalone.Namespace}, sts); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	if sts.Spec.Template.Annotations == nil {
+		sts.Spec.Template.Annotations = make(map[string]string)
+	}
+	sts.Spec.Template.Annotations["neo4j.com/config-restarted-at"] = time.Now().UTC().Format(time.RFC3339)
+	return r.Update(ctx, sts)
 }
 
 // splitCSVSet parses a comma-separated annotation value into a set.
@@ -522,7 +596,63 @@ func (r *Neo4jEnterpriseStandaloneReconciler) createHeadlessService(standalone *
 	}
 }
 
-// reconcileStatefulSet reconciles the StatefulSet for the standalone deployment
+// standaloneOwnedEnvVarsAnnotation lists the env-var names the standalone
+// controller rendered into the StatefulSet's neo4j container on the last
+// reconcile. It mirrors the cluster controller's neo4j.com/cluster-controller-
+// env-vars annotation and lets a subsequent reconcile drop a var the operator
+// stopped owning (e.g. a removed spec.config key) WITHOUT clobbering foreign
+// vars patched in by the plugin / fleet controllers (NEO4J_PLUGINS, fleet
+// token, APOC vars). See mergeEnvVars for the merge semantics.
+const standaloneOwnedEnvVarsAnnotation = "neo4j.com/standalone-controller-env-vars"
+
+// standaloneTemplateHashAnnotation stores a hash of the operator's DESIRED pod
+// template from the previous reconcile. reconcileStatefulSet applies the
+// desired template (image, resources, probes, env, volumes…) only when this
+// hash changes — comparing the operator's own desired-vs-last-desired rather
+// than desired-vs-server-state, so API-server field defaulting can't make every
+// reconcile look like a change and roll the pod in a loop.
+const standaloneTemplateHashAnnotation = "neo4j.com/standalone-template-hash"
+
+// standalonePodTemplateHash returns a stable hash of a pod template. JSON
+// marshalling sorts map keys, so the hash is deterministic across reconciles
+// for an unchanged template (no spurious rolls). Returns "" on the (practically
+// impossible) marshal error, which the caller treats as "changed" — converge
+// rather than silently skip.
+func standalonePodTemplateHash(t corev1.PodTemplateSpec) string {
+	data, err := json.Marshal(t)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+// standaloneEnvVarNames returns the env-var names sorted and comma-joined, for
+// the owned-env-vars annotation (stable so it doesn't churn the StatefulSet).
+func standaloneEnvVarNames(env []corev1.EnvVar) string {
+	names := make([]string, 0, len(env))
+	for _, e := range env {
+		names = append(names, e.Name)
+	}
+	sort.Strings(names)
+	return strings.Join(names, ",")
+}
+
+// reconcileStatefulSet reconciles the StatefulSet for the standalone deployment.
+//
+// CreateOrUpdate's Get overwrites the passed object with the EXISTING cluster
+// state on update, so the desired template MUST be (re)applied inside the mutate
+// fn. The previous empty mutate (`return nil`) meant template changes — image
+// upgrades, resource edits, probe/securityContext/volume changes, updateStrategy
+// switches — were silently written back as the stale stored spec and never rolled
+// to a running standalone (the upgrade event fired but no upgrade happened).
+//
+// To avoid rolling the pod on every reconcile (API-server field defaulting makes
+// a naive DeepEqual always differ), the desired template is applied only when its
+// hash differs from the hash recorded on the previous reconcile. Foreign env vars
+// (NEO4J_PLUGINS etc. patched by the plugin / fleet controllers) and foreign pod-
+// template annotations (the conf-path config-restart stamp, service-mesh
+// injection) are preserved across the apply.
 func (r *Neo4jEnterpriseStandaloneReconciler) reconcileStatefulSet(ctx context.Context, standalone *neo4jv1beta1.Neo4jEnterpriseStandalone) error {
 	logger := log.FromContext(ctx)
 
@@ -534,10 +664,72 @@ func (r *Neo4jEnterpriseStandaloneReconciler) reconcileStatefulSet(ctx context.C
 		return fmt.Errorf("failed to set owner reference: %w", err)
 	}
 
+	// Capture the desired spec + its template hash BEFORE CreateOrUpdate's Get
+	// clobbers `statefulSet` with the existing cluster object on update.
+	desiredSpec := *statefulSet.Spec.DeepCopy()
+	desiredHash := standalonePodTemplateHash(desiredSpec.Template)
+	desiredEnv := []corev1.EnvVar{}
+	if len(desiredSpec.Template.Spec.Containers) > 0 {
+		desiredEnv = desiredSpec.Template.Spec.Containers[0].Env
+	}
+
 	// Create or update StatefulSet with retry logic to handle resource version conflicts
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		_, err := controllerutil.CreateOrUpdate(ctx, r.Client, statefulSet, func() error {
-			// StatefulSet template updates for standalone deployments
+			// On update, CreateOrUpdate's Get has replaced `statefulSet` with the
+			// stored object (carrying our previously-stamped tracking annotations);
+			// on create it still holds the freshly-built desired object (no
+			// annotations yet). We branch on the template-hash annotation rather
+			// than UID: UID isn't populated by the fake client used in unit tests,
+			// and ResourceVersion is set even for new objects (so neither is a
+			// reliable create-vs-update signal here).
+
+			// Spec-level fields are cheap to set unconditionally — they don't roll
+			// pods on their own and CreateOrUpdate skips the Update when nothing
+			// changed. UpdateStrategy must apply so a Rolling↔Recreate switch takes
+			// effect; Replicas is always 1 for a standalone.
+			statefulSet.Spec.Replicas = desiredSpec.Replicas
+			statefulSet.Spec.UpdateStrategy = desiredSpec.UpdateStrategy
+
+			// Apply the desired template only when our desired hash differs from the
+			// hash recorded last reconcile. Matching hash → leave the stored template
+			// alone, preserving foreign env vars and the conf-path restart annotation,
+			// and CreateOrUpdate no-ops (no pod disruption). A missing annotation —
+			// create, or first reconcile after operator upgrade — is treated as
+			// changed so we converge (on create the template already equals desired,
+			// so the apply is a harmless no-op that just stamps the tracking).
+			if statefulSet.Annotations[standaloneTemplateHashAnnotation] == desiredHash {
+				return nil
+			}
+
+			// Apply the desired template, preserving:
+			//   - foreign env vars (plugin / fleet additions) via mergeEnvVars,
+			//     which also drops vars the operator previously owned but no longer
+			//     does (e.g. a removed spec.config key);
+			//   - foreign pod-template annotations (conf-path config-restart stamp,
+			//     mesh injection) by overlaying the desired annotations onto them.
+			previousOwned := splitCSVSet(statefulSet.Annotations[standaloneOwnedEnvVarsAnnotation])
+			currentEnv := []corev1.EnvVar{}
+			if len(statefulSet.Spec.Template.Spec.Containers) > 0 {
+				currentEnv = statefulSet.Spec.Template.Spec.Containers[0].Env
+			}
+			mergedEnv := mergeEnvVars(currentEnv, desiredEnv, previousOwned)
+
+			mergedAnnotations := map[string]string{}
+			for k, v := range statefulSet.Spec.Template.Annotations {
+				mergedAnnotations[k] = v
+			}
+			for k, v := range desiredSpec.Template.Annotations {
+				mergedAnnotations[k] = v
+			}
+
+			statefulSet.Spec.Template = *desiredSpec.Template.DeepCopy()
+			statefulSet.Spec.Template.Annotations = mergedAnnotations
+			if len(statefulSet.Spec.Template.Spec.Containers) > 0 {
+				statefulSet.Spec.Template.Spec.Containers[0].Env = mergedEnv
+			}
+
+			r.stampStandaloneStatefulSetTracking(statefulSet, desiredHash, desiredEnv)
 			return nil
 		})
 		return err
@@ -548,6 +740,17 @@ func (r *Neo4jEnterpriseStandaloneReconciler) reconcileStatefulSet(ctx context.C
 	logger.Info("Successfully created or updated StatefulSet", "name", statefulSet.Name)
 
 	return nil
+}
+
+// stampStandaloneStatefulSetTracking records the desired template hash and the
+// operator-owned env-var names on the StatefulSet so the next reconcile can diff
+// against them (template-change detection + foreign-env preservation).
+func (r *Neo4jEnterpriseStandaloneReconciler) stampStandaloneStatefulSetTracking(sts *appsv1.StatefulSet, templateHash string, ownedEnv []corev1.EnvVar) {
+	if sts.Annotations == nil {
+		sts.Annotations = map[string]string{}
+	}
+	sts.Annotations[standaloneTemplateHashAnnotation] = templateHash
+	sts.Annotations[standaloneOwnedEnvVarsAnnotation] = standaloneEnvVarNames(ownedEnv)
 }
 
 // reconcileNetworkPolicy reconciles the NetworkPolicy for the standalone
@@ -1840,7 +2043,22 @@ func (r *Neo4jEnterpriseStandaloneReconciler) SetupWithManager(mgr ctrl.Manager)
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.Service{}).
 		Owns(&corev1.ConfigMap{}).
-		Owns(&networkingv1.Ingress{})
+		Owns(&networkingv1.Ingress{}).
+		// A Neo4jPlugin's settings are folded into the standalone's neo4j.conf
+		// (the standalone controller is the single owner — issue #146), so
+		// re-reconcile the targeted standalone whenever a plugin is added,
+		// changed, or removed (so its keys are rendered or pruned).
+		Watches(&neo4jv1beta1.Neo4jPlugin{}, handler.EnqueueRequestsFromMapFunc(
+			func(_ context.Context, obj client.Object) []ctrl.Request {
+				plugin, ok := obj.(*neo4jv1beta1.Neo4jPlugin)
+				if !ok || plugin.Spec.ClusterRef == "" {
+					return nil
+				}
+				return []ctrl.Request{{NamespacedName: types.NamespacedName{
+					Namespace: plugin.Namespace,
+					Name:      plugin.Spec.ClusterRef,
+				}}}
+			}))
 
 	// Only watch Certificate resources if cert-manager is actually installed
 	// in the cluster. We check the REST mapper (real CRD presence) rather than

--- a/internal/controller/neo4jenterprisestandalone_controller.go
+++ b/internal/controller/neo4jenterprisestandalone_controller.go
@@ -441,17 +441,10 @@ func (r *Neo4jEnterpriseStandaloneReconciler) reconcileConfigMap(ctx context.Con
 	}
 	logger.Info("Successfully created or updated ConfigMap", "name", configMap.Name)
 
-	// Roll the pod when the rendered neo4j.conf changes so Neo4j re-reads it
-	// (it only reads conf at startup). Driven by a hash of the rendered conf
-	// stamped on the pod template — NOT by the ConfigMap's create/update result —
-	// so that a roll which FAILS to apply is retried on the next reconcile
-	// (the hash still differs) instead of leaving Neo4j on stale conf until the
-	// ConfigMap happens to change again. Idempotent: a matching hash is a no-op.
-	// The error is returned (requeue), not swallowed.
-	if err := r.ensureStandalonePodConfigHash(ctx, standalone, standaloneConfHash(configMap.Data["neo4j.conf"])); err != nil {
-		return fmt.Errorf("failed to roll standalone pod after config change: %w", err)
-	}
-
+	// Rolling the pod when neo4j.conf changes is handled by reconcileStatefulSet,
+	// which stamps a hash of the rendered conf onto the pod template so the roll
+	// flows through the normal template-apply path: present from pod creation (no
+	// deferred extra restart), retried on failure, idempotent when unchanged.
 	return nil
 }
 
@@ -493,30 +486,20 @@ func standaloneConfHash(conf string) string {
 	return hex.EncodeToString(sum[:])
 }
 
-// ensureStandalonePodConfigHash rolls the standalone's pod when the rendered conf
-// changes, by stamping confHash on the pod template. Idempotent (matching hash →
-// no-op), so it's safe to call every reconcile; the Update error is returned so a
-// failed roll requeues and is retried (#146 makes config-change rolls the
-// standalone controller's responsibility). A missing StatefulSet (pod not created
-// yet) is a no-op. Wrapped in RetryOnConflict for the read-modify-write.
-func (r *Neo4jEnterpriseStandaloneReconciler) ensureStandalonePodConfigHash(ctx context.Context, standalone *neo4jv1beta1.Neo4jEnterpriseStandalone, confHash string) error {
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		sts := &appsv1.StatefulSet{}
-		if err := r.Get(ctx, types.NamespacedName{Name: standalone.Name, Namespace: standalone.Namespace}, sts); err != nil {
-			if errors.IsNotFound(err) {
-				return nil
-			}
-			return err
-		}
-		if sts.Spec.Template.Annotations[standaloneConfigHashAnnotation] == confHash {
-			return nil
-		}
-		if sts.Spec.Template.Annotations == nil {
-			sts.Spec.Template.Annotations = make(map[string]string)
-		}
-		sts.Spec.Template.Annotations[standaloneConfigHashAnnotation] = confHash
-		return r.Update(ctx, sts)
-	})
+// renderedConfHash reads the standalone's ConfigMap and returns a stable hash of
+// its neo4j.conf, for stamping onto the pod template (see reconcileStatefulSet).
+// Returns "" when the ConfigMap or its neo4j.conf isn't present yet — the caller
+// then skips the stamp rather than rolling on a transient absence.
+func (r *Neo4jEnterpriseStandaloneReconciler) renderedConfHash(ctx context.Context, standalone *neo4jv1beta1.Neo4jEnterpriseStandalone) string {
+	cm := &corev1.ConfigMap{}
+	if err := r.Get(ctx, types.NamespacedName{Name: standalone.Name + "-config", Namespace: standalone.Namespace}, cm); err != nil {
+		return ""
+	}
+	conf := cm.Data["neo4j.conf"]
+	if conf == "" {
+		return ""
+	}
+	return standaloneConfHash(conf)
 }
 
 // splitCSVSet parses a comma-separated annotation value into a set.
@@ -755,6 +738,21 @@ func (r *Neo4jEnterpriseStandaloneReconciler) reconcileStatefulSet(ctx context.C
 
 	// Create StatefulSet using the standalone configuration
 	statefulSet := r.createStatefulSet(standalone)
+
+	// Stamp a hash of the rendered neo4j.conf onto the desired pod template so a
+	// conf change rolls the pod through the NORMAL template-apply path below
+	// (Neo4j only reads conf at startup). Doing it here — rather than as a
+	// separate post-hoc StatefulSet update — means the hash is present from pod
+	// creation (no deferred extra restart) and the roll inherits the apply path's
+	// every-reconcile, hash-gated, error-returning retry. reconcileConfigMap has
+	// already written the ConfigMap this reconcile (it runs first), so the conf
+	// is available; an absent ConfigMap (shouldn't happen) just skips the stamp.
+	if confHash := r.renderedConfHash(ctx, standalone); confHash != "" {
+		if statefulSet.Spec.Template.Annotations == nil {
+			statefulSet.Spec.Template.Annotations = map[string]string{}
+		}
+		statefulSet.Spec.Template.Annotations[standaloneConfigHashAnnotation] = confHash
+	}
 
 	// Set owner reference
 	if err := controllerutil.SetControllerReference(standalone, statefulSet, r.Scheme); err != nil {

--- a/internal/controller/neo4jenterprisestandalone_statefulset_test.go
+++ b/internal/controller/neo4jenterprisestandalone_statefulset_test.go
@@ -243,3 +243,63 @@ func hasEnvVarName(env []corev1.EnvVar, name string) bool {
 	}
 	return false
 }
+
+// TestReconcileStatefulSet_PreservesForeignInitContainersAndVolumes: the plugin
+// controller's VerifiedDownload mode patches an init container (and auth/CA
+// volumes) onto the StatefulSet. A template-changing reconcile (image bump) must
+// preserve them by name — otherwise the upgraded pod rolls without the verified
+// plugin JAR. Regression for Bugbot "Template apply drops plugin inits".
+func TestReconcileStatefulSet_PreservesForeignInitContainersAndVolumes(t *testing.T) {
+	r, _ := standaloneCMTestReconciler(t)
+	ctx := context.Background()
+
+	sa := standaloneForSTS("5.26.0-enterprise")
+	if err := r.reconcileStatefulSet(ctx, sa); err != nil {
+		t.Fatalf("reconcile 1: %v", err)
+	}
+
+	// Simulate the plugin controller injecting a verified-download init container
+	// plus its volume, exactly as injectVerifiedDownloadInitContainer does.
+	sts := getSTS(t, r)
+	sts.Spec.Template.Spec.InitContainers = append(sts.Spec.Template.Spec.InitContainers,
+		corev1.Container{Name: "plugin-download-gds", Image: "plugin-init:latest"})
+	sts.Spec.Template.Spec.Volumes = append(sts.Spec.Template.Spec.Volumes,
+		corev1.Volume{Name: "plugin-auth-gds", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}})
+	if err := r.Update(ctx, sts); err != nil {
+		t.Fatalf("inject foreign init/volume: %v", err)
+	}
+
+	// Image bump → template apply.
+	sa.Spec.Image.Tag = "2025.01.0-enterprise"
+	if err := r.reconcileStatefulSet(ctx, sa); err != nil {
+		t.Fatalf("reconcile 2: %v", err)
+	}
+	sts = getSTS(t, r)
+	if got := neo4jContainerImage(sts); got != "neo4j:2025.01.0-enterprise" {
+		t.Errorf("image not upgraded: %q", got)
+	}
+	if !hasInitContainer(sts.Spec.Template.Spec.InitContainers, "plugin-download-gds") {
+		t.Errorf("foreign init container was dropped: %+v", sts.Spec.Template.Spec.InitContainers)
+	}
+	if !hasVolume(sts.Spec.Template.Spec.Volumes, "plugin-auth-gds") {
+		t.Errorf("foreign volume was dropped: %+v", sts.Spec.Template.Spec.Volumes)
+	}
+}
+
+func hasInitContainer(cs []corev1.Container, name string) bool {
+	for _, c := range cs {
+		if c.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func hasVolume(vs []corev1.Volume, name string) bool {
+	for _, v := range vs {
+		if v.Name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/controller/neo4jenterprisestandalone_statefulset_test.go
+++ b/internal/controller/neo4jenterprisestandalone_statefulset_test.go
@@ -286,6 +286,47 @@ func TestReconcileStatefulSet_PreservesForeignInitContainersAndVolumes(t *testin
 	}
 }
 
+// TestReconcileStatefulSet_MonitoringOffRemovesScrapeAnnotations: disabling
+// spec.monitoring must remove the operator-managed prometheus.io/* pod-template
+// annotations (not leave them scraping a port that's gone), while preserving
+// foreign annotations. Regression for Bugbot "Monitoring off keeps scrape
+// annotations".
+func TestReconcileStatefulSet_MonitoringOffRemovesScrapeAnnotations(t *testing.T) {
+	r, _ := standaloneCMTestReconciler(t)
+	ctx := context.Background()
+
+	sa := standaloneForSTS("5.26.0-enterprise")
+	sa.Spec.Monitoring = &neo4jv1beta1.MonitoringSpec{Enabled: true}
+	if err := r.reconcileStatefulSet(ctx, sa); err != nil {
+		t.Fatalf("reconcile 1: %v", err)
+	}
+	sts := getSTS(t, r)
+	if sts.Spec.Template.Annotations["prometheus.io/scrape"] != "true" {
+		t.Fatalf("expected prometheus.io/scrape=true with monitoring on; got %+v", sts.Spec.Template.Annotations)
+	}
+
+	// Stamp a foreign annotation (as the conf-restart path would).
+	sts.Spec.Template.Annotations["neo4j.com/config-restarted-at"] = "2026-06-10T00:00:00Z"
+	if err := r.Update(ctx, sts); err != nil {
+		t.Fatalf("stamp foreign annotation: %v", err)
+	}
+
+	// Disable monitoring → template changes (annotations + metrics port) → apply.
+	sa.Spec.Monitoring.Enabled = false
+	if err := r.reconcileStatefulSet(ctx, sa); err != nil {
+		t.Fatalf("reconcile 2: %v", err)
+	}
+	sts = getSTS(t, r)
+	for _, k := range []string{"prometheus.io/scrape", "prometheus.io/port", "prometheus.io/path"} {
+		if _, ok := sts.Spec.Template.Annotations[k]; ok {
+			t.Errorf("%s should be removed after monitoring disabled; got %+v", k, sts.Spec.Template.Annotations)
+		}
+	}
+	if sts.Spec.Template.Annotations["neo4j.com/config-restarted-at"] != "2026-06-10T00:00:00Z" {
+		t.Errorf("foreign annotation must be preserved across the apply; got %+v", sts.Spec.Template.Annotations)
+	}
+}
+
 func hasInitContainer(cs []corev1.Container, name string) bool {
 	for _, c := range cs {
 		if c.Name == name {

--- a/internal/controller/neo4jenterprisestandalone_statefulset_test.go
+++ b/internal/controller/neo4jenterprisestandalone_statefulset_test.go
@@ -327,6 +327,52 @@ func TestReconcileStatefulSet_MonitoringOffRemovesScrapeAnnotations(t *testing.T
 	}
 }
 
+// TestReconcileStatefulSet_RemovedOwnedInitContainerDropped: an init container
+// the operator used to render but no longer does (the truststore-init once
+// spec.trustedCASecrets is cleared) must be DROPPED on the next apply — not
+// mistaken for a foreign item and re-appended. A genuinely foreign init (the
+// plugin controller's) must still survive. Regression for Bugbot "Removed
+// truststore inits kept foreign".
+func TestReconcileStatefulSet_RemovedOwnedInitContainerDropped(t *testing.T) {
+	r, _ := standaloneCMTestReconciler(t)
+	ctx := context.Background()
+
+	sa := standaloneForSTS("5.26.0-enterprise")
+	sa.Spec.TrustedCASecrets = []neo4jv1beta1.TrustedCASecret{{Name: "corp-ca"}}
+	if err := r.reconcileStatefulSet(ctx, sa); err != nil {
+		t.Fatalf("reconcile 1: %v", err)
+	}
+	sts := getSTS(t, r)
+	if !hasInitContainer(sts.Spec.Template.Spec.InitContainers, "truststore-init") {
+		t.Fatalf("expected operator-owned truststore-init with trustedCASecrets set; got %+v", sts.Spec.Template.Spec.InitContainers)
+	}
+
+	// Simulate the plugin controller injecting a foreign init container + volume.
+	sts.Spec.Template.Spec.InitContainers = append(sts.Spec.Template.Spec.InitContainers,
+		corev1.Container{Name: "plugin-download-gds", Image: "plugin-init:latest"})
+	sts.Spec.Template.Spec.Volumes = append(sts.Spec.Template.Spec.Volumes,
+		corev1.Volume{Name: "plugin-auth-gds", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}})
+	if err := r.Update(ctx, sts); err != nil {
+		t.Fatalf("inject foreign init/volume: %v", err)
+	}
+
+	// Clear trustedCASecrets → operator no longer renders truststore-init.
+	sa.Spec.TrustedCASecrets = nil
+	if err := r.reconcileStatefulSet(ctx, sa); err != nil {
+		t.Fatalf("reconcile 2: %v", err)
+	}
+	sts = getSTS(t, r)
+	if hasInitContainer(sts.Spec.Template.Spec.InitContainers, "truststore-init") {
+		t.Errorf("operator-owned truststore-init should be dropped after trustedCASecrets cleared; got %+v", sts.Spec.Template.Spec.InitContainers)
+	}
+	if !hasInitContainer(sts.Spec.Template.Spec.InitContainers, "plugin-download-gds") {
+		t.Errorf("foreign init container must be preserved; got %+v", sts.Spec.Template.Spec.InitContainers)
+	}
+	if !hasVolume(sts.Spec.Template.Spec.Volumes, "plugin-auth-gds") {
+		t.Errorf("foreign volume must be preserved; got %+v", sts.Spec.Template.Spec.Volumes)
+	}
+}
+
 func hasInitContainer(cs []corev1.Container, name string) bool {
 	for _, c := range cs {
 		if c.Name == name {

--- a/internal/controller/neo4jenterprisestandalone_statefulset_test.go
+++ b/internal/controller/neo4jenterprisestandalone_statefulset_test.go
@@ -1,0 +1,245 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
+)
+
+// standaloneForSTS builds a minimal standalone with the fields createStatefulSet
+// needs (Image + Storage.Size — the latter is MustParse'd so it can't be empty).
+func standaloneForSTS(tag string) *neo4jv1beta1.Neo4jEnterpriseStandalone {
+	return &neo4jv1beta1.Neo4jEnterpriseStandalone{
+		ObjectMeta: metav1.ObjectMeta{Name: "sa", Namespace: "default"},
+		Spec: neo4jv1beta1.Neo4jEnterpriseStandaloneSpec{
+			Image:   neo4jv1beta1.ImageSpec{Repo: "neo4j", Tag: tag},
+			Storage: neo4jv1beta1.StorageSpec{Size: "1Gi"},
+		},
+	}
+}
+
+func getSTS(t *testing.T, r *Neo4jEnterpriseStandaloneReconciler) *appsv1.StatefulSet {
+	t.Helper()
+	sts := &appsv1.StatefulSet{}
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "sa", Namespace: "default"}, sts); err != nil {
+		t.Fatalf("get statefulset: %v", err)
+	}
+	return sts
+}
+
+func neo4jContainerImage(sts *appsv1.StatefulSet) string {
+	for _, c := range sts.Spec.Template.Spec.Containers {
+		if c.Name == "neo4j" {
+			return c.Image
+		}
+	}
+	return ""
+}
+
+// TestReconcileStatefulSet_ImageUpgradeApplies is the core regression for the
+// latent empty-mutate bug: changing spec.Image.Tag must roll the new image to a
+// running standalone. The old `CreateOrUpdate(..., func() error { return nil })`
+// let Get write the stale stored template back, so image upgrades silently never
+// applied (the upgrade event fired but no upgrade happened).
+func TestReconcileStatefulSet_ImageUpgradeApplies(t *testing.T) {
+	r, _ := standaloneCMTestReconciler(t)
+	ctx := context.Background()
+
+	sa := standaloneForSTS("5.26.0-enterprise")
+	if err := r.reconcileStatefulSet(ctx, sa); err != nil {
+		t.Fatalf("reconcile 1: %v", err)
+	}
+	if got := neo4jContainerImage(getSTS(t, r)); got != "neo4j:5.26.0-enterprise" {
+		t.Fatalf("after create, image = %q, want neo4j:5.26.0-enterprise", got)
+	}
+
+	// User bumps the tag.
+	sa.Spec.Image.Tag = "2025.01.0-enterprise"
+	if err := r.reconcileStatefulSet(ctx, sa); err != nil {
+		t.Fatalf("reconcile 2: %v", err)
+	}
+	if got := neo4jContainerImage(getSTS(t, r)); got != "neo4j:2025.01.0-enterprise" {
+		t.Errorf("after upgrade, image = %q, want neo4j:2025.01.0-enterprise", got)
+	}
+}
+
+// TestReconcileStatefulSet_ResourcesChangeApplies: a resources edit must reach a
+// running standalone (another field the empty mutate silently dropped).
+func TestReconcileStatefulSet_ResourcesChangeApplies(t *testing.T) {
+	r, _ := standaloneCMTestReconciler(t)
+	ctx := context.Background()
+
+	sa := standaloneForSTS("5.26.0-enterprise")
+	if err := r.reconcileStatefulSet(ctx, sa); err != nil {
+		t.Fatalf("reconcile 1: %v", err)
+	}
+
+	sa.Spec.Resources = &corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("2Gi")},
+	}
+	if err := r.reconcileStatefulSet(ctx, sa); err != nil {
+		t.Fatalf("reconcile 2: %v", err)
+	}
+	sts := getSTS(t, r)
+	got := sts.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory]
+	if got.String() != "2Gi" {
+		t.Errorf("memory request = %q, want 2Gi", got.String())
+	}
+}
+
+// TestReconcileStatefulSet_PreservesForeignEnvVars: an env var patched onto the
+// StatefulSet by another controller (the plugin controller adds NEO4J_PLUGINS
+// directly) must survive a template-changing reconcile. Mirrors the cluster
+// controller's mergeEnvVars + ownership-annotation contract.
+func TestReconcileStatefulSet_PreservesForeignEnvVars(t *testing.T) {
+	r, _ := standaloneCMTestReconciler(t)
+	ctx := context.Background()
+
+	sa := standaloneForSTS("5.26.0-enterprise")
+	if err := r.reconcileStatefulSet(ctx, sa); err != nil {
+		t.Fatalf("reconcile 1: %v", err)
+	}
+
+	// Simulate the plugin controller patching NEO4J_PLUGINS onto the container.
+	sts := getSTS(t, r)
+	sts.Spec.Template.Spec.Containers[0].Env = append(sts.Spec.Template.Spec.Containers[0].Env,
+		corev1.EnvVar{Name: "NEO4J_PLUGINS", Value: `["apoc"]`})
+	if err := r.Update(ctx, sts); err != nil {
+		t.Fatalf("patch foreign env: %v", err)
+	}
+
+	// A template-changing reconcile (image bump) must keep the foreign var.
+	sa.Spec.Image.Tag = "2025.01.0-enterprise"
+	if err := r.reconcileStatefulSet(ctx, sa); err != nil {
+		t.Fatalf("reconcile 2: %v", err)
+	}
+	sts = getSTS(t, r)
+	if got := neo4jContainerImage(sts); got != "neo4j:2025.01.0-enterprise" {
+		t.Errorf("image not upgraded: %q", got)
+	}
+	if !hasEnvVar(sts.Spec.Template.Spec.Containers[0].Env, "NEO4J_PLUGINS", `["apoc"]`) {
+		t.Errorf("foreign NEO4J_PLUGINS env var was clobbered: %+v", sts.Spec.Template.Spec.Containers[0].Env)
+	}
+}
+
+// TestReconcileStatefulSet_IdempotentNoChurn: reconciling with no spec change
+// must not write the StatefulSet again (no ResourceVersion bump → no pod roll).
+// The template-hash gate is what prevents API-server field defaulting from
+// making every reconcile look like a change.
+func TestReconcileStatefulSet_IdempotentNoChurn(t *testing.T) {
+	r, _ := standaloneCMTestReconciler(t)
+	ctx := context.Background()
+
+	sa := standaloneForSTS("5.26.0-enterprise")
+	if err := r.reconcileStatefulSet(ctx, sa); err != nil {
+		t.Fatalf("reconcile 1: %v", err)
+	}
+	rv1 := getSTS(t, r).ResourceVersion
+
+	if err := r.reconcileStatefulSet(ctx, sa); err != nil {
+		t.Fatalf("reconcile 2: %v", err)
+	}
+	rv2 := getSTS(t, r).ResourceVersion
+	if rv1 != rv2 {
+		t.Errorf("StatefulSet churned on a no-op reconcile: rv %s -> %s", rv1, rv2)
+	}
+}
+
+// TestReconcileStatefulSet_PreservesConfigRestartAnnotation: the conf-path roll
+// stamp (neo4j.com/config-restarted-at, applied by restartStandalonePod after a
+// neo4j.conf change) lives on the pod-template annotations. A later template
+// apply (image bump) must NOT wipe it, or the conf-driven pod roll would be
+// undone within the same reconcile loop.
+func TestReconcileStatefulSet_PreservesConfigRestartAnnotation(t *testing.T) {
+	r, _ := standaloneCMTestReconciler(t)
+	ctx := context.Background()
+
+	sa := standaloneForSTS("5.26.0-enterprise")
+	if err := r.reconcileStatefulSet(ctx, sa); err != nil {
+		t.Fatalf("reconcile 1: %v", err)
+	}
+
+	// Simulate the conf path stamping a restart annotation on the template.
+	sts := getSTS(t, r)
+	if sts.Spec.Template.Annotations == nil {
+		sts.Spec.Template.Annotations = map[string]string{}
+	}
+	sts.Spec.Template.Annotations["neo4j.com/config-restarted-at"] = "2026-06-10T00:00:00Z"
+	if err := r.Update(ctx, sts); err != nil {
+		t.Fatalf("stamp restart annotation: %v", err)
+	}
+
+	sa.Spec.Image.Tag = "2025.01.0-enterprise"
+	if err := r.reconcileStatefulSet(ctx, sa); err != nil {
+		t.Fatalf("reconcile 2: %v", err)
+	}
+	sts = getSTS(t, r)
+	if sts.Spec.Template.Annotations["neo4j.com/config-restarted-at"] != "2026-06-10T00:00:00Z" {
+		t.Errorf("config-restart annotation was wiped by the template apply: %+v", sts.Spec.Template.Annotations)
+	}
+}
+
+// TestReconcileStatefulSet_RemovedOwnedEnvVarDropped: a var the operator owned
+// last reconcile but no longer renders must be removed (the removal half of the
+// ownership contract), without disturbing foreign vars.
+func TestReconcileStatefulSet_RemovedOwnedEnvVarDropped(t *testing.T) {
+	r, _ := standaloneCMTestReconciler(t)
+	ctx := context.Background()
+
+	sa := standaloneForSTS("5.26.0-enterprise")
+	if err := r.reconcileStatefulSet(ctx, sa); err != nil {
+		t.Fatalf("reconcile 1: %v", err)
+	}
+
+	// Forge an owned-env annotation claiming the operator rendered OWNED_GONE,
+	// and put it (plus a foreign var) on the container — as if a prior version
+	// had rendered it. The next reconcile's desired set won't contain it.
+	sts := getSTS(t, r)
+	sts.Spec.Template.Spec.Containers[0].Env = append(sts.Spec.Template.Spec.Containers[0].Env,
+		corev1.EnvVar{Name: "OWNED_GONE", Value: "stale"},
+		corev1.EnvVar{Name: "NEO4J_PLUGINS", Value: `["apoc"]`})
+	existing := sts.Annotations[standaloneOwnedEnvVarsAnnotation]
+	sts.Annotations[standaloneOwnedEnvVarsAnnotation] = existing + ",OWNED_GONE"
+	// Force the template hash stale so the apply branch runs.
+	sts.Annotations[standaloneTemplateHashAnnotation] = "stale"
+	if err := r.Update(ctx, sts); err != nil {
+		t.Fatalf("seed owned/foreign env: %v", err)
+	}
+
+	if err := r.reconcileStatefulSet(ctx, sa); err != nil {
+		t.Fatalf("reconcile 2: %v", err)
+	}
+	sts = getSTS(t, r)
+	env := sts.Spec.Template.Spec.Containers[0].Env
+	if hasEnvVarName(env, "OWNED_GONE") {
+		t.Errorf("previously-owned OWNED_GONE should have been dropped: %+v", env)
+	}
+	if !hasEnvVar(env, "NEO4J_PLUGINS", `["apoc"]`) {
+		t.Errorf("foreign NEO4J_PLUGINS should have been preserved: %+v", env)
+	}
+}
+
+func hasEnvVar(env []corev1.EnvVar, name, value string) bool {
+	for _, e := range env {
+		if e.Name == name && e.Value == value {
+			return true
+		}
+	}
+	return false
+}
+
+func hasEnvVarName(env []corev1.EnvVar, name string) bool {
+	for _, e := range env {
+		if e.Name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/controller/neo4jenterprisestandalone_statefulset_test.go
+++ b/internal/controller/neo4jenterprisestandalone_statefulset_test.go
@@ -373,6 +373,53 @@ func TestReconcileStatefulSet_RemovedOwnedInitContainerDropped(t *testing.T) {
 	}
 }
 
+// TestReconcileStatefulSet_ConfigHashStampedAndRollsOnConfChange: the rendered
+// neo4j.conf hash is stamped on the pod template at CREATION (so there's no
+// deferred extra restart — Bugbot "Config hash deferred extra restart"), an
+// unchanged conf doesn't churn the StatefulSet, and a conf change flips the hash
+// (rolling the pod through the normal template-apply path).
+func TestReconcileStatefulSet_ConfigHashStampedAndRollsOnConfChange(t *testing.T) {
+	r, _ := standaloneCMTestReconciler(t)
+	ctx := context.Background()
+
+	sa := standaloneForSTS("5.26.0-enterprise")
+	sa.Spec.Config = map[string]string{"db.transaction.timeout": "30s"}
+
+	// ConfigMap first (reconcileStatefulSet reads it for the conf hash), as the
+	// reconcile loop orders them.
+	if err := r.reconcileConfigMap(ctx, sa); err != nil {
+		t.Fatalf("configmap 1: %v", err)
+	}
+	if err := r.reconcileStatefulSet(ctx, sa); err != nil {
+		t.Fatalf("sts create: %v", err)
+	}
+	h1 := getSTS(t, r).Spec.Template.Annotations[standaloneConfigHashAnnotation]
+	if h1 == "" {
+		t.Fatal("config-hash must be stamped on the StatefulSet at creation (no deferred roll)")
+	}
+
+	// Unchanged conf → no churn (no spurious roll).
+	rv := getSTS(t, r).ResourceVersion
+	if err := r.reconcileStatefulSet(ctx, sa); err != nil {
+		t.Fatalf("sts idempotent: %v", err)
+	}
+	if getSTS(t, r).ResourceVersion != rv {
+		t.Errorf("unchanged conf should not churn the StatefulSet (rv changed from %s)", rv)
+	}
+
+	// Change conf → re-render ConfigMap → STS config-hash changes (pod rolls).
+	sa.Spec.Config["db.transaction.timeout"] = "90s"
+	if err := r.reconcileConfigMap(ctx, sa); err != nil {
+		t.Fatalf("configmap 2: %v", err)
+	}
+	if err := r.reconcileStatefulSet(ctx, sa); err != nil {
+		t.Fatalf("sts roll: %v", err)
+	}
+	if h2 := getSTS(t, r).Spec.Template.Annotations[standaloneConfigHashAnnotation]; h2 == h1 {
+		t.Errorf("config-hash should change when neo4j.conf changes; still %s", h2)
+	}
+}
+
 func hasInitContainer(cs []corev1.Container, name string) bool {
 	for _, c := range cs {
 		if c.Name == name {

--- a/internal/controller/plugin_conf_settings.go
+++ b/internal/controller/plugin_conf_settings.go
@@ -1,0 +1,102 @@
+package controller
+
+import (
+	"sort"
+	"strings"
+
+	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
+	"github.com/neo4j-partners/neo4j-kubernetes-operator/internal/resources"
+)
+
+// Plugin-derived neo4j.conf settings, factored into one place so the standalone
+// controller (which OWNS the ConfigMap) and the plugin controller agree on the
+// exact set. The standalone controller computes the UNION across all of a
+// target's Neo4jPlugin CRs and renders it as part of neo4j.conf — making those
+// keys operator-owned (tracked by the conf-keys ownership annotation), so they
+// are pruned when a plugin is uninstalled, with no after-the-fact patching of
+// the ConfigMap the standalone controller rebuilds (issue #146).
+
+// automaticPluginSecuritySettings returns the neo4j.conf security settings a
+// plugin requires to function (procedure allowlists, HTTP auth allowlist,
+// unmanaged extension classes). Receiver-free so both controllers can call it.
+func automaticPluginSecuritySettings(pluginName string) map[string]string {
+	settings := make(map[string]string)
+	switch pluginName {
+	case "bloom":
+		settings["dbms.security.procedures.unrestricted"] = "bloom.*"
+		settings["dbms.security.http_auth_allowlist"] = "/,/browser.*,/bloom.*"
+		settings["server.unmanaged_extension_classes"] = "com.neo4j.bloom.server=/bloom"
+	case "graph-data-science", "gds":
+		settings["dbms.security.procedures.unrestricted"] = "gds.*,apoc.load.*"
+	case "fleet-management":
+		settings["dbms.security.procedures.unrestricted"] = "fleetManagement.*"
+		settings["dbms.security.procedures.allowlist"] = "fleetManagement.*"
+	}
+	return settings
+}
+
+// pluginConfKeyIsNonDynamic reports whether a setting must be present in
+// neo4j.conf at startup (it can't be set dynamically).
+func pluginConfKeyIsNonDynamic(key string) bool {
+	switch key {
+	case "gds.enterprise.license_file",
+		"dbms.bloom.license_file",
+		"dbms.security.procedures.allowlist",
+		"dbms.security.procedures.denylist",
+		"dbms.security.procedures.unrestricted":
+		return true
+	}
+	return false
+}
+
+// pluginConfKeyIsSecurity reports whether a key is a security setting that must
+// be applied via neo4j.conf at startup.
+func pluginConfKeyIsSecurity(key string) bool {
+	return strings.HasPrefix(key, "dbms.security.") ||
+		strings.HasPrefix(key, "server.unmanaged_extension_classes") ||
+		strings.HasPrefix(key, "dbms.bloom.")
+}
+
+// pluginConfSettings returns the neo4j.conf settings derived from a single
+// Neo4jPlugin: its automatic security settings plus any non-dynamic/security
+// keys the user set in spec.config (user values override the automatic ones).
+func pluginConfSettings(plugin *neo4jv1beta1.Neo4jPlugin) map[string]string {
+	settings := make(map[string]string)
+	for k, v := range automaticPluginSecuritySettings(plugin.Spec.Name) {
+		settings[k] = v
+	}
+	for k, v := range plugin.Spec.Config {
+		if pluginConfKeyIsNonDynamic(k) || pluginConfKeyIsSecurity(k) {
+			settings[k] = v
+		}
+	}
+	return settings
+}
+
+// unionPluginConfSettings merges the conf settings of every enabled Neo4jPlugin
+// targeting targetRef. Additive keys (procedure allowlists, http_auth_allowlist)
+// are unioned across plugins (so GDS + APOC keep both token sets); other keys
+// take the last value in plugin-name order (deterministic). Plugins are sorted
+// by name so the result is stable between reconciles (no ConfigMap churn).
+func unionPluginConfSettings(plugins []neo4jv1beta1.Neo4jPlugin, targetRef string) map[string]string {
+	sorted := make([]*neo4jv1beta1.Neo4jPlugin, 0, len(plugins))
+	for i := range plugins {
+		p := &plugins[i]
+		if p.Spec.ClusterRef == targetRef && p.Spec.Enabled {
+			sorted = append(sorted, p)
+		}
+	}
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Name < sorted[j].Name })
+
+	out := make(map[string]string)
+	for _, p := range sorted {
+		for k, v := range pluginConfSettings(p) {
+			if existing, ok := out[k]; ok && resources.IsAdditiveConfKey(k) {
+				out[k] = resources.MergeConfListValues(existing, v)
+			} else {
+				out[k] = v
+			}
+		}
+	}
+	return out
+}

--- a/internal/controller/plugin_controller.go
+++ b/internal/controller/plugin_controller.go
@@ -274,16 +274,13 @@ func (r *Neo4jPluginReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, nil // Don't return error - status is set correctly
 	}
 
-	// Apply ConfigMap-based configurations first (before checking connectivity)
-	// This is critical for security settings that need to be in place before Neo4j starts
-	if deployment.Type == "standalone" {
-		if err := r.updateStandaloneConfigMapForPlugin(ctx, plugin, deployment); err != nil {
-			logger.Error(err, "Failed to update ConfigMap for standalone deployment", "plugin", plugin.Spec.Name)
-			r.updatePluginStatus(ctx, plugin, "Failed", fmt.Sprintf("Failed to update ConfigMap: %v", err))
-			return ctrl.Result{}, nil
-		}
-		logger.Info("Successfully updated ConfigMap for standalone deployment", "plugin", plugin.Spec.Name)
-	}
+	// Standalone neo4j.conf (plugin security settings) is owned by the standalone
+	// controller, which folds in the union of all Neo4jPlugin CRs for the target
+	// and rolls the pod on change (issue #146). It watches Neo4jPlugin, so creating
+	// this CR triggers that reconcile — the plugin controller no longer patches the
+	// standalone's ConfigMap here (that caused a two-controller tug-of-war and left
+	// uninstalled plugins' keys behind). NEO4J_PLUGINS env + init containers below
+	// are still managed here.
 
 	// Check if deployment is actually functional, not just status reporting
 	if !r.isDeploymentFunctional(ctx, deployment) {
@@ -1403,118 +1400,6 @@ func formatPluginInitOwned(set map[string]struct{}) string {
 	return strings.Join(names, ",")
 }
 
-// updateStandaloneConfigMapForPlugin updates the ConfigMap for standalone deployments with plugin security settings
-func (r *Neo4jPluginReconciler) updateStandaloneConfigMapForPlugin(ctx context.Context, plugin *neo4jv1beta1.Neo4jPlugin, deployment *DeploymentInfo) error {
-	logger := log.FromContext(ctx)
-
-	// Get automatic security settings for this plugin
-	automaticSettings := r.getAutomaticSecuritySettings(plugin.Spec.Name)
-
-	// Get user-provided non-dynamic settings that must be applied at startup
-	nonDynamicUserSettings := make(map[string]string)
-	for key, value := range plugin.Spec.Config {
-		// Include settings that are non-dynamic and must be in neo4j.conf at startup
-		if r.isNonDynamicSetting(key) || r.isSecuritySetting(key) {
-			nonDynamicUserSettings[key] = value
-		}
-	}
-
-	// Combine automatic and user-provided settings
-	allSettings := make(map[string]string)
-	for key, value := range automaticSettings {
-		allSettings[key] = value
-	}
-	for key, value := range nonDynamicUserSettings {
-		allSettings[key] = value // User settings can override automatic ones
-	}
-
-	if len(allSettings) == 0 {
-		logger.Info("No ConfigMap settings required for plugin", "plugin", plugin.Spec.Name)
-		return nil
-	}
-
-	// Get the standalone resource
-	standalone, ok := deployment.Object.(*neo4jv1beta1.Neo4jEnterpriseStandalone)
-	if !ok {
-		return fmt.Errorf("deployment typed as standalone but object is %T", deployment.Object)
-	}
-
-	// Get the ConfigMap name for the standalone
-	configMapName := fmt.Sprintf("%s-config", standalone.Name)
-	configMapKey := types.NamespacedName{
-		Namespace: standalone.Namespace,
-		Name:      configMapName,
-	}
-
-	// Retrieve the current ConfigMap
-	configMap := &corev1.ConfigMap{}
-	if err := r.Get(ctx, configMapKey, configMap); err != nil {
-		return fmt.Errorf("failed to get ConfigMap %s: %w", configMapName, err)
-	}
-
-	// Get current neo4j.conf content
-	currentConf := configMap.Data["neo4j.conf"]
-	if currentConf == "" {
-		return fmt.Errorf("neo4j.conf not found in ConfigMap %s", configMapName)
-	}
-
-	// Merge plugin settings into neo4j.conf without creating duplicate keys.
-	// The previous approach appended a line guarded only by an exact-substring
-	// check, so a plugin allowlist (e.g. dbms.security.procedures.unrestricted=
-	// apoc.*) was added as a SECOND declaration when the conf already had that
-	// key (e.g. =gds.*) — CalVer Neo4j then refuses to start ("declared multiple
-	// times"). UpsertNeo4jConfSettings unions additive keys and adds scalar keys
-	// only when absent; it is idempotent, so a no-op won't churn the ConfigMap
-	// or restart the pod.
-	updatedConf := resources.UpsertNeo4jConfSettings(currentConf, allSettings)
-
-	// Update the ConfigMap if changes were made
-	if updatedConf != currentConf {
-		configMap.Data["neo4j.conf"] = updatedConf
-		if err := r.Update(ctx, configMap); err != nil {
-			return fmt.Errorf("failed to update ConfigMap %s: %w", configMapName, err)
-		}
-		logger.Info("ConfigMap updated with plugin security settings", "plugin", plugin.Spec.Name)
-
-		// Restart the standalone pod to pick up the configuration changes
-		if err := r.restartStandalonePods(ctx, standalone); err != nil {
-			logger.Error(err, "Failed to restart standalone pods after ConfigMap update")
-			// Don't fail the entire operation if restart fails - ConfigMap is updated
-		}
-	}
-
-	return nil
-}
-
-// restartStandalonePods restarts the pods of a standalone deployment to pick up ConfigMap changes
-func (r *Neo4jPluginReconciler) restartStandalonePods(ctx context.Context, standalone *neo4jv1beta1.Neo4jEnterpriseStandalone) error {
-	logger := log.FromContext(ctx)
-
-	// Get the StatefulSet for the standalone
-	stsKey := types.NamespacedName{
-		Namespace: standalone.Namespace,
-		Name:      standalone.Name,
-	}
-
-	sts := &appsv1.StatefulSet{}
-	if err := r.Get(ctx, stsKey, sts); err != nil {
-		return fmt.Errorf("failed to get StatefulSet %s: %w", standalone.Name, err)
-	}
-
-	// Add a restart annotation to force pod restart
-	if sts.Spec.Template.Annotations == nil {
-		sts.Spec.Template.Annotations = make(map[string]string)
-	}
-	sts.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
-
-	if err := r.Update(ctx, sts); err != nil {
-		return fmt.Errorf("failed to update StatefulSet to restart pods: %w", err)
-	}
-
-	logger.Info("StatefulSet updated with restart annotation", "name", standalone.Name)
-	return nil
-}
-
 // mapPluginName maps our plugin names to Neo4j's expected plugin names for NEO4J_PLUGINS
 func (r *Neo4jPluginReconciler) mapPluginName(pluginName string) string {
 	switch pluginName {
@@ -1899,25 +1784,11 @@ func (r *Neo4jPluginReconciler) requiresAutomaticSecurityConfiguration(pluginNam
 	}
 }
 
-// getAutomaticSecuritySettings returns the required security settings for plugins that need automatic configuration
+// getAutomaticSecuritySettings returns the security settings a plugin requires.
+// Delegates to the shared helper so the env-var path and the standalone
+// ConfigMap owner (issue #146) agree on the exact set.
 func (r *Neo4jPluginReconciler) getAutomaticSecuritySettings(pluginName string) map[string]string {
-	settings := make(map[string]string)
-
-	switch pluginName {
-	case "bloom":
-		// Bloom requires these security settings to function properly
-		settings["dbms.security.procedures.unrestricted"] = "bloom.*"
-		settings["dbms.security.http_auth_allowlist"] = "/,/browser.*,/bloom.*"
-		settings["server.unmanaged_extension_classes"] = "com.neo4j.bloom.server=/bloom"
-	case "graph-data-science", "gds":
-		// GDS default automatic security (can be overridden by user security settings)
-		settings["dbms.security.procedures.unrestricted"] = "gds.*,apoc.load.*"
-	case "fleet-management":
-		settings["dbms.security.procedures.unrestricted"] = "fleetManagement.*"
-		settings["dbms.security.procedures.allowlist"] = "fleetManagement.*"
-	}
-
-	return settings
+	return automaticPluginSecuritySettings(pluginName)
 }
 
 // filterNeo4jClientConfig filters out plugin-specific configurations that should be handled via environment variables
@@ -1945,13 +1816,6 @@ func (r *Neo4jPluginReconciler) filterNeo4jClientConfig(config map[string]string
 	}
 
 	return filtered
-}
-
-// isSecuritySetting determines if a configuration setting is security-related and must be in neo4j.conf at startup
-func (r *Neo4jPluginReconciler) isSecuritySetting(key string) bool {
-	return strings.HasPrefix(key, "dbms.security.") ||
-		strings.HasPrefix(key, "server.unmanaged_extension_classes") ||
-		strings.HasPrefix(key, "dbms.bloom.") // Bloom-specific settings
 }
 
 // isNonDynamicSetting determines if a configuration setting can only be applied at startup

--- a/internal/controller/plugin_controller_unit_test.go
+++ b/internal/controller/plugin_controller_unit_test.go
@@ -508,13 +508,12 @@ func TestGetAutomaticSecuritySettings(t *testing.T) {
 }
 
 func TestIsSecuritySetting(t *testing.T) {
-	r := &Neo4jPluginReconciler{}
-	assert.True(t, r.isSecuritySetting("dbms.security.procedures.unrestricted"))
-	assert.True(t, r.isSecuritySetting("dbms.security.procedures.allowlist"))
-	assert.True(t, r.isSecuritySetting("server.unmanaged_extension_classes"))
-	assert.True(t, r.isSecuritySetting("dbms.bloom.license_file"))
-	assert.False(t, r.isSecuritySetting("server.memory.heap.max_size"))
-	assert.False(t, r.isSecuritySetting("gds.maxConcurrentRequests"))
+	assert.True(t, pluginConfKeyIsSecurity("dbms.security.procedures.unrestricted"))
+	assert.True(t, pluginConfKeyIsSecurity("dbms.security.procedures.allowlist"))
+	assert.True(t, pluginConfKeyIsSecurity("server.unmanaged_extension_classes"))
+	assert.True(t, pluginConfKeyIsSecurity("dbms.bloom.license_file"))
+	assert.False(t, pluginConfKeyIsSecurity("server.memory.heap.max_size"))
+	assert.False(t, pluginConfKeyIsSecurity("gds.maxConcurrentRequests"))
 }
 
 func TestFilterNeo4jClientConfig(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #146.

Plugin-derived `neo4j.conf` delivery for **standalone** was a two-controller tug-of-war: the plugin controller patched the standalone's ConfigMap *after the fact*, so uninstalling a plugin left its keys behind and the two controllers fought over the same file. This makes the **standalone controller the single owner of `neo4j.conf`**:

- It folds in the **union** of every `Neo4jPlugin` CR targeting the standalone (new shared helpers in `plugin_conf_settings.go`), rendering those keys as operator-owned (tracked via `neo4j.com/standalone-controller-conf-keys`) so they **prune on uninstall**. Additive keys (procedure allowlists, `http_auth_allowlist`) union across plugins; scalars are deterministic by plugin name.
- It **watches `Neo4jPlugin`**, so create/change/delete triggers a reconcile, and it rolls the pod when the rendered conf actually changes.
- The plugin controller **no longer patches** the standalone ConfigMap. Its `NEO4J_PLUGINS` env + init-container management for **clusters** is unchanged (the cluster path uses env vars + the `mergeEnvVars` ownership annotation and never had the ConfigMap bug — see #145).

### Latent StatefulSet bug fixed along the way

This work surfaced a real bug: `reconcileStatefulSet` used an **empty** `CreateOrUpdate` mutate (`func() error { return nil }`). On update, `Get` overwrites the passed object with the stored state and the empty mutate writes it straight back — so **image upgrades, resource edits, probe / securityContext / volume / updateStrategy changes silently never reached a running standalone** (the pre-upgrade health check fired its "Upgrading" event, but no upgrade happened).

The mutate now applies the desired template, **gated by a hash of the operator's own desired template** (comparing desired-vs-last-desired, not desired-vs-server-state, so API-server field defaulting can't make every reconcile look like a change and roll the pod in a loop). It preserves:
- **foreign env vars** (`NEO4J_PLUGINS`, fleet token, APOC) via the cluster's `mergeEnvVars` + a standalone env-ownership annotation (`neo4j.com/standalone-controller-env-vars`), which also drops vars the operator previously owned but no longer renders;
- **foreign pod-template annotations** (the conf-path config-restart stamp, service-mesh injection) by overlaying desired annotations onto the existing set.

## Type of change

- [x] Bug fix
- [x] Refactor / chore / CI

## Testing

- [x] `make test-unit` passes locally (full envtest Ginkgo suite + table tests)
- [ ] `make lint` — local `golangci-lint` binary is built with go1.25 vs the repo's go1.26 target (pre-existing env mismatch); the **pre-commit** golangci-lint + staticcheck hooks pass
- [x] `make check-drift` clean (no generated-file changes — controller-only)

New/updated tests:
- ConfigMap: plugin-union render + prune, user+plugin additive union, idempotency, removed-key clears, foreign-key preserved.
- StatefulSet: image upgrade applies, resources apply, foreign env preserved, previously-owned env removed, config-restart annotation preserved, no churn on a no-op reconcile.

> Touches the standalone controller — please add the `run-integration-tests` label / `[run-integration]` to exercise the Extended Integration suite.

## Checklist

- [x] Conventional Commit title
- [x] No API-type / RBAC-marker / CRD changes (the `neo4jplugins` get/list/watch grant already exists in the shared ClusterRole) → no `sync-all` needed, `check-drift` green
- [ ] Docs unchanged (internal behavior; no new spec fields)
- [x] Respects `CLAUDE.md` invariants (no webhooks, server-based architecture, plugin live-patch ownership pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches standalone ConfigMap security settings, StatefulSet rolling updates, and multi-controller merge semantics—incorrect pruning or template apply could break upgrades or strip procedure allowlists.
> 
> **Overview**
> Closes **#146** by making the **standalone controller the sole owner of `neo4j.conf`**: it unions plugin-derived settings from enabled `Neo4jPlugin` CRs (shared logic in `plugin_conf_settings.go`), tracks them as operator-owned, **prunes on uninstall**, and **fails reconcile** if plugin listing errors (avoids stripping security settings). The plugin controller **stops patching** the standalone ConfigMap and restarts; it still manages `NEO4J_PLUGINS` and init containers. Standalone **watches `Neo4jPlugin`** to re-reconcile on plugin changes; **cluster-first** resolution skips folding plugins into a same-named standalone when a `Neo4jEnterpriseCluster` exists.
> 
> **StatefulSet reconcile** is rewritten: the old empty `CreateOrUpdate` mutate no longer blocks **image/resource/probe** updates. Template applies are **hash-gated** to avoid reconcile loops; **ownership annotations** merge foreign env vars, init containers, and volumes from the plugin controller while dropping operator-owned items that were removed. **`neo4j.com/config-hash`** on the pod template rolls pods when rendered conf changes.
> 
> Extensive ConfigMap and StatefulSet unit tests cover union/prune, idempotency, and merge behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e27139bf69d687e1b6e7e0b5debb5eb19d38a41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->