### PR TITLE
fix(plugin): wire the dormant PluginValidator into the reconciler

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -380,6 +380,7 @@ func setupProductionControllers(mgr ctrl.Manager) error {
 				Recorder:        mgr.GetEventRecorderFor("neo4j-plugin-controller"),
 				RequeueAfter:    controller.GetTestRequeueAfter(),
 				PluginInitImage: os.Getenv("PLUGIN_INIT_CONTAINER_IMAGE"),
+				Validator:       validation.NewPluginValidator(),
 			},
 		},
 		{
@@ -506,6 +507,7 @@ func setupDevelopmentControllers(mgr ctrl.Manager, controllers []string) error {
 				Recorder:        mgr.GetEventRecorderFor("neo4j-plugin-controller"),
 				RequeueAfter:    controller.GetTestRequeueAfter(),
 				PluginInitImage: os.Getenv("PLUGIN_INIT_CONTAINER_IMAGE"),
+				Validator:       validation.NewPluginValidator(),
 			}, "Neo4jPlugin"
 		},
 		"shardeddatabase": func() (interface{ SetupWithManager(ctrl.Manager) error }, string) {

--- a/internal/controller/plugin_controller.go
+++ b/internal/controller/plugin_controller.go
@@ -38,6 +38,7 @@ import (
 	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
 	neo4jclient "github.com/neo4j-partners/neo4j-kubernetes-operator/internal/neo4j"
 	"github.com/neo4j-partners/neo4j-kubernetes-operator/internal/resources"
+	"github.com/neo4j-partners/neo4j-kubernetes-operator/internal/validation"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -120,6 +121,13 @@ type Neo4jPluginReconciler struct {
 	Scheme       *runtime.Scheme
 	Recorder     record.EventRecorder
 	RequeueAfter time.Duration
+
+	// Validator performs structural validation of the Neo4jPlugin spec
+	// (name/version/source/checksum/dependencies/security/resources) inline
+	// before any install work. Hard errors short-circuit the reconcile into
+	// the "Invalid" phase; compatibility-matrix advisories are surfaced as
+	// Warning events only. Always set via NewPluginValidator() in cmd/main.go.
+	Validator *validation.PluginValidator
 
 	// PluginInitImage overrides the default init container image
 	// (resources.DefaultPluginInitContainerImage) used for
@@ -227,6 +235,25 @@ func (r *Neo4jPluginReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{Requeue: true}, nil
+	}
+
+	// Structural validation gate. Hard errors (missing name/version, bad
+	// source/checksum, conflicting security, VerifiedDownload gaps) leave the
+	// plugin in "Invalid" with no requeue — re-edit the CR to retry. The
+	// compatibility matrix produces advisory Warnings only (the operator
+	// installs arbitrary, incl. URL-sourced, plugins and is forward-compatible
+	// across Neo4j versions), so those never block install.
+	if r.Validator != nil {
+		result := r.Validator.Validate(plugin)
+		for _, w := range result.Warnings {
+			r.Recorder.Event(plugin, corev1.EventTypeWarning, EventReasonValidationWarning, w)
+		}
+		if len(result.Errors) > 0 {
+			msg := fmt.Sprintf("Neo4jPlugin spec is invalid: %s", result.Errors.ToAggregate().Error())
+			r.updatePluginStatus(ctx, plugin, "Invalid", msg)
+			r.Recorder.Event(plugin, corev1.EventTypeWarning, EventReasonValidationFailed, msg)
+			return ctrl.Result{}, nil
+		}
 	}
 
 	// Refuse to reconcile if another Neo4jPlugin CR already owns this

--- a/internal/validation/plugin_validator.go
+++ b/internal/validation/plugin_validator.go
@@ -40,13 +40,22 @@ func NewPluginValidator() *PluginValidator {
 	return &PluginValidator{}
 }
 
-// Validate validates the plugin configuration for Neo4j 5.26+ compatibility
-func (v *PluginValidator) Validate(plugin *neo4jv1beta1.Neo4jPlugin) field.ErrorList {
-	var allErrs field.ErrorList
+// PluginValidationResult carries hard errors (which block install) separately
+// from advisory warnings (surfaced as events but never block). Mirrors
+// DatabaseValidationResult so callers handle both validators uniformly.
+type PluginValidationResult struct {
+	Errors   field.ErrorList
+	Warnings []string
+}
+
+// Validate validates the plugin configuration for Neo4j 5.26+ compatibility.
+// Hard errors land in Errors; advisory compatibility notes land in Warnings.
+func (v *PluginValidator) Validate(plugin *neo4jv1beta1.Neo4jPlugin) *PluginValidationResult {
+	result := &PluginValidationResult{}
 
 	// Validate plugin name
 	if plugin.Spec.Name == "" {
-		allErrs = append(allErrs, field.Required(
+		result.Errors = append(result.Errors, field.Required(
 			field.NewPath("spec", "name"),
 			"plugin name must be specified",
 		))
@@ -54,47 +63,46 @@ func (v *PluginValidator) Validate(plugin *neo4jv1beta1.Neo4jPlugin) field.Error
 
 	// Validate plugin version
 	if plugin.Spec.Version == "" {
-		allErrs = append(allErrs, field.Required(
+		result.Errors = append(result.Errors, field.Required(
 			field.NewPath("spec", "version"),
 			"plugin version must be specified",
 		))
 	}
 
-	// Validate plugin compatibility with Neo4j 5.26+
+	// Plugin compatibility with the known matrix is advisory only — the
+	// operator installs arbitrary (incl. URL-sourced) plugins and is
+	// forward-compatible across Neo4j versions, so an unknown/older entry is
+	// a warning, never a hard reject.
 	if plugin.Spec.Name != "" && plugin.Spec.Version != "" {
-		if err := v.validatePluginCompatibility(plugin.Spec.Name, plugin.Spec.Version); err != nil {
-			allErrs = append(allErrs, field.Invalid(
-				field.NewPath("spec", "name"),
-				plugin.Spec.Name,
-				err.Error(),
-			))
+		if msg := v.pluginCompatibilityWarning(plugin.Spec.Name, plugin.Spec.Version); msg != "" {
+			result.Warnings = append(result.Warnings, msg)
 		}
 	}
 
 	// Validate plugin source
 	if plugin.Spec.Source != nil {
-		allErrs = append(allErrs, v.validatePluginSource(plugin.Spec.Source)...)
+		result.Errors = append(result.Errors, v.validatePluginSource(plugin.Spec.Source)...)
 	}
 
 	// Validate plugin dependencies
 	if len(plugin.Spec.Dependencies) > 0 {
-		allErrs = append(allErrs, v.validatePluginDependencies(plugin.Spec.Dependencies)...)
+		result.Errors = append(result.Errors, v.validatePluginDependencies(plugin.Spec.Dependencies)...)
 	}
 
 	// Validate plugin security configuration
 	if plugin.Spec.Security != nil {
-		allErrs = append(allErrs, v.validatePluginSecurity(plugin.Spec.Security)...)
+		result.Errors = append(result.Errors, v.validatePluginSecurity(plugin.Spec.Security)...)
 	}
 
 	// Validate plugin resources
 	if plugin.Spec.Resources != nil {
-		allErrs = append(allErrs, v.validatePluginResources(plugin.Spec.Resources)...)
+		result.Errors = append(result.Errors, v.validatePluginResources(plugin.Spec.Resources)...)
 	}
 
 	// Cross-field gates for installMode: VerifiedDownload.
-	allErrs = append(allErrs, v.validateVerifiedDownloadMode(plugin)...)
+	result.Errors = append(result.Errors, v.validateVerifiedDownloadMode(plugin)...)
 
-	return allErrs
+	return result
 }
 
 // validateVerifiedDownloadMode enforces the gates the VerifiedDownload
@@ -154,7 +162,14 @@ func (v *PluginValidator) validateVerifiedDownloadMode(plugin *neo4jv1beta1.Neo4
 }
 
 // validatePluginCompatibility validates plugin compatibility with Neo4j 5.26+
-func (v *PluginValidator) validatePluginCompatibility(name, version string) error {
+// pluginCompatibilityWarning returns an advisory message when a plugin isn't
+// in the known compatibility matrix, is deprecated, or is below the matrix's
+// recorded minimum version. It NEVER hard-rejects: the operator installs
+// arbitrary (incl. URL-sourced) plugins and is forward-compatible across
+// Neo4j versions, and this matrix is a best-effort convenience that drifts as
+// Neo4j ships new plugins (and uses different labels, e.g. "neo4j-bloom" vs
+// the operator's "bloom"). Returns "" when nothing noteworthy.
+func (v *PluginValidator) pluginCompatibilityWarning(name, version string) string {
 	// Define known plugins and their minimum compatible versions with Neo4j 5.26+
 	compatibilityMatrix := map[string]string{
 		"apoc":                   "5.26.0",
@@ -177,21 +192,23 @@ func (v *PluginValidator) validatePluginCompatibility(name, version string) erro
 	// Check if plugin is known
 	minVersion, exists := compatibilityMatrix[strings.ToLower(name)]
 	if !exists {
-		// For unknown plugins, require they explicitly state Neo4j 5.26+ compatibility
-		return fmt.Errorf("plugin '%s' is not in the known compatibility matrix. Please verify it supports Neo4j 5.26+", name)
+		// Unknown plugins are common and legitimate (URL-sourced, newly
+		// shipped, or labelled differently than this matrix records) — note
+		// it, don't block.
+		return fmt.Sprintf("plugin '%s' is not in the operator's known compatibility matrix — verify it supports your Neo4j version", name)
 	}
 
 	// Check for deprecated plugins
 	if minVersion == "deprecated" {
-		return fmt.Errorf("plugin '%s' is deprecated in Neo4j 5.26+. Please use alternative plugins", name)
+		return fmt.Sprintf("plugin '%s' is deprecated in Neo4j 5.26+ — consider an alternative", name)
 	}
 
 	// Validate version against minimum requirement
 	if !v.isPluginVersionCompatible(version, minVersion) {
-		return fmt.Errorf("plugin '%s' version '%s' is not compatible with Neo4j 5.26+. Minimum version required: %s", name, version, minVersion)
+		return fmt.Sprintf("plugin '%s' version '%s' is below the operator's recorded minimum for Neo4j 5.26+ (%s) — verify compatibility", name, version, minVersion)
 	}
 
-	return nil
+	return ""
 }
 
 // validatePluginSource validates plugin source configuration

--- a/internal/validation/plugin_validator_test.go
+++ b/internal/validation/plugin_validator_test.go
@@ -29,10 +29,11 @@ func TestPluginValidator_Validate(t *testing.T) {
 	validator := NewPluginValidator()
 
 	tests := []struct {
-		name        string
-		plugin      *neo4jv1beta1.Neo4jPlugin
-		expectError bool
-		errorCount  int
+		name         string
+		plugin       *neo4jv1beta1.Neo4jPlugin
+		expectError  bool
+		errorCount   int
+		warningCount int
 	}{
 		{
 			name: "valid APOC plugin",
@@ -79,8 +80,9 @@ func TestPluginValidator_Validate(t *testing.T) {
 					Enabled:    true,
 				},
 			},
-			expectError: true,
-			errorCount:  1,
+			expectError:  false, // compatibility is advisory: warning, not error
+			errorCount:   0,
+			warningCount: 1,
 		},
 		{
 			name: "deprecated plugin",
@@ -95,8 +97,9 @@ func TestPluginValidator_Validate(t *testing.T) {
 					Enabled:    true,
 				},
 			},
-			expectError: true,
-			errorCount:  1,
+			expectError:  false, // deprecation is advisory: warning, not error
+			errorCount:   0,
+			warningCount: 1,
 		},
 		{
 			name: "unknown plugin",
@@ -111,8 +114,9 @@ func TestPluginValidator_Validate(t *testing.T) {
 					Enabled:    true,
 				},
 			},
-			expectError: true,
-			errorCount:  1,
+			expectError:  false, // unknown plugins are advisory: warning, not error
+			errorCount:   0,
+			warningCount: 1,
 		},
 		{
 			name: "missing plugin name",
@@ -318,17 +322,20 @@ func TestPluginValidator_Validate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			errors := validator.Validate(tt.plugin)
+			result := validator.Validate(tt.plugin)
 
 			if tt.expectError {
-				if len(errors) == 0 {
+				if len(result.Errors) == 0 {
 					t.Errorf("expected validation errors but got none")
 				}
-				if len(errors) != tt.errorCount {
-					t.Errorf("expected %d errors but got %d: %v", tt.errorCount, len(errors), errors)
+				if len(result.Errors) != tt.errorCount {
+					t.Errorf("expected %d errors but got %d: %v", tt.errorCount, len(result.Errors), result.Errors)
 				}
-			} else if len(errors) > 0 {
-				t.Errorf("expected no validation errors but got %d: %v", len(errors), errors)
+			} else if len(result.Errors) > 0 {
+				t.Errorf("expected no validation errors but got %d: %v", len(result.Errors), result.Errors)
+			}
+			if len(result.Warnings) != tt.warningCount {
+				t.Errorf("expected %d warnings but got %d: %v", tt.warningCount, len(result.Warnings), result.Warnings)
 			}
 		})
 	}
@@ -413,7 +420,7 @@ func TestPluginValidator_ChecksumRules(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			errs := validator.Validate(base(tt.source))
+			errs := validator.Validate(base(tt.source)).Errors
 			if tt.wantErr {
 				if len(errs) == 0 {
 					t.Fatalf("expected an error, got none")
@@ -430,70 +437,70 @@ func TestPluginValidator_ChecksumRules(t *testing.T) {
 	}
 }
 
-func TestPluginValidator_validatePluginCompatibility(t *testing.T) {
+func TestPluginValidator_pluginCompatibilityWarning(t *testing.T) {
 	validator := NewPluginValidator()
 
 	tests := []struct {
-		name        string
-		pluginName  string
-		version     string
-		expectError bool
+		name          string
+		pluginName    string
+		version       string
+		expectWarning bool
 	}{
 		{
-			name:        "valid APOC version",
-			pluginName:  "apoc",
-			version:     "5.26.0",
-			expectError: false,
+			name:          "valid APOC version",
+			pluginName:    "apoc",
+			version:       "5.26.0",
+			expectWarning: false,
 		},
 		{
-			name:        "valid GDS version",
-			pluginName:  "graph-data-science",
-			version:     "2.9.0",
-			expectError: false,
+			name:          "valid GDS version",
+			pluginName:    "graph-data-science",
+			version:       "2.9.0",
+			expectWarning: false,
 		},
 		{
-			name:        "invalid APOC version - too old",
-			pluginName:  "apoc",
-			version:     "5.25.0",
-			expectError: true,
+			name:          "APOC version below recorded minimum warns",
+			pluginName:    "apoc",
+			version:       "5.25.0",
+			expectWarning: true,
 		},
 		{
-			name:        "deprecated plugin",
-			pluginName:  "neo4j-graph-algorithms",
-			version:     "3.5.0",
-			expectError: true,
+			name:          "deprecated plugin warns",
+			pluginName:    "neo4j-graph-algorithms",
+			version:       "3.5.0",
+			expectWarning: true,
 		},
 		{
-			name:        "unknown plugin",
-			pluginName:  "unknown-plugin",
-			version:     "1.0.0",
-			expectError: true,
+			name:          "unknown plugin warns",
+			pluginName:    "unknown-plugin",
+			version:       "1.0.0",
+			expectWarning: true,
 		},
 		{
-			name:        "valid plugin version newer than minimum",
-			pluginName:  "apoc",
-			version:     "5.26.5", // synthetic fixture to verify version-comparison ordering (> 5.26.0); not a claim about an actual published APOC release
-			expectError: false,
+			name:          "valid plugin version newer than minimum",
+			pluginName:    "apoc",
+			version:       "5.26.5", // synthetic fixture to verify version-comparison ordering (> 5.26.0); not a claim about an actual published APOC release
+			expectWarning: false,
 		},
 		{
-			name:        "valid CalVer plugin",
-			pluginName:  "neo4j-genai",
-			version:     "2025.01.0",
-			expectError: false,
+			name:          "valid CalVer plugin",
+			pluginName:    "neo4j-genai",
+			version:       "2025.01.0",
+			expectWarning: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validator.validatePluginCompatibility(tt.pluginName, tt.version)
+			msg := validator.pluginCompatibilityWarning(tt.pluginName, tt.version)
 
-			if tt.expectError {
-				if err == nil {
-					t.Errorf("expected error but got none")
+			if tt.expectWarning {
+				if msg == "" {
+					t.Errorf("expected a warning but got none")
 				}
 			} else {
-				if err != nil {
-					t.Errorf("expected no error but got: %v", err)
+				if msg != "" {
+					t.Errorf("expected no warning but got: %q", msg)
 				}
 			}
 		})
@@ -625,7 +632,7 @@ func TestPluginValidator_VerifiedDownloadGates(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			errs := validator.Validate(base(tt.source, tt.deps))
+			errs := validator.Validate(base(tt.source, tt.deps)).Errors
 			if tt.wantErr {
 				if len(errs) == 0 {
 					t.Fatalf("expected an error, got none")


### PR DESCRIPTION
## Summary

The `PluginValidator` existed in `internal/validation/` but was **never invoked** — `Neo4jPlugin` CRs skipped structural validation entirely (same dormant-validator class as #159's `BackupValidator`). This wires it inline into the plugin controller, no webhooks, mirroring how every other validator is wired.

## Behaviour

**Hard errors → block install** (phase `Invalid` + `ValidationFailed` Warning event, no requeue; re-edit the CR to retry):
- missing `spec.name` / `spec.version`
- bad source config / missing-or-malformed checksum
- conflicting allow/deny procedures
- `installMode: VerifiedDownload` cross-field gaps

**Compatibility matrix → advisory only.** Downgraded from a hard reject to a `ValidationWarning` event. Rationale:
- The operator installs arbitrary (incl. URL-sourced) plugins and is forward-compatible across Neo4j versions — an unknown/older/deprecated matrix entry must not block install.
- The matrix labels (`neo4j-bloom`, `neo4j-genai`, `graph-data-science`) drift from the operator's own plugin labels (`bloom`, `genai`, `gds`), so leaving compatibility as a hard error would have produced **false rejections of valid plugins**.

## Changes
- `plugin_validator.go`: `Validate` now returns `*PluginValidationResult{Errors, Warnings}` (mirrors `DatabaseValidationResult`); `validatePluginCompatibility` → `pluginCompatibilityWarning` returning an advisory string (`""` = nothing noteworthy).
- `plugin_controller.go`: add `Validator` field; validate after the finalizer block, before any install work.
- `cmd/main.go`: construct `NewPluginValidator()` in both dev- and prod-mode reconciler wiring.
- tests: compatibility cases reclassified error→warning; new `warningCount` assertions; compatibility unit test renamed and asserts on the returned string.

## Test
- `go build ./...`, `go vet`, `gofmt` clean.
- `go test ./internal/validation/...` — pass.
- `go test ./internal/controller/... -run TestControllers` (envtest) — pass.
- pre-commit (golangci-lint, staticcheck, drift gate) — pass.

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit da1503a9756e5053cf288df970558da9d14a8a58. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->