### PR TITLE
fix(database): drop the database on standalone hosts when the CR is deleted

### DIFF
--- a/internal/controller/neo4jdatabase_controller.go
+++ b/internal/controller/neo4jdatabase_controller.go
@@ -124,40 +124,19 @@ func (r *Neo4jDatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}
 
-	// Get referenced cluster or standalone
-	cluster := &neo4jv1beta1.Neo4jEnterpriseCluster{}
-	clusterKey := types.NamespacedName{
-		Name:      database.Spec.ClusterRef,
-		Namespace: database.Namespace,
+	// Get referenced cluster or standalone (shared with handleDeletion via
+	// resolveDatabaseHost so the create and delete paths can't drift).
+	cluster, standalone, isStandalone, found, err := r.resolveDatabaseHost(ctx, database)
+	if err != nil {
+		logger.Error(err, "Failed to get referenced cluster/standalone")
+		return ctrl.Result{}, err
 	}
-
-	clusterErr := r.Get(ctx, clusterKey, cluster)
-	var standalone *neo4jv1beta1.Neo4jEnterpriseStandalone
-	var isStandalone bool
-
-	// If cluster not found, try to get standalone
-	if errors.IsNotFound(clusterErr) {
-		standalone = &neo4jv1beta1.Neo4jEnterpriseStandalone{}
-		standaloneKey := types.NamespacedName{
-			Name:      database.Spec.ClusterRef,
-			Namespace: database.Namespace,
-		}
-
-		if err := r.Get(ctx, standaloneKey, standalone); err != nil {
-			if errors.IsNotFound(err) {
-				r.updateDatabaseStatus(ctx, database, metav1.ConditionFalse, EventReasonClusterNotFound,
-					fmt.Sprintf("Referenced cluster %s not found", database.Spec.ClusterRef))
-				r.Recorder.Eventf(database, corev1.EventTypeWarning, EventReasonClusterNotFound,
-					"Referenced cluster %s not found", database.Spec.ClusterRef)
-				return ctrl.Result{RequeueAfter: r.RequeueAfter}, nil
-			}
-			logger.Error(err, "Failed to get referenced standalone")
-			return ctrl.Result{}, err
-		}
-		isStandalone = true
-	} else if clusterErr != nil {
-		logger.Error(clusterErr, "Failed to get referenced cluster")
-		return ctrl.Result{}, clusterErr
+	if !found {
+		r.updateDatabaseStatus(ctx, database, metav1.ConditionFalse, EventReasonClusterNotFound,
+			fmt.Sprintf("Referenced cluster %s not found", database.Spec.ClusterRef))
+		r.Recorder.Eventf(database, corev1.EventTypeWarning, EventReasonClusterNotFound,
+			"Referenced cluster %s not found", database.Spec.ClusterRef)
+		return ctrl.Result{RequeueAfter: r.RequeueAfter}, nil
 	}
 
 	// Check if cluster/standalone is ready
@@ -176,7 +155,7 @@ func (r *Neo4jDatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	// Create Neo4j client with retry for transient connection issues
 	var neo4jClient *neo4j.Client
-	err := retry.OnError(retry.DefaultBackoff, func(err error) bool {
+	err = retry.OnError(retry.DefaultBackoff, func(err error) bool {
 		// Retry on connection errors
 		return strings.Contains(err.Error(), "connection") || strings.Contains(err.Error(), "timeout")
 	}, func() error {
@@ -300,37 +279,36 @@ func (r *Neo4jDatabaseReconciler) handleDeletion(ctx context.Context, database *
 
 	logger.Info("Starting deletion handler", "finalizers", database.Finalizers, "deletionTimestamp", database.DeletionTimestamp)
 
-	// Get referenced cluster
-	cluster := &neo4jv1beta1.Neo4jEnterpriseCluster{}
-	clusterKey := types.NamespacedName{
-		Name:      database.Spec.ClusterRef,
-		Namespace: database.Namespace,
-	}
-	if err := r.Get(ctx, clusterKey, cluster); err != nil {
-		if errors.IsNotFound(err) {
-			logger.Info("Referenced cluster not found, removing finalizer", "clusterKey", clusterKey)
-			controllerutil.RemoveFinalizer(database, DatabaseFinalizer)
-			err := r.Update(ctx, database)
-			if err != nil {
-				logger.Error(err, "Failed to update database after removing finalizer")
-			}
-			return ctrl.Result{}, err
-		}
-		logger.Error(err, "Failed to get referenced cluster during deletion")
+	// Resolve the referenced host — cluster first, then standalone. A
+	// standalone-targeted database previously failed to drop here because this
+	// path only looked up clusters: the cluster Get returned NotFound, the
+	// finalizer was removed, and DropDatabase was never called — orphaning the
+	// database in Neo4j. resolveDatabaseHost (shared with Reconcile) fixes that.
+	cluster, standalone, isStandalone, found, err := r.resolveDatabaseHost(ctx, database)
+	if err != nil {
+		logger.Error(err, "Failed to resolve referenced host during deletion")
 		return ctrl.Result{}, err
+	}
+	if !found {
+		// Neither cluster nor standalone exists — the host (and its databases)
+		// are gone, so there is nothing to drop. Release the finalizer.
+		logger.Info("Referenced cluster/standalone not found, removing finalizer", "clusterRef", database.Spec.ClusterRef)
+		controllerutil.RemoveFinalizer(database, DatabaseFinalizer)
+		return ctrl.Result{}, r.Update(ctx, database)
 	}
 
-	// Create Neo4j client
-	neo4jClient, err := r.createNeo4jClient(ctx, cluster)
+	// Create the Neo4j client for the resolved host (cluster or standalone).
+	var neo4jClient *neo4j.Client
+	if isStandalone {
+		neo4jClient, err = r.createNeo4jClientForStandalone(ctx, standalone)
+	} else {
+		neo4jClient, err = r.createNeo4jClient(ctx, cluster)
+	}
 	if err != nil {
 		logger.Error(err, "Failed to create Neo4j client during deletion")
-		// If we can't connect, assume database is already gone
+		// If we can't connect, assume the database is already gone.
 		controllerutil.RemoveFinalizer(database, DatabaseFinalizer)
-		err := r.Update(ctx, database)
-		if err != nil {
-			logger.Error(err, "Failed to update database after removing finalizer")
-		}
-		return ctrl.Result{}, err
+		return ctrl.Result{}, r.Update(ctx, database)
 	}
 	defer func() {
 		if err := neo4jClient.Close(); err != nil {
@@ -357,6 +335,37 @@ func (r *Neo4jDatabaseReconciler) handleDeletion(ctx context.Context, database *
 	}
 	logger.Info("Successfully removed finalizer and updated database", "finalizers", database.Finalizers, "deletionTimestamp", database.DeletionTimestamp)
 	return ctrl.Result{}, nil
+}
+
+// resolveDatabaseHost looks up the Neo4jDatabase's referenced host, trying a
+// Neo4jEnterpriseCluster first and then a Neo4jEnterpriseStandalone of the same
+// name (same precedence as DatabaseValidator). found is false (with a nil
+// error) when neither exists; err is non-nil only on an unexpected
+// (non-NotFound) API error. Both Reconcile and handleDeletion use this so the
+// create and delete paths can't drift on host resolution — a
+// standalone-targeted database previously failed to drop on delete because
+// handleDeletion only looked up clusters.
+func (r *Neo4jDatabaseReconciler) resolveDatabaseHost(ctx context.Context, database *neo4jv1beta1.Neo4jDatabase) (cluster *neo4jv1beta1.Neo4jEnterpriseCluster, standalone *neo4jv1beta1.Neo4jEnterpriseStandalone, isStandalone, found bool, err error) {
+	key := types.NamespacedName{Name: database.Spec.ClusterRef, Namespace: database.Namespace}
+
+	cluster = &neo4jv1beta1.Neo4jEnterpriseCluster{}
+	cErr := r.Get(ctx, key, cluster)
+	if cErr == nil {
+		return cluster, nil, false, true, nil
+	}
+	if !errors.IsNotFound(cErr) {
+		return nil, nil, false, false, cErr
+	}
+
+	standalone = &neo4jv1beta1.Neo4jEnterpriseStandalone{}
+	sErr := r.Get(ctx, key, standalone)
+	if sErr == nil {
+		return nil, standalone, true, true, nil
+	}
+	if errors.IsNotFound(sErr) {
+		return nil, nil, false, false, nil
+	}
+	return nil, nil, false, false, sErr
 }
 
 func (r *Neo4jDatabaseReconciler) ensureDatabase(ctx context.Context, client *neo4j.Client, database *neo4jv1beta1.Neo4jDatabase) error {

--- a/internal/controller/neo4jdatabase_resolvehost_test.go
+++ b/internal/controller/neo4jdatabase_resolvehost_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
+)
+
+func newDatabaseReconcilerForResolve(t *testing.T, objs ...client.Object) *Neo4jDatabaseReconciler {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, neo4jv1beta1.AddToScheme(scheme))
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	return &Neo4jDatabaseReconciler{Client: c, Scheme: scheme}
+}
+
+// TestResolveDatabaseHost covers the shared cluster-or-standalone resolution
+// used by both Reconcile and handleDeletion. The standalone case is the
+// regression that caused Neo4jDatabase deletion to silently skip DropDatabase
+// on standalone hosts (handleDeletion used to look up only clusters).
+func TestResolveDatabaseHost(t *testing.T) {
+	ctx := context.Background()
+	ns := "default"
+	db := func(ref string) *neo4jv1beta1.Neo4jDatabase {
+		return &neo4jv1beta1.Neo4jDatabase{
+			ObjectMeta: metav1.ObjectMeta{Name: "db", Namespace: ns},
+			Spec:       neo4jv1beta1.Neo4jDatabaseSpec{Name: "mydb", ClusterRef: ref},
+		}
+	}
+
+	t.Run("resolves a cluster", func(t *testing.T) {
+		cl := &neo4jv1beta1.Neo4jEnterpriseCluster{ObjectMeta: metav1.ObjectMeta{Name: "c1", Namespace: ns}}
+		r := newDatabaseReconcilerForResolve(t, cl)
+		cluster, standalone, isStandalone, found, err := r.resolveDatabaseHost(ctx, db("c1"))
+		require.NoError(t, err)
+		assert.True(t, found)
+		assert.False(t, isStandalone)
+		assert.NotNil(t, cluster)
+		assert.Nil(t, standalone)
+	})
+
+	t.Run("falls back to a standalone (deletion regression)", func(t *testing.T) {
+		sa := &neo4jv1beta1.Neo4jEnterpriseStandalone{ObjectMeta: metav1.ObjectMeta{Name: "s1", Namespace: ns}}
+		r := newDatabaseReconcilerForResolve(t, sa)
+		cluster, standalone, isStandalone, found, err := r.resolveDatabaseHost(ctx, db("s1"))
+		require.NoError(t, err)
+		assert.True(t, found)
+		assert.True(t, isStandalone)
+		assert.Nil(t, cluster)
+		assert.NotNil(t, standalone)
+	})
+
+	t.Run("neither cluster nor standalone → not found, no error", func(t *testing.T) {
+		r := newDatabaseReconcilerForResolve(t)
+		_, _, _, found, err := r.resolveDatabaseHost(ctx, db("ghost"))
+		require.NoError(t, err)
+		assert.False(t, found)
+	})
+}


### PR DESCRIPTION
Closes #165.

## Problem
Deleting a `Neo4jDatabase` CR drops the database on a **cluster** but silently leaves it on a **standalone**.

`handleDeletion` only looked up a `Neo4jEnterpriseCluster`. For a standalone-targeted database the cluster `Get` returns `NotFound`, so the code assumed the host was gone, **removed the finalizer, and returned without calling `DropDatabase`** — the CR disappears from Kubernetes but the database remains in Neo4j (silent orphan).

The create/update path already resolved cluster-then-standalone; `handleDeletion` never got that fallback, and the two drifted.

## Fix
Extract the host resolution into a shared `resolveDatabaseHost(ctx, database)` helper (cluster first, then standalone — same precedence as `DatabaseValidator`) used by **both** `Reconcile` and `handleDeletion`, so they can't diverge again.

`handleDeletion` now connects to the standalone (`createNeo4jClientForStandalone`) and drops the database. The finalizer is released **without** a drop only when **neither** cluster nor standalone exists (host genuinely gone) — preserving the existing "host gone → release finalizer" behavior.

## Tests
Unit test `TestResolveDatabaseHost`: resolves a cluster; **falls back to a standalone** (the regression); neither → not-found, no error. (`DropDatabase` itself needs a live Bolt connection, so it's covered by the resolution unit test rather than envtest.)

## Notes
Pre-existing behavior preserved (not changed here): "client creation fails → assume DB gone, release finalizer." It's orthogonal to this bug, though arguably risky (a briefly-unreachable host could orphan a DB) — happy to tighten in a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deletion and finalizer behavior for databases on standalones; incorrect resolution could still skip DropDatabase or drop against the wrong host, though logic is centralized and unit-tested.
> 
> **Overview**
> Fixes a bug where deleting a `Neo4jDatabase` pointed at a **standalone** host removed the Kubernetes finalizer without calling **`DropDatabase`**, leaving an orphaned database in Neo4j. **`handleDeletion`** only fetched `Neo4jEnterpriseCluster`; a missing cluster was treated as “host gone,” while reconcile already supported cluster-then-standalone.
> 
> This PR adds shared **`resolveDatabaseHost`** (cluster first, then standalone, aligned with **`DatabaseValidator`**) and uses it in both **`Reconcile`** and **`handleDeletion`**. On delete, the reconciler now builds the correct Neo4j client for standalones and drops the database; the finalizer is cleared without a drop only when **neither** host CR exists. **`TestResolveDatabaseHost`** covers cluster resolution, standalone fallback, and not-found.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccda084e0d91aa0acf13c68a44bc269f3cad8a9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->