### PR TITLE
fix(backup): reject scheduled backup names too long for the generated CronJob

### DIFF
--- a/internal/controller/neo4jbackup_controller.go
+++ b/internal/controller/neo4jbackup_controller.go
@@ -210,6 +210,18 @@ func (r *Neo4jBackupReconciler) handleDeletion(ctx context.Context, backup *neo4
 func (r *Neo4jBackupReconciler) handleScheduledBackup(ctx context.Context, backup *neo4jv1beta1.Neo4jBackup, cluster *neo4jv1beta1.Neo4jEnterpriseCluster) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
+	// A scheduled backup generates a CronJob named "<name>-backup-cron".
+	// Reject an over-long name here with a clear message — otherwise the
+	// CronJob create below fails with an opaque apiserver error and the
+	// scheduled backup silently never runs. This is a spec problem the user
+	// must fix (rename), so don't requeue; a spec edit re-triggers reconcile.
+	if err := validation.ValidateScheduledBackupName(backup.Name); err != nil {
+		logger.Info("Scheduled backup name too long", "error", err.Error())
+		r.updateBackupStatus(ctx, backup, "Failed", err.Error())
+		r.Recorder.Event(backup, corev1.EventTypeWarning, EventReasonBackupFailed, err.Error())
+		return ctrl.Result{}, nil
+	}
+
 	// Ensure backup ServiceAccount exists (and carries workload-identity annotations).
 	if err := r.ensureBackupServiceAccount(ctx, backup); err != nil {
 		logger.Error(err, "Failed to ensure backup ServiceAccount")

--- a/internal/controller/neo4jbackup_history_test.go
+++ b/internal/controller/neo4jbackup_history_test.go
@@ -12,6 +12,7 @@ package controller
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -413,4 +414,41 @@ func TestRecordOneShotBackupRun_FailedJobAppendsToHistory(t *testing.T) {
 	// NOT overwrite it. If no prior success exists, it stays nil.
 	assert.Nil(t, got.Status.Stats,
 		"a failed run must not write to status.stats (Stats is the latest-succeeded summary)")
+}
+
+// TestHandleScheduledBackup_RejectsLongName pins the reconciler guard added
+// for the scheduled-backup CronJob name-length gap: a name that would make
+// "<name>-backup-cron" exceed Kubernetes' 52-char CronJob limit must fail
+// fast with a clear status (and create no CronJob) instead of letting the
+// CronJob create fail opaquely at apiserver time.
+func TestHandleScheduledBackup_RejectsLongName(t *testing.T) {
+	ctx := context.Background()
+	ns := "default"
+	longName := strings.Repeat("a", 41) // "<name>-backup-cron" = 53 chars > 52
+
+	backup := &neo4jv1beta1.Neo4jBackup{
+		ObjectMeta: metav1.ObjectMeta{Name: longName, Namespace: ns},
+		Spec: neo4jv1beta1.Neo4jBackupSpec{
+			Target:   neo4jv1beta1.BackupTarget{Kind: "Cluster", Name: "c"},
+			Storage:  neo4jv1beta1.StorageLocation{Type: "pvc", PVC: &neo4jv1beta1.PVCSpec{Name: "pvc"}},
+			Schedule: "0 2 * * *",
+		},
+	}
+	r := newBackupTestReconcilerWithStatus(t, backup)
+	cluster := &neo4jv1beta1.Neo4jEnterpriseCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: ns},
+	}
+
+	_, err := r.handleScheduledBackup(ctx, backup, cluster)
+	require.NoError(t, err, "name-length rejection is a spec error, not a reconcile error")
+
+	got := &neo4jv1beta1.Neo4jBackup{}
+	require.NoError(t, r.Get(ctx, client.ObjectKey{Name: longName, Namespace: ns}, got))
+	assert.Equal(t, "Failed", got.Status.Phase)
+	assert.Contains(t, got.Status.Message, "52-character CronJob")
+
+	// No CronJob should have been created for the invalid name.
+	var cronjobs batchv1.CronJobList
+	require.NoError(t, r.List(ctx, &cronjobs, client.InNamespace(ns)))
+	assert.Empty(t, cronjobs.Items, "no CronJob should be created when the name is rejected")
 }

--- a/internal/validation/backup_validator.go
+++ b/internal/validation/backup_validator.go
@@ -28,6 +28,35 @@ import (
 	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
 )
 
+// maxScheduledBackupNameLength bounds a scheduled Neo4jBackup's name so the
+// generated CronJob name ("<name>-backup-cron") stays within Kubernetes'
+// 52-character CronJob-name limit. Kubernetes caps CronJob names at 52
+// (DNS-1035 label max 63 minus the 11-char "-<timestamp>" suffix the CronJob
+// controller appends to child Jobs); "-backup-cron" is 12 chars, so
+// 52 - 12 = 40. Without this check a longer name fails only at CronJob
+// creation time with an opaque apiserver error and the scheduled backup
+// never runs. One-shot backups are unaffected: their Job ("<name>-backup")
+// and temp PVC ("<name>-temp-staging") names are bounded by the 253-char
+// limit, so they don't hard-fail.
+const maxScheduledBackupNameLength = 40
+
+// ValidateScheduledBackupName returns an error if a scheduled Neo4jBackup's
+// name is too long for the CronJob the operator generates from it
+// ("<name>-backup-cron"). It is called inline from the backup reconciler
+// before the CronJob is created (the operator has no admission webhooks), so
+// an over-long name fails fast with this clear message rather than at
+// CronJob-create time with an opaque apiserver error — at which point the
+// scheduled backup would silently never run. One-shot (unscheduled) backups
+// don't need this: their Job/PVC names are bounded by the 253-char limit.
+func ValidateScheduledBackupName(name string) error {
+	if len(name) > maxScheduledBackupNameLength {
+		return fmt.Errorf(
+			"backup name %q is too long for a scheduled backup (%d chars): the generated CronJob name %q would exceed Kubernetes' 52-character CronJob name limit; use a name of at most %d characters",
+			name, len(name), name+"-backup-cron", maxScheduledBackupNameLength)
+	}
+	return nil
+}
+
 // BackupValidator validates Neo4j backup configuration for Neo4j 5.26+ compatibility
 type BackupValidator struct{}
 
@@ -52,6 +81,18 @@ func (v *BackupValidator) Validate(backup *neo4jv1beta1.Neo4jBackup) field.Error
 			allErrs = append(allErrs, field.Invalid(
 				field.NewPath("spec", "schedule"),
 				backup.Spec.Schedule,
+				err.Error(),
+			))
+		}
+
+		// A scheduled backup generates a CronJob named "<name>-backup-cron".
+		// Kubernetes caps CronJob names at 52 chars; catch an over-long name
+		// here instead of letting the CronJob create fail opaquely at
+		// reconcile time (the backup would never run).
+		if err := ValidateScheduledBackupName(backup.Name); err != nil {
+			allErrs = append(allErrs, field.Invalid(
+				field.NewPath("metadata", "name"),
+				backup.Name,
 				err.Error(),
 			))
 		}

--- a/internal/validation/backup_validator_test.go
+++ b/internal/validation/backup_validator_test.go
@@ -400,6 +400,42 @@ func TestBackupValidator_Validate(t *testing.T) {
 			expectError: false,
 			errorCount:  0,
 		},
+		{
+			// 41 chars + a schedule → generated CronJob "<name>-backup-cron"
+			// is 53 chars, over Kubernetes' 52-char CronJob name limit.
+			name: "scheduled backup name too long for CronJob",
+			backup: &neo4jv1beta1.Neo4jBackup{
+				ObjectMeta: metav1.ObjectMeta{Name: strings.Repeat("a", 41)},
+				Spec: neo4jv1beta1.Neo4jBackupSpec{
+					Target: neo4jv1beta1.BackupTarget{Kind: "Cluster", Name: "test-cluster"},
+					Storage: neo4jv1beta1.StorageLocation{
+						Type: "pvc",
+						PVC:  &neo4jv1beta1.PVCSpec{Name: "backup-pvc"},
+					},
+					Schedule: "0 2 * * *",
+				},
+			},
+			expectError:           true,
+			errorCount:            1,
+			expectedErrorContains: []string{"metadata.name", "52-character CronJob"},
+		},
+		{
+			// 41 chars at the boundary is fine for a one-shot backup — the
+			// CronJob-name limit only applies when a schedule is set.
+			name: "long name without schedule is allowed (one-shot)",
+			backup: &neo4jv1beta1.Neo4jBackup{
+				ObjectMeta: metav1.ObjectMeta{Name: strings.Repeat("a", 41)},
+				Spec: neo4jv1beta1.Neo4jBackupSpec{
+					Target: neo4jv1beta1.BackupTarget{Kind: "Cluster", Name: "test-cluster"},
+					Storage: neo4jv1beta1.StorageLocation{
+						Type: "pvc",
+						PVC:  &neo4jv1beta1.PVCSpec{Name: "backup-pvc"},
+					},
+				},
+			},
+			expectError: false,
+			errorCount:  0,
+		},
 	}
 
 	for _, tt := range tests {
@@ -488,6 +524,32 @@ func TestBackupValidator_validateStorageType(t *testing.T) {
 				if err != nil {
 					t.Errorf("expected no error but got: %v", err)
 				}
+			}
+		})
+	}
+}
+
+func TestValidateScheduledBackupName(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		expectErr bool
+	}{
+		{"boundary 40 chars ok", strings.Repeat("a", 40), false},
+		{"41 chars rejected", strings.Repeat("a", 41), true},
+		{"typical short name ok", "nightly-backup", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateScheduledBackupName(tc.input)
+			if tc.expectErr && err == nil {
+				t.Fatalf("expected an error for a %d-char name", len(tc.input))
+			}
+			if !tc.expectErr && err != nil {
+				t.Fatalf("unexpected error for a %d-char name: %v", len(tc.input), err)
+			}
+			if tc.expectErr && !strings.Contains(err.Error(), "52-character CronJob") {
+				t.Errorf("error message should explain the CronJob limit, got: %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
## Problem
A scheduled `Neo4jBackup` generates a CronJob named `<name>-backup-cron`. Kubernetes caps CronJob names at **52 characters** (DNS-1035 label max 63 minus the 11-char `-<timestamp>` suffix it appends to child Jobs). So a backup name **> 40 chars + a schedule** made the CronJob `create` fail with an opaque apiserver error — and the scheduled backup **silently never ran**.

(One-shot backups are unaffected: their Job `<name>-backup` and temp PVC `<name>-temp-staging` names are bounded by the 253-char limit, so they don't hard-fail.)

## Fix
Add `validation.ValidateScheduledBackupName` and call it **inline from the reconciler's scheduled path** (the operator has no admission webhooks). An over-long name now fails fast with a clear status:

> backup name "…" is too long for a scheduled backup (41 chars): the generated CronJob name "…-backup-cron" would exceed Kubernetes' 52-character CronJob name limit; use a name of at most 40 characters

…and no CronJob is created. It's a spec error, so the reconcile returns without requeue (a spec edit re-triggers).

The dormant `BackupValidator.Validate` also calls the new function, so the check is in place if/when that validator is wired into the reconciler — tracked in #159.

## Changes
- `internal/validation`: `ValidateScheduledBackupName` + `maxScheduledBackupNameLength = 40`
- `handleScheduledBackup`: inline guard → status `Failed`, no requeue
- tests: pure-function table + reconciler-guard test (asserts `Failed` status + no CronJob created)

## Notes
- Pure-Go change; no generated artifacts affected.
- Discovered while reviewing #158. The companion finding — that `BackupValidator` is never invoked by the reconciler at all — is filed as #159.
- Backup integration tests stayed green because they're happy-path and short-named (longest scheduled name ~16 chars), so they never reached this limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted validation on the scheduled backup path with tests; no auth or data-path changes, and one-shot backups are unaffected.
> 
> **Overview**
> Scheduled `Neo4jBackup` resources can fail silently when the CR name is too long: the operator builds a CronJob named `<name>-backup-cron`, which must stay within Kubernetes’ **52-character** CronJob name limit (at most **40** characters for the backup name).
> 
> This PR adds **`validation.ValidateScheduledBackupName`** and runs it on the scheduled reconcile path **before** CronJob creation. Invalid names set status to **`Failed`** with an explicit message, emit a warning event, **do not requeue**, and **no CronJob** is created. The same check is wired into **`BackupValidator.Validate`** when `spec.schedule` is set (for future reconciler use). One-shot backups without a schedule are unchanged.
> 
> Tests cover the helper, validator cases (scheduled vs one-shot), and a reconciler test asserting `Failed` status and zero CronJobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1875f77f3bc7e984b081daeaa8ba984c6af5ce46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->