### PR TITLE
chore(codeowners): add @benofben as a co-owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,5 +5,5 @@
 #   /internal/controller/  @neo4j-partners/operator-controllers
 #   /docs/                  @neo4j-partners/operator-docs
 
-# Catch-all: the maintainer owns everything until ownership is split out.
-*   @priyolahiri
+# Catch-all: the maintainers own everything until ownership is split out.
+*   @priyolahiri @benofben


### PR DESCRIPTION
Adds **@benofben** (Ben Lackey, already a repo collaborator) to the catch-all in `.github/CODEOWNERS`, so reviews are auto-requested from him alongside @priyolahiri.

```diff
-*   @priyolahiri
+*   @priyolahiri @benofben
```

**Charles** is intentionally not included yet — he hasn't accepted the repo invite, and CODEOWNERS entries are only valid for users with repo access (GitHub flags unknown handles). I'll add him in a follow-up once he's a collaborator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Repository metadata only; no runtime or application code changes.
> 
> **Overview**
> Updates the catch-all **CODEOWNERS** rule so GitHub auto-requests reviews from **@benofben** in addition to **@priyolahiri** on every PR. The catch-all comment is tweaked from singular “maintainer” to “maintainers” to match shared ownership.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7b027dcb57f4e16a7b9640a22bc34be00e84f15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->