### PR TITLE
feat(backup): use Job name (not opaque UID) for BackupRun.RunID (#158)

### DIFF
--- a/api/v1beta1/neo4jbackup_types.go
+++ b/api/v1beta1/neo4jbackup_types.go
@@ -277,9 +277,12 @@ type BackupStats struct {
 // BackupRun represents a single backup execution
 type BackupRun struct {
 	// RunID uniquely identifies this backup execution. Populated from the
-	// backing Job's metadata.uid so a history entry can be correlated with
-	// the actual Job artifact (or audit log) that produced it. Stable for
-	// the lifetime of the Job; new for every retry.
+	// backing Job's name (e.g. "my-backup-backup" for a one-shot run,
+	// "my-backup-cron-1737028800" for a scheduled child) so a history entry
+	// is human-readable and maps directly to the Job found via
+	// `kubectl get jobs` — the same value the backup Pod sees as
+	// BACKUP_RUN_ID. Unique per run: one-shot Jobs are created once per CR;
+	// CronJob children carry a Unix-second suffix.
 	RunID string `json:"runID,omitempty"`
 
 	// Start time of the backup run

--- a/api/v1beta1/neo4jshardeddatabase_types.go
+++ b/api/v1beta1/neo4jshardeddatabase_types.go
@@ -246,7 +246,7 @@ type ShardedDatabaseBackupReference struct {
 	BackupRef string `json:"backupRef"`
 
 	// RunID matches BackupRun.RunID in the Neo4jBackup CR (the backup Job's
-	// metadata.uid). Stable across status refreshes and unique per run.
+	// name). Stable across status refreshes and unique per run.
 	RunID string `json:"runID,omitempty"`
 
 	// BackupsPath is the per-run subdirectory inside the backup storage where

--- a/bundle/manifests/neo4j.neo4j.com_neo4jbackups.yaml
+++ b/bundle/manifests/neo4j.neo4j.com_neo4jbackups.yaml
@@ -565,9 +565,12 @@ spec:
                     runID:
                       description: |-
                         RunID uniquely identifies this backup execution. Populated from the
-                        backing Job's metadata.uid so a history entry can be correlated with
-                        the actual Job artifact (or audit log) that produced it. Stable for
-                        the lifetime of the Job; new for every retry.
+                        backing Job's name (e.g. "my-backup-backup" for a one-shot run,
+                        "my-backup-cron-1737028800" for a scheduled child) so a history entry
+                        is human-readable and maps directly to the Job found via
+                        `kubectl get jobs` — the same value the backup Pod sees as
+                        BACKUP_RUN_ID. Unique per run: one-shot Jobs are created once per CR;
+                        CronJob children carry a Unix-second suffix.
                       type: string
                     shardArtifacts:
                       description: |-

--- a/bundle/manifests/neo4j.neo4j.com_neo4jshardeddatabases.yaml
+++ b/bundle/manifests/neo4j.neo4j.com_neo4jshardeddatabases.yaml
@@ -419,7 +419,7 @@ spec:
                   runID:
                     description: |-
                       RunID matches BackupRun.RunID in the Neo4jBackup CR (the backup Job's
-                      metadata.uid). Stable across status refreshes and unique per run.
+                      name). Stable across status refreshes and unique per run.
                     type: string
                   timestamp:
                     description: Timestamp is the time the backup Job's Pod reported

--- a/charts/neo4j-operator/crds/neo4j.neo4j.com_neo4jbackups.yaml
+++ b/charts/neo4j-operator/crds/neo4j.neo4j.com_neo4jbackups.yaml
@@ -565,9 +565,12 @@ spec:
                     runID:
                       description: |-
                         RunID uniquely identifies this backup execution. Populated from the
-                        backing Job's metadata.uid so a history entry can be correlated with
-                        the actual Job artifact (or audit log) that produced it. Stable for
-                        the lifetime of the Job; new for every retry.
+                        backing Job's name (e.g. "my-backup-backup" for a one-shot run,
+                        "my-backup-cron-1737028800" for a scheduled child) so a history entry
+                        is human-readable and maps directly to the Job found via
+                        `kubectl get jobs` — the same value the backup Pod sees as
+                        BACKUP_RUN_ID. Unique per run: one-shot Jobs are created once per CR;
+                        CronJob children carry a Unix-second suffix.
                       type: string
                     shardArtifacts:
                       description: |-

--- a/charts/neo4j-operator/crds/neo4j.neo4j.com_neo4jshardeddatabases.yaml
+++ b/charts/neo4j-operator/crds/neo4j.neo4j.com_neo4jshardeddatabases.yaml
@@ -419,7 +419,7 @@ spec:
                   runID:
                     description: |-
                       RunID matches BackupRun.RunID in the Neo4jBackup CR (the backup Job's
-                      metadata.uid). Stable across status refreshes and unique per run.
+                      name). Stable across status refreshes and unique per run.
                     type: string
                   timestamp:
                     description: Timestamp is the time the backup Job's Pod reported

