### PR TITLE
fix(backup): wire BackupValidator into reconcile + fix its false-positives

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.29.0
 	github.com/onsi/gomega v1.41.0
 	github.com/prometheus/client_golang v1.23.2
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0

--- a/go.sum
+++ b/go.sum
@@ -105,6 +105,8 @@ github.com/prometheus/common v0.67.5 h1:pIgK94WWlQt1WLwAC5j2ynLaBRDiinoAb86HZHTU
 github.com/prometheus/common v0.67.5/go.mod h1:SjE/0MzDEEAyrdr5Gqc6G+sXI67maCxzaT3A2+HqjUw=
 github.com/prometheus/procfs v0.19.2 h1:zUMhqEW66Ex7OXIiDkll3tl9a1ZdilUOd/F6ZXw4Vws=
 github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05ZpYlu+b4J7mw=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=

--- a/internal/controller/conditions.go
+++ b/internal/controller/conditions.go
@@ -97,7 +97,7 @@ func PhaseToConditionStatus(phase string) (metav1.ConditionStatus, string) {
 		return metav1.ConditionTrue, ConditionReasonReady
 	case "Completed":
 		return metav1.ConditionTrue, ConditionReasonBackupSucceeded
-	case "Failed", "Degraded", "Suspended":
+	case "Failed", "Degraded", "Suspended", "Invalid":
 		return metav1.ConditionFalse, ConditionReasonFailed
 	case "Upgrading":
 		return metav1.ConditionUnknown, ConditionReasonUpgrading

--- a/internal/controller/neo4jbackup_controller.go
+++ b/internal/controller/neo4jbackup_controller.go
@@ -136,6 +136,21 @@ func (r *Neo4jBackupReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{Requeue: true}, nil
 	}
 
+	// Validate the backup spec before touching any cluster or creating
+	// resources. Validation lives in internal/validation and is called inline
+	// here (the operator has no admission webhooks). An invalid spec is a
+	// user error, so we surface it as phase=Invalid (recoverable — fixing the
+	// spec re-triggers reconcile; unlike the terminal one-time "Failed" guard)
+	// and don't requeue. Catching it here gives a clear, aggregated message
+	// instead of an opaque apiserver failure when a resource is later created.
+	if errs := validation.NewBackupValidator().Validate(backup); len(errs) > 0 {
+		msg := errs.ToAggregate().Error()
+		logger.Info("Invalid Neo4jBackup spec", "errors", msg)
+		r.updateBackupStatus(ctx, backup, "Invalid", "Invalid backup spec: "+msg)
+		r.Recorder.Event(backup, corev1.EventTypeWarning, EventReasonBackupFailed, msg)
+		return ctrl.Result{}, nil
+	}
+
 	// Get target cluster
 	targetCluster, err := r.getTargetCluster(ctx, backup)
 	if err != nil {
@@ -210,17 +225,10 @@ func (r *Neo4jBackupReconciler) handleDeletion(ctx context.Context, backup *neo4
 func (r *Neo4jBackupReconciler) handleScheduledBackup(ctx context.Context, backup *neo4jv1beta1.Neo4jBackup, cluster *neo4jv1beta1.Neo4jEnterpriseCluster) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
-	// A scheduled backup generates a CronJob named "<name>-backup-cron".
-	// Reject an over-long name here with a clear message — otherwise the
-	// CronJob create below fails with an opaque apiserver error and the
-	// scheduled backup silently never runs. This is a spec problem the user
-	// must fix (rename), so don't requeue; a spec edit re-triggers reconcile.
-	if err := validation.ValidateScheduledBackupName(backup.Name); err != nil {
-		logger.Info("Scheduled backup name too long", "error", err.Error())
-		r.updateBackupStatus(ctx, backup, "Failed", err.Error())
-		r.Recorder.Event(backup, corev1.EventTypeWarning, EventReasonBackupFailed, err.Error())
-		return ctrl.Result{}, nil
-	}
+	// The scheduled-name length check (and all other spec validation) now runs
+	// up front in Reconcile via validation.NewBackupValidator().Validate, so a
+	// too-long "<name>-backup-cron" is already rejected (phase=Invalid) before
+	// we get here.
 
 	// Ensure backup ServiceAccount exists (and carries workload-identity annotations).
 	if err := r.ensureBackupServiceAccount(ctx, backup); err != nil {

--- a/internal/controller/neo4jbackup_history_test.go
+++ b/internal/controller/neo4jbackup_history_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -442,18 +443,24 @@ func TestRecordOneShotBackupRun_FailedJobAppendsToHistory(t *testing.T) {
 		"a failed run must not write to status.stats (Stats is the latest-succeeded summary)")
 }
 
-// TestHandleScheduledBackup_RejectsLongName pins the reconciler guard added
-// for the scheduled-backup CronJob name-length gap: a name that would make
-// "<name>-backup-cron" exceed Kubernetes' 52-char CronJob limit must fail
-// fast with a clear status (and create no CronJob) instead of letting the
-// CronJob create fail opaquely at apiserver time.
-func TestHandleScheduledBackup_RejectsLongName(t *testing.T) {
+// TestReconcile_RejectsInvalidSpec pins the wired-in spec validation (#159):
+// an invalid Neo4jBackup spec is rejected up front in Reconcile via
+// validation.NewBackupValidator().Validate, surfaced as phase=Invalid with a
+// clear message, and no backing resources are created. Uses a scheduled name
+// too long for the generated CronJob ("<name>-backup-cron" > 52 chars) as the
+// invalid case. The finalizer is pre-seeded so Reconcile proceeds past the
+// finalizer-add step to the validation gate.
+func TestReconcile_RejectsInvalidSpec(t *testing.T) {
 	ctx := context.Background()
 	ns := "default"
 	longName := strings.Repeat("a", 41) // "<name>-backup-cron" = 53 chars > 52
 
 	backup := &neo4jv1beta1.Neo4jBackup{
-		ObjectMeta: metav1.ObjectMeta{Name: longName, Namespace: ns},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       longName,
+			Namespace:  ns,
+			Finalizers: []string{BackupFinalizer},
+		},
 		Spec: neo4jv1beta1.Neo4jBackupSpec{
 			Target:   neo4jv1beta1.BackupTarget{Kind: "Cluster", Name: "c"},
 			Storage:  neo4jv1beta1.StorageLocation{Type: "pvc", PVC: &neo4jv1beta1.PVCSpec{Name: "pvc"}},
@@ -461,20 +468,17 @@ func TestHandleScheduledBackup_RejectsLongName(t *testing.T) {
 		},
 	}
 	r := newBackupTestReconcilerWithStatus(t, backup)
-	cluster := &neo4jv1beta1.Neo4jEnterpriseCluster{
-		ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: ns},
-	}
 
-	_, err := r.handleScheduledBackup(ctx, backup, cluster)
-	require.NoError(t, err, "name-length rejection is a spec error, not a reconcile error")
+	_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKey{Name: longName, Namespace: ns}})
+	require.NoError(t, err, "invalid spec is a user error, not a reconcile error")
 
 	got := &neo4jv1beta1.Neo4jBackup{}
 	require.NoError(t, r.Get(ctx, client.ObjectKey{Name: longName, Namespace: ns}, got))
-	assert.Equal(t, "Failed", got.Status.Phase)
+	assert.Equal(t, "Invalid", got.Status.Phase)
 	assert.Contains(t, got.Status.Message, "52-character CronJob")
 
-	// No CronJob should have been created for the invalid name.
+	// No CronJob should have been created for the invalid spec.
 	var cronjobs batchv1.CronJobList
 	require.NoError(t, r.List(ctx, &cronjobs, client.InNamespace(ns)))
-	assert.Empty(t, cronjobs.Items, "no CronJob should be created when the name is rejected")
+	assert.Empty(t, cronjobs.Items, "no CronJob should be created when the spec is invalid")
 }

--- a/internal/validation/backup_validator.go
+++ b/internal/validation/backup_validator.go
@@ -89,7 +89,7 @@ func (v *BackupValidator) Validate(backup *neo4jv1beta1.Neo4jBackup) field.Error
 	allErrs = append(allErrs, v.validateBackupTarget(&backup.Spec.Target, backup.Namespace)...)
 
 	// Validate storage configuration
-	allErrs = append(allErrs, v.validateStorageConfiguration(&backup.Spec.Storage)...)
+	allErrs = append(allErrs, v.validateStorageConfiguration(&backup.Spec.Storage, backup.Spec.Cloud)...)
 
 	// Validate schedule if specified
 	if backup.Spec.Schedule != "" {
@@ -214,8 +214,11 @@ func (v *BackupValidator) validateBackupTarget(target *neo4jv1beta1.BackupTarget
 	return allErrs
 }
 
-// validateStorageConfiguration validates storage configuration for Neo4j 5.26+
-func (v *BackupValidator) validateStorageConfiguration(storage *neo4jv1beta1.StorageLocation) field.ErrorList {
+// validateStorageConfiguration validates storage configuration for Neo4j 5.26+.
+// specCloud is the top-level spec.cloud block; the operator resolves the
+// effective cloud config as storage.cloud ?? spec.cloud (see getCloudBlock in
+// the backup controller), so provider checks must consider both.
+func (v *BackupValidator) validateStorageConfiguration(storage *neo4jv1beta1.StorageLocation, specCloud *neo4jv1beta1.CloudBlock) field.ErrorList {
 	var allErrs field.ErrorList
 	storagePath := field.NewPath("spec", "storage")
 
@@ -236,7 +239,7 @@ func (v *BackupValidator) validateStorageConfiguration(storage *neo4jv1beta1.Sto
 	}
 
 	// Validate storage provider specific configurations
-	if err := v.validateStorageProvider(storage); err != nil {
+	if err := v.validateStorageProvider(storage, specCloud); err != nil {
 		allErrs = append(allErrs, field.Invalid(
 			storagePath,
 			storage,
@@ -309,9 +312,18 @@ func (v *BackupValidator) validateSchemeSpecificURI(uri, scheme string) error {
 	return nil
 }
 
-// validateStorageProvider validates provider-specific storage configurations
-func (v *BackupValidator) validateStorageProvider(storage *neo4jv1beta1.StorageLocation) error {
+// validateStorageProvider validates provider-specific storage configurations.
+// effectiveCloud mirrors the controller's resolution (storage.cloud ?? spec.cloud)
+// so cloud-provider requirements are checked against the block the operator
+// actually uses — the cloud config commonly lives at spec.cloud, not nested
+// under storage.cloud.
+func (v *BackupValidator) validateStorageProvider(storage *neo4jv1beta1.StorageLocation, specCloud *neo4jv1beta1.CloudBlock) error {
 	storageType := strings.ToLower(storage.Type)
+
+	effectiveCloud := storage.Cloud
+	if effectiveCloud == nil {
+		effectiveCloud = specCloud
+	}
 
 	// For cloud storage providers, validate additional configuration
 	switch storageType {
@@ -320,24 +332,24 @@ func (v *BackupValidator) validateStorageProvider(storage *neo4jv1beta1.StorageL
 		if storage.Bucket == "" {
 			return fmt.Errorf("S3 storage requires bucket name for Neo4j 5.26+")
 		}
-		if storage.Cloud == nil || storage.Cloud.Provider != "aws" {
-			return fmt.Errorf("S3 storage requires cloud provider to be set to 'aws'")
+		if effectiveCloud == nil || effectiveCloud.Provider != "aws" {
+			return fmt.Errorf("S3 storage requires cloud provider 'aws' (set spec.cloud.provider or spec.storage.cloud.provider)")
 		}
 	case "gcs":
 		// GCS specific validations
 		if storage.Bucket == "" {
 			return fmt.Errorf("Google Cloud Storage requires bucket name for Neo4j 5.26+")
 		}
-		if storage.Cloud == nil || storage.Cloud.Provider != "gcp" {
-			return fmt.Errorf("GCS storage requires cloud provider to be set to 'gcp'")
+		if effectiveCloud == nil || effectiveCloud.Provider != "gcp" {
+			return fmt.Errorf("GCS storage requires cloud provider 'gcp' (set spec.cloud.provider or spec.storage.cloud.provider)")
 		}
 	case "azure":
 		// Azure specific validations
 		if storage.Bucket == "" {
 			return fmt.Errorf("Azure Blob Storage requires container name for Neo4j 5.26+")
 		}
-		if storage.Cloud == nil || storage.Cloud.Provider != "azure" {
-			return fmt.Errorf("Azure storage requires cloud provider to be set to 'azure'")
+		if effectiveCloud == nil || effectiveCloud.Provider != "azure" {
+			return fmt.Errorf("Azure storage requires cloud provider 'azure' (set spec.cloud.provider or spec.storage.cloud.provider)")
 		}
 	case "pvc":
 		// PVC specific validations.

--- a/internal/validation/backup_validator.go
+++ b/internal/validation/backup_validator.go
@@ -385,9 +385,19 @@ func (v *BackupValidator) validateStorageProvider(storage *neo4jv1beta1.StorageL
 // macros ("@daily"). A hand-rolled check previously rejected several of those
 // valid forms and, conversely, accepted 6-field expressions that the CronJob
 // then rejected at create time — so we defer to the canonical parser.
-func (v *BackupValidator) validateSchedule(schedule string) error {
-	if _, err := cron.ParseStandard(schedule); err != nil {
-		return fmt.Errorf("invalid cron schedule %q: %v (Kubernetes CronJob expects standard 5-field cron, e.g. \"0 2 * * *\", or a macro like \"@daily\")", schedule, err)
+func (v *BackupValidator) validateSchedule(schedule string) (err error) {
+	// robfig/cron's parser can panic on some malformed inputs (e.g. certain
+	// TZ=/CRON_TZ= forms) instead of returning an error. Kubernetes wraps the
+	// same parser with a recover; do the same so a bad user-supplied schedule
+	// is reported as a validation error rather than crashing the reconcile
+	// worker.
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("invalid cron schedule %q: %v", schedule, r)
+		}
+	}()
+	if _, perr := cron.ParseStandard(schedule); perr != nil {
+		return fmt.Errorf("invalid cron schedule %q: %v (Kubernetes CronJob expects standard 5-field cron, e.g. \"0 2 * * *\", or a macro like \"@daily\")", schedule, perr)
 	}
 	return nil
 }

--- a/internal/validation/backup_validator.go
+++ b/internal/validation/backup_validator.go
@@ -396,6 +396,16 @@ func (v *BackupValidator) validateSchedule(schedule string) (err error) {
 			err = fmt.Errorf("invalid cron schedule %q: %v", schedule, r)
 		}
 	}()
+
+	// robfig/cron's ParseStandard accepts a leading "TZ="/"CRON_TZ=" prefix,
+	// but Kubernetes rejects timezone-embedded strings in CronJob.spec.schedule
+	// (the operator does not set CronJob.spec.timeZone). Accepting them here
+	// would let the CronJob create fail later with an opaque apiserver error,
+	// defeating up-front validation — so reject them with a clear message.
+	if t := strings.TrimSpace(schedule); strings.HasPrefix(t, "TZ=") || strings.HasPrefix(t, "CRON_TZ=") {
+		return fmt.Errorf("cron schedule %q must not embed a timezone (TZ=/CRON_TZ=) — Kubernetes rejects timezone-prefixed CronJob schedules; use a plain UTC schedule such as \"0 2 * * *\"", schedule)
+	}
+
 	if _, perr := cron.ParseStandard(schedule); perr != nil {
 		return fmt.Errorf("invalid cron schedule %q: %v (Kubernetes CronJob expects standard 5-field cron, e.g. \"0 2 * * *\", or a macro like \"@daily\")", schedule, perr)
 	}

--- a/internal/validation/backup_validator.go
+++ b/internal/validation/backup_validator.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	cron "github.com/robfig/cron/v3"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
@@ -55,6 +56,21 @@ func ValidateScheduledBackupName(name string) error {
 			name, len(name), name+"-backup-cron", maxScheduledBackupNameLength)
 	}
 	return nil
+}
+
+// maxAgeShorthand matches the day/hour/minute/second retention shorthand the
+// backup controller's parseFindTimeArg understands (e.g. "7d", "30d", "24h").
+var maxAgeShorthand = regexp.MustCompile(`^[1-9][0-9]*[dhms]$`)
+
+// isValidMaxAge reports whether a retention maxAge is one the operator can
+// actually apply: either the "<n>{d|h|m|s}" shorthand or a value Go's
+// time.ParseDuration accepts. (time.ParseDuration alone rejects "7d"/"30d".)
+func isValidMaxAge(maxAge string) bool {
+	if maxAgeShorthand.MatchString(maxAge) {
+		return true
+	}
+	_, err := time.ParseDuration(maxAge)
+	return err == nil
 }
 
 // BackupValidator validates Neo4j backup configuration for Neo4j 5.26+ compatibility
@@ -349,116 +365,19 @@ func (v *BackupValidator) validateStorageProvider(storage *neo4jv1beta1.StorageL
 	return nil
 }
 
-// validateSchedule validates cron schedule format
+// validateSchedule validates the cron schedule using the SAME parser
+// Kubernetes uses for CronJob.spec.schedule (github.com/robfig/cron/v3
+// ParseStandard). This guarantees the operator accepts exactly what the
+// generated CronJob will accept — standard 5-field cron plus lists ("0,30"),
+// ranges ("1-5"), steps ("*/15", "1-30/5"), names ("MON-FRI", "JAN"), and
+// macros ("@daily"). A hand-rolled check previously rejected several of those
+// valid forms and, conversely, accepted 6-field expressions that the CronJob
+// then rejected at create time — so we defer to the canonical parser.
 func (v *BackupValidator) validateSchedule(schedule string) error {
-	// Basic cron validation (5 or 6 fields)
-	fields := strings.Fields(schedule)
-	if len(fields) < 5 || len(fields) > 6 {
-		return fmt.Errorf("invalid cron schedule format. Expected 5 or 6 fields, got %d", len(fields))
+	if _, err := cron.ParseStandard(schedule); err != nil {
+		return fmt.Errorf("invalid cron schedule %q: %v (Kubernetes CronJob expects standard 5-field cron, e.g. \"0 2 * * *\", or a macro like \"@daily\")", schedule, err)
 	}
-
-	// Validate each field in the cron expression
-
-	for i, field := range fields {
-		switch i {
-		case 0: // Second (if 6 fields) or Minute (if 5 fields)
-			if len(fields) == 6 {
-				// Second field (0-59)
-				if !v.validateCronField(field, 0, 59) {
-					return fmt.Errorf("invalid second field in cron schedule: %s", field)
-				}
-			} else {
-				// Minute field (0-59)
-				if !v.validateCronField(field, 0, 59) {
-					return fmt.Errorf("invalid minute field in cron schedule: %s", field)
-				}
-			}
-		case 1: // Minute (if 6 fields) or Hour (if 5 fields)
-			if len(fields) == 6 {
-				// Minute field (0-59)
-				if !v.validateCronField(field, 0, 59) {
-					return fmt.Errorf("invalid minute field in cron schedule: %s", field)
-				}
-			} else {
-				// Hour field (0-23)
-				if !v.validateCronField(field, 0, 23) {
-					return fmt.Errorf("invalid hour field in cron schedule: %s", field)
-				}
-			}
-		case 2: // Hour (if 6 fields) or Day (if 5 fields)
-			if len(fields) == 6 {
-				// Hour field (0-23)
-				if !v.validateCronField(field, 0, 23) {
-					return fmt.Errorf("invalid hour field in cron schedule: %s", field)
-				}
-			} else {
-				// Day field (1-31)
-				if !v.validateCronField(field, 1, 31) {
-					return fmt.Errorf("invalid day field in cron schedule: %s", field)
-				}
-			}
-		case 3: // Day (if 6 fields) or Month (if 5 fields)
-			if len(fields) == 6 {
-				// Day field (1-31)
-				if !v.validateCronField(field, 1, 31) {
-					return fmt.Errorf("invalid day field in cron schedule: %s", field)
-				}
-			} else {
-				// Month field (1-12)
-				if !v.validateCronField(field, 1, 12) {
-					return fmt.Errorf("invalid month field in cron schedule: %s", field)
-				}
-			}
-		case 4: // Month (if 6 fields) or Day of week (if 5 fields)
-			if len(fields) == 6 {
-				// Month field (1-12)
-				if !v.validateCronField(field, 1, 12) {
-					return fmt.Errorf("invalid month field in cron schedule: %s", field)
-				}
-			} else {
-				// Day of week field (0-7, where 0 and 7 are Sunday)
-				if !v.validateCronField(field, 0, 7) {
-					return fmt.Errorf("invalid day of week field in cron schedule: %s", field)
-				}
-			}
-		case 5: // Day of week (only if 6 fields)
-			// Day of week field (0-7, where 0 and 7 are Sunday)
-			if !v.validateCronField(field, 0, 7) {
-				return fmt.Errorf("invalid day of week field in cron schedule: %s", field)
-			}
-		}
-	}
-
 	return nil
-}
-
-// validateCronField validates individual cron field
-func (v *BackupValidator) validateCronField(field string, min, max int) bool {
-	if field == "*" {
-		return true
-	}
-
-	// Handle step values (*/n)
-	if strings.HasPrefix(field, "*/") {
-		stepStr := field[2:]
-		step, err := strconv.Atoi(stepStr)
-		return err == nil && step > 0 && step <= max
-	}
-
-	// Handle ranges (n-m)
-	if strings.Contains(field, "-") {
-		parts := strings.Split(field, "-")
-		if len(parts) != 2 {
-			return false
-		}
-		start, err1 := strconv.Atoi(parts[0])
-		end, err2 := strconv.Atoi(parts[1])
-		return err1 == nil && err2 == nil && start >= min && start <= max && end >= min && end <= max && start <= end
-	}
-
-	// Handle single number
-	num, err := strconv.Atoi(field)
-	return err == nil && num >= min && num <= max
 }
 
 // validateCloudConfiguration validates cloud-specific backup configuration
@@ -503,15 +422,18 @@ func (v *BackupValidator) validateRetentionPolicy(retention *neo4jv1beta1.Retent
 	var allErrs field.ErrorList
 	retentionPath := field.NewPath("spec", "retention")
 
-	// Validate max age format if specified
-	if retention.MaxAge != "" {
-		if _, err := time.ParseDuration(retention.MaxAge); err != nil {
-			allErrs = append(allErrs, field.Invalid(
-				retentionPath.Child("maxAge"),
-				retention.MaxAge,
-				"invalid duration format. Use format like '24h', '7d', '30d'",
-			))
-		}
+	// Validate max age format if specified. The runtime (parseFindTimeArg in
+	// the backup controller) accepts a day/hour/minute/second shorthand like
+	// "7d", "30d", "24h" — which Go's time.ParseDuration rejects (no "d"
+	// unit). Accept the shorthand the runtime understands, and also tolerate
+	// any value time.ParseDuration accepts, so the validator never rejects a
+	// maxAge the operator can actually apply.
+	if retention.MaxAge != "" && !isValidMaxAge(retention.MaxAge) {
+		allErrs = append(allErrs, field.Invalid(
+			retentionPath.Child("maxAge"),
+			retention.MaxAge,
+			"invalid duration format. Use a value like '7d', '30d', '24h', or '90m'",
+		))
 	}
 
 	// Validate max count

--- a/internal/validation/backup_validator_test.go
+++ b/internal/validation/backup_validator_test.go
@@ -569,6 +569,8 @@ func TestValidateSchedule(t *testing.T) {
 		{"0 0 2 * * *", true},         // 6-field — K8s CronJob rejects (was wrongly accepted before)
 		{"* * * *", true},             // 4-field
 		{"not-a-cron", true},
+		{"CRON_TZ=UTC 0 0 * * *", false}, // CRON_TZ= prefix is supported by ParseStandard
+		{"", true},                       // empty → error (and must not panic; validateSchedule recovers)
 	}
 	for _, tc := range cases {
 		t.Run(tc.schedule, func(t *testing.T) {

--- a/internal/validation/backup_validator_test.go
+++ b/internal/validation/backup_validator_test.go
@@ -607,3 +607,29 @@ func TestIsValidMaxAge(t *testing.T) {
 		})
 	}
 }
+
+// TestBackupValidator_CloudAtSpecLevel pins the fix for the regression that
+// surfaced when BackupValidator was wired into the reconciler: cloud config
+// commonly lives at the top-level spec.cloud (not nested under spec.storage.cloud),
+// and the reconciler resolves storage.cloud ?? spec.cloud. The validator must
+// accept a cloud backup whose provider is set only at spec.cloud.
+func TestBackupValidator_CloudAtSpecLevel(t *testing.T) {
+	v := NewBackupValidator()
+	backup := &neo4jv1beta1.Neo4jBackup{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-backup"},
+		Spec: neo4jv1beta1.Neo4jBackupSpec{
+			Target:  neo4jv1beta1.BackupTarget{Kind: "Cluster", Name: "test-cluster"},
+			Storage: neo4jv1beta1.StorageLocation{Type: "s3", Bucket: "test-bucket"}, // no nested storage.cloud
+			Cloud:   &neo4jv1beta1.CloudBlock{Provider: "aws"},                       // provider only at spec.cloud
+		},
+	}
+	if errs := v.Validate(backup); len(errs) != 0 {
+		t.Errorf("expected no errors for S3 backup with provider at spec.cloud, got: %v", errs)
+	}
+
+	// And it still rejects when neither spec.cloud nor storage.cloud has a provider.
+	backup.Spec.Cloud = nil
+	if errs := v.Validate(backup); len(errs) == 0 {
+		t.Error("expected an error for S3 backup with no cloud provider anywhere")
+	}
+}

--- a/internal/validation/backup_validator_test.go
+++ b/internal/validation/backup_validator_test.go
@@ -569,8 +569,11 @@ func TestValidateSchedule(t *testing.T) {
 		{"0 0 2 * * *", true},         // 6-field — K8s CronJob rejects (was wrongly accepted before)
 		{"* * * *", true},             // 4-field
 		{"not-a-cron", true},
-		{"CRON_TZ=UTC 0 0 * * *", false}, // CRON_TZ= prefix is supported by ParseStandard
-		{"", true},                       // empty → error (and must not panic; validateSchedule recovers)
+		// Timezone-embedded schedules parse in robfig/cron but Kubernetes
+		// rejects them in CronJob.spec.schedule — reject up front.
+		{"CRON_TZ=UTC 0 0 * * *", true},
+		{"TZ=America/New_York 0 0 * * *", true},
+		{"", true}, // empty → error (and must not panic; validateSchedule recovers)
 	}
 	for _, tc := range cases {
 		t.Run(tc.schedule, func(t *testing.T) {

--- a/internal/validation/backup_validator_test.go
+++ b/internal/validation/backup_validator_test.go
@@ -554,3 +554,56 @@ func TestValidateScheduledBackupName(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateSchedule(t *testing.T) {
+	v := &BackupValidator{}
+	cases := []struct {
+		schedule  string
+		expectErr bool
+	}{
+		{"0 2 * * *", false},          // standard 5-field
+		{"0,30 * * * *", false},       // comma list (was wrongly rejected before)
+		{"0 9-17 * * MON-FRI", false}, // range + named days
+		{"*/15 * * * *", false},       // step
+		{"@daily", false},             // macro
+		{"0 0 2 * * *", true},         // 6-field — K8s CronJob rejects (was wrongly accepted before)
+		{"* * * *", true},             // 4-field
+		{"not-a-cron", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.schedule, func(t *testing.T) {
+			err := v.validateSchedule(tc.schedule)
+			if tc.expectErr && err == nil {
+				t.Fatalf("expected error for schedule %q", tc.schedule)
+			}
+			if !tc.expectErr && err != nil {
+				t.Fatalf("unexpected error for schedule %q: %v", tc.schedule, err)
+			}
+		})
+	}
+}
+
+func TestIsValidMaxAge(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"7d", true}, // runtime shorthand — time.ParseDuration rejects this
+		{"30d", true},
+		{"24h", true},
+		{"90m", true},
+		{"45s", true},
+		{"1h30m", true}, // valid Go duration
+		{"7days", false},
+		{"0d", false},
+		{"abc", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			if got := isValidMaxAge(tc.in); got != tc.want {
+				t.Errorf("isValidMaxAge(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #159.

## Problem
`BackupValidator` was written but **never invoked** by any controller — the Neo4jBackup reconciler only called the standalone `ValidateNeo4jVersion` / `ValidateScheduledBackupName`. So target / storage / schedule / cloud / retention / options validation was dead at runtime.

Wiring it in **as-is would have rejected CRs the operator actually accepts**, so this PR fixes the false-positives first, then wires it.

## False-positives fixed
- **Cron schedule** — the hand-rolled field parser rejected valid forms (comma lists `0,30 * * * *`, ranges, names `MON-FRI`, macros `@daily`) and *wrongly accepted* 6-field expressions the CronJob then rejects at create time. Replaced with **`robfig/cron/v3` `ParseStandard`** — the exact parser Kubernetes uses for `CronJob.spec.schedule`, so the validator now accepts precisely what the generated CronJob will.
- **Retention `maxAge`** — `7d`/`30d` are supported by the runtime (`parseFindTimeArg`) but rejected by `time.ParseDuration`. Now accepts the `<n>{d|h|m|s}` shorthand (and any Go duration).

## Wiring
`Reconcile` runs `NewBackupValidator().Validate(backup)` right after the finalizer step (before any cluster lookup or resource creation). Invalid spec → `phase=Invalid` (recoverable — fixing the spec re-triggers reconcile; distinct from the terminal one-time `Failed` guard) + Warning event, and **no resources created**. `Invalid` maps to `Ready=False`. The now-redundant inline `ValidateScheduledBackupName` guard in `handleScheduledBackup` is removed.

## Tests
- `validateSchedule`: comma/range/names/macros accepted; 6-field and 4-field rejected.
- `isValidMaxAge`: `7d`/`30d`/`24h` accepted; `7days`/`0d`/`abc` rejected.
- Reconcile-level negative test: invalid spec → `Invalid`, no CronJob created.
- Adds `github.com/robfig/cron/v3` as a direct dependency.

## Notes
Found during this work: **`PluginValidator` is also dormant** (never wired). Filed separately as a follow-up. The other wired validators (Cluster/Standalone/Database/ShardedDatabase/User/Role/RoleBinding/AuthRule) are fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes backup reconcile gating and validation semantics; invalid or previously edge-case specs may now stop earlier with phase=Invalid, while some formerly rejected valid specs (cron, maxAge, spec.cloud) should pass.
> 
> **Overview**
> **Neo4jBackup** reconciliation now runs the full **`BackupValidator`** immediately after the finalizer is in place and **before** any cluster lookup or Job/CronJob creation. Invalid specs set **`phase=Invalid`** (recoverable; **`Ready=False`**) with an aggregated message and warning event, with **no requeue** and **no backing resources**. The duplicate scheduled-name check in **`handleScheduledBackup`** is removed because validation covers it centrally.
> 
> Validator fixes so wiring does not reject valid CRs: **cron** uses **`robfig/cron/v3` `ParseStandard`** (aligned with Kubernetes CronJobs), with panic recovery and explicit rejection of **`TZ=` / `CRON_TZ=`** prefixes; **retention `maxAge`** accepts runtime shorthands like **`7d`** via **`isValidMaxAge`**; **S3/GCS/Azure** provider checks use **`spec.storage.cloud` ?? `spec.cloud`**, matching the controller’s **`cloudBlockForBackup`** resolution.
> 
> Adds direct dependency on **`github.com/robfig/cron/v3`** and tests at validator and reconcile levels (including **`Invalid`** vs former **`Failed`** for long scheduled names).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eecbc0810ce5164c8c6c90bfad89399045eb514a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->