--- a/config/crd/bases/neo4j.neo4j.com_neo4jbackups.yaml
+++ b/config/crd/bases/neo4j.neo4j.com_neo4jbackups.yaml
@@ -565,9 +565,12 @@ spec:
                     runID:
                       description: |-
                         RunID uniquely identifies this backup execution. Populated from the
-                        backing Job's metadata.uid so a history entry can be correlated with
-                        the actual Job artifact (or audit log) that produced it. Stable for
-                        the lifetime of the Job; new for every retry.
+                        backing Job's name (e.g. "my-backup-backup" for a one-shot run,
+                        "my-backup-cron-1737028800" for a scheduled child) so a history entry
+                        is human-readable and maps directly to the Job found via
+                        `kubectl get jobs` — the same value the backup Pod sees as
+                        BACKUP_RUN_ID. Unique per run: one-shot Jobs are created once per CR;
+                        CronJob children carry a Unix-second suffix.
                       type: string
                     shardArtifacts:
                       description: |-

--- a/config/crd/bases/neo4j.neo4j.com_neo4jshardeddatabases.yaml
+++ b/config/crd/bases/neo4j.neo4j.com_neo4jshardeddatabases.yaml
@@ -419,7 +419,7 @@ spec:
                   runID:
                     description: |-
                       RunID matches BackupRun.RunID in the Neo4jBackup CR (the backup Job's
-                      metadata.uid). Stable across status refreshes and unique per run.
+                      name). Stable across status refreshes and unique per run.
                     type: string
                   timestamp:
                     description: Timestamp is the time the backup Job's Pod reported

--- a/internal/controller/neo4jbackup_controller.go
+++ b/internal/controller/neo4jbackup_controller.go
@@ -276,7 +276,7 @@ func (r *Neo4jBackupReconciler) reconcileScheduledHistory(ctx context.Context, b
 			if !ok {
 				continue // still running
 			}
-			if backupRunAlreadyRecorded(latest.Status.History, run) {
+			if backupRunAlreadyRecorded(latest.Status.History, run, string(job.UID)) {
 				continue
 			}
 			// F3 / F4: augment with per-Job filename/size + validation
@@ -412,17 +412,31 @@ func jobToBackupRun(job *batchv1.Job, backupsPath string) (neo4jv1beta1.BackupRu
 	}
 }
 
-// backupRunAlreadyRecorded reports whether a BackupRun with the same RunID is
-// already in history. RunID is the Job's name, which is unique per recorded
-// run (one-shot: "<backup>-backup", created once per CR — issue #116;
-// scheduled: "<cronjob>-<unix-seconds>" per child), so it is a reliable dedup
-// key.
-func backupRunAlreadyRecorded(history []neo4jv1beta1.BackupRun, run neo4jv1beta1.BackupRun) bool {
+// backupRunAlreadyRecorded reports whether a BackupRun for this Job is already
+// in history. RunID is the Job's name, which is unique per recorded run
+// (one-shot: "<backup>-backup", created once per CR — issue #116; scheduled:
+// "<cronjob>-<unix-seconds>" per child), so it is a reliable dedup key.
+//
+// jobUID is matched in addition to RunID purely for the upgrade transition:
+// before #158, RunID was populated from the Job's metadata.uid. After upgrade,
+// a CronJob child that completed pre-upgrade still has a UID-keyed history
+// entry, while reconcileScheduledHistory now builds the run with a name-keyed
+// RunID — so a name-only check would re-record the same Job (duplicating it
+// until the history cap trims it). Matching jobUID recognises the legacy entry
+// and skips it. No false-positive risk: a UID is a UUID and a RunID/name is a
+// DNS label, so the two value spaces never overlap.
+func backupRunAlreadyRecorded(history []neo4jv1beta1.BackupRun, run neo4jv1beta1.BackupRun, jobUID string) bool {
 	if run.RunID == "" {
 		return false
 	}
 	for _, existing := range history {
+		if existing.RunID == "" {
+			continue
+		}
 		if existing.RunID == run.RunID {
+			return true
+		}
+		if jobUID != "" && existing.RunID == jobUID {
 			return true
 		}
 	}
@@ -1704,7 +1718,7 @@ func (r *Neo4jBackupReconciler) recordOneShotBackupRun(ctx context.Context, back
 		// produces a new Job with a new UID. Returning nil (instead of an
 		// idempotent Status.Update) saves the round-trip and the
 		// resourceVersion bump on every redundant reconcile.
-		if backupRunAlreadyRecorded(latest.Status.History, run) {
+		if backupRunAlreadyRecorded(latest.Status.History, run, string(job.UID)) {
 			return nil
 		}
 

--- a/internal/controller/neo4jbackup_controller.go
+++ b/internal/controller/neo4jbackup_controller.go
@@ -355,11 +355,11 @@ func (r *Neo4jBackupReconciler) reconcileScheduledHistory(ctx context.Context, b
 // reconcileScheduledHistory could drop different entries on different
 // reconciles when StartTime collisions are present.
 //
-// RunID descending (lexicographic) is the chosen tie-break direction; UID
-// has no semantic ordering anyway, we just need *some* total order, and
-// "higher string sorts to the top" keeps the function's contract uniform
-// (newest first → if you can't tell which is newest, pick the
-// lexicographically-larger UID).
+// RunID descending (lexicographic) is the chosen tie-break direction. RunID
+// is the backing Job's name; for CronJob children ("<cronjob>-<unix-seconds>")
+// the lexicographically-larger name is the later run, so this keeps the
+// function's contract uniform (newest first → if StartTimes tie, pick the
+// lexicographically-larger RunID).
 func sortBackupRunsNewestFirst(runs []neo4jv1beta1.BackupRun) {
 	sort.Slice(runs, func(i, j int) bool {
 		a, b := runs[i], runs[j]
@@ -377,10 +377,17 @@ func sortBackupRunsNewestFirst(runs []neo4jv1beta1.BackupRun) {
 // root) — same for every run of one CR under the shared-directory layout
 // (rule 40). Pass the Neo4jBackup CR name; jobToBackupRun records it as
 // `BackupRun.BackupsPath` for audit + sharded-seed-proxy URL building.
-// The Job UID still uniquely identifies the run via `BackupRun.RunID`.
+//
+// RunID is the backing Job's NAME (not its opaque UID), so a history entry
+// is human-readable and maps directly to the Job a user finds via
+// `kubectl get jobs` — and to the same value the backup Pod sees as
+// BACKUP_RUN_ID (issue #158). The name is unique per recorded run: one-shot
+// Jobs are "<backup>-backup", created exactly once per CR (the Completed/
+// Failed terminal guard in handleOneTimeBackup never recreates them —
+// issue #116); CronJob children are "<cronjob>-<unix-seconds>".
 func jobToBackupRun(job *batchv1.Job, backupsPath string) (neo4jv1beta1.BackupRun, bool) {
 	run := neo4jv1beta1.BackupRun{
-		RunID:       string(job.UID),
+		RunID:       job.Name,
 		BackupsPath: backupsPath,
 	}
 	if job.Status.StartTime != nil {
@@ -406,8 +413,10 @@ func jobToBackupRun(job *batchv1.Job, backupsPath string) (neo4jv1beta1.BackupRu
 }
 
 // backupRunAlreadyRecorded reports whether a BackupRun with the same RunID is
-// already in history. RunID comes from the Job's metadata.uid which is unique
-// and stable per Job, so this is a reliable dedup key.
+// already in history. RunID is the Job's name, which is unique per recorded
+// run (one-shot: "<backup>-backup", created once per CR — issue #116;
+// scheduled: "<cronjob>-<unix-seconds>" per child), so it is a reliable dedup
+// key.
 func backupRunAlreadyRecorded(history []neo4jv1beta1.BackupRun, run neo4jv1beta1.BackupRun) bool {
 	if run.RunID == "" {
 		return false

--- a/internal/controller/neo4jbackup_history_test.go
+++ b/internal/controller/neo4jbackup_history_test.go
@@ -82,8 +82,8 @@ func TestJobToBackupRun(t *testing.T) {
 		if !ok {
 			t.Fatalf("expected ok=true for a succeeded Job")
 		}
-		if run.RunID != "uid-a" {
-			t.Errorf("RunID: got %q, want %q", run.RunID, "uid-a")
+		if run.RunID != "my-backup-backup-cron-28832400" {
+			t.Errorf("RunID: got %q, want the Job name %q (issue #158)", run.RunID, "my-backup-backup-cron-28832400")
 		}
 		if run.Status != "Succeeded" {
 			t.Errorf("Status: got %q, want Succeeded", run.Status)
@@ -99,7 +99,7 @@ func TestJobToBackupRun(t *testing.T) {
 
 	t.Run("failed Job → BackupRun without Duration", func(t *testing.T) {
 		job := &batchv1.Job{
-			ObjectMeta: metav1.ObjectMeta{UID: types.UID("uid-b")},
+			ObjectMeta: metav1.ObjectMeta{Name: "my-backup-backup"},
 			Status:     batchv1.JobStatus{Failed: 3, StartTime: &start},
 		}
 		run, ok := jobToBackupRun(job, "my-backup")
@@ -116,7 +116,7 @@ func TestJobToBackupRun(t *testing.T) {
 
 	t.Run("still-running Job → ok=false", func(t *testing.T) {
 		job := &batchv1.Job{
-			ObjectMeta: metav1.ObjectMeta{UID: types.UID("uid-c")},
+			ObjectMeta: metav1.ObjectMeta{Name: "my-backup-backup"},
 			Status:     batchv1.JobStatus{StartTime: &start},
 		}
 		if _, ok := jobToBackupRun(job, "my-backup"); ok {
@@ -320,12 +320,17 @@ func TestRecordOneShotBackupRunDedup(t *testing.T) {
 
 	start := metav1.NewTime(time.Date(2026, 6, 2, 10, 0, 0, 0, time.UTC))
 	end := metav1.NewTime(start.Add(45 * time.Second))
+	// RunID is now the Job name (issue #158), which is the dedup key. jobA
+	// and jobB carry distinct names to exercise the dedup function's
+	// "different run → new entry" path. (In production the one-shot terminal
+	// guard means one CR only ever produces one Job name; this unit test
+	// drives the dedup logic directly.)
 	jobA := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{UID: types.UID("uid-A")},
+		ObjectMeta: metav1.ObjectMeta{Name: "b-backup"},
 		Status:     batchv1.JobStatus{Succeeded: 1, StartTime: &start, CompletionTime: &end},
 	}
 	jobB := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{UID: types.UID("uid-B")},
+		ObjectMeta: metav1.ObjectMeta{Name: "b-backup-2"},
 		Status:     batchv1.JobStatus{Succeeded: 1, StartTime: &start, CompletionTime: &end},
 	}
 	backup := &neo4jv1beta1.Neo4jBackup{
@@ -350,28 +355,28 @@ func TestRecordOneShotBackupRunDedup(t *testing.T) {
 		require.NotNil(t, got.Status.Stats, "Stats must be set after first call")
 		assert.Equal(t, "45s", got.Status.Stats.Duration)
 		require.Len(t, got.Status.History, 1)
-		assert.Equal(t, "uid-A", got.Status.History[0].RunID)
+		assert.Equal(t, "b-backup", got.Status.History[0].RunID)
 	})
 
 	t.Run("duplicate call is a no-op (no resourceVersion bump)", func(t *testing.T) {
 		before := get()
 		rvBefore := before.ResourceVersion
 
-		r.recordOneShotBackupRun(ctx, backup, jobA) // same Job UID
+		r.recordOneShotBackupRun(ctx, backup, jobA) // same Job name
 
 		after := get()
 		assert.Equal(t, rvBefore, after.ResourceVersion, "duplicate recordOneShotBackupRun must not write")
 		require.Len(t, after.Status.History, 1, "history must stay at length 1")
 	})
 
-	t.Run("new Job UID appends a second history entry", func(t *testing.T) {
+	t.Run("new Job name appends a second history entry", func(t *testing.T) {
 		r.recordOneShotBackupRun(ctx, backup, jobB)
 
 		got := get()
 		require.Len(t, got.Status.History, 2)
 		// Newest first per the prepend convention.
-		assert.Equal(t, "uid-B", got.Status.History[0].RunID)
-		assert.Equal(t, "uid-A", got.Status.History[1].RunID)
+		assert.Equal(t, "b-backup-2", got.Status.History[0].RunID)
+		assert.Equal(t, "b-backup", got.Status.History[1].RunID)
 	})
 }
 
@@ -405,7 +410,7 @@ func TestRecordOneShotBackupRun_FailedJobAppendsToHistory(t *testing.T) {
 	require.Len(t, got.Status.History, 1,
 		"failed one-shot Jobs must be appended to status.history (recheck gap 2)")
 	assert.Equal(t, "Failed", got.Status.History[0].Status)
-	assert.Equal(t, "uid-fail", got.Status.History[0].RunID)
+	assert.Equal(t, "my-backup-backup", got.Status.History[0].RunID)
 	assert.Equal(t, "b", got.Status.History[0].BackupsPath,
 		"BackupsPath must be populated for failed runs too — partial artifacts may exist. "+
 			"Value is the CR name (shared-directory layout, rule 40), not the Job name.")

--- a/internal/controller/neo4jbackup_history_test.go
+++ b/internal/controller/neo4jbackup_history_test.go
@@ -134,26 +134,27 @@ func TestBackupRunAlreadyRecorded(t *testing.T) {
 		name    string
 		history []neo4jv1beta1.BackupRun
 		run     neo4jv1beta1.BackupRun
+		jobUID  string
 		want    bool
 	}{
 		{
 			name: "match found",
 			history: []neo4jv1beta1.BackupRun{
-				mk("uid-a"), mk("uid-b"),
+				mk("a"), mk("b"),
 			},
-			run:  mk("uid-b"),
+			run:  mk("b"),
 			want: true,
 		},
 		{
 			name:    "no match",
-			history: []neo4jv1beta1.BackupRun{mk("uid-a")},
-			run:     mk("uid-b"),
+			history: []neo4jv1beta1.BackupRun{mk("a")},
+			run:     mk("b"),
 			want:    false,
 		},
 		{
 			name:    "empty history",
 			history: nil,
-			run:     mk("uid-a"),
+			run:     mk("a"),
 			want:    false,
 		},
 		{
@@ -161,15 +162,35 @@ func TestBackupRunAlreadyRecorded(t *testing.T) {
 			// Avoids false positives against historic entries pre-upgrade
 			// that have RunID="" — those would otherwise all "match" each
 			// other and break the append path the first time around.
-			history: []neo4jv1beta1.BackupRun{mk(""), mk("uid-a")},
+			history: []neo4jv1beta1.BackupRun{mk(""), mk("a")},
 			run:     mk(""),
+			want:    false,
+		},
+		{
+			// Upgrade transition: a CronJob child recorded before #158 has a
+			// UID-keyed history entry; after upgrade the run is rebuilt with a
+			// name-keyed RunID. Matching jobUID recognises the legacy entry so
+			// the same Job isn't re-recorded (duplicated).
+			name:    "legacy UID-keyed entry matched by jobUID (no re-record on upgrade)",
+			history: []neo4jv1beta1.BackupRun{mk("550e8400-e29b-41d4-a716-446655440000")},
+			run:     mk("my-backup-cron-1737028800"),
+			jobUID:  "550e8400-e29b-41d4-a716-446655440000",
+			want:    true,
+		},
+		{
+			// A genuinely new run (different name, different UID) is not a
+			// duplicate of the legacy entry.
+			name:    "new run with different name and UID is not a duplicate",
+			history: []neo4jv1beta1.BackupRun{mk("550e8400-e29b-41d4-a716-446655440000")},
+			run:     mk("my-backup-cron-1737099999"),
+			jobUID:  "660e8400-e29b-41d4-a716-446655449999",
 			want:    false,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := backupRunAlreadyRecorded(tc.history, tc.run)
+			got := backupRunAlreadyRecorded(tc.history, tc.run, tc.jobUID)
 			if got != tc.want {
 				t.Errorf("backupRunAlreadyRecorded() = %v, want %v", got, tc.want)
 			}


### PR DESCRIPTION
Closes #158.

## What
`status.history[].runID` was populated from the backing Job's `metadata.uid` — an opaque UUID. Browsing history (to pick a run) showed a list of UUIDs with no way to tell them apart. Populate `RunID` from `job.Name` instead.

```yaml
# before
runID: "550e8400-e29b-41d4-a716-446655440000"
# after
runID: "my-backup-backup-cron-1737028800"
```

## Why it's safe
- **Uniqueness preserved.** One-shot Jobs are `<backup>-backup`, created exactly once per CR (the Completed/Failed terminal guard in `handleOneTimeBackup` never recreates them — #116). CronJob children are `<cronjob>-<unix-seconds>`. So `backupRunAlreadyRecorded` dedup-by-RunID stays correct.
- **No name-length interaction.** `RunID` is only ever read into a free-text status field — it never builds a resource name, label, or path (the one `fmt.Sprintf` with it is an error message). So it can't push any generated name over a K8s limit.
- **Consistency.** Aligns `RunID` with `backupsPath` (already `job.Name` since #129) and the `BACKUP_RUN_ID` env var (the job-name label).

## Changes
- `jobToBackupRun`: `RunID = job.Name` (was `string(job.UID)`)
- godoc/comments: `BackupRun.RunID`, `ShardedDatabaseBackupReference.RunID`, `jobToBackupRun`, `backupRunAlreadyRecorded`, sort tie-break
- tests updated to assert/drive RunID by Job name
- regenerated CRD bases, Helm CRDs, bundle manifests

## Test
`go test ./internal/controller/ -run Backup` green; `make check-drift` clean (pre-commit "generated artifacts in sync" passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes observed status semantics for `runID` on upgrade and in any external tooling that assumed UUIDs; controller dedup mitigates duplicate history but existing stored UID values remain until reconciled.
> 
> **Overview**
> **`status.history[].runID`** (and matching **`ShardedDatabaseBackupReference.runID`**) now stores the backing backup **Job’s name** instead of **`metadata.uid`**, so history lines up with **`kubectl get jobs`** and the pod env **`BACKUP_RUN_ID`**.
> 
> The backup controller sets **`RunID`** in **`jobToBackupRun`** via **`job.Name`**. **`backupRunAlreadyRecorded`** also accepts **`jobUID`** so pre-upgrade history rows keyed by UID are not duplicated after upgrade. API godoc and regenerated CRD/bundle/Helm manifests describe the new semantics; controller tests assert Job-name **`RunID`** and the upgrade dedup path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 276812b2b6149d806ca13abd2858eadb8f7b229e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->