### PR TITLE
fix: privilege canonicalisation quoting, client goroutine leak, day-2 cluster drift, privilege-add correctness

### DIFF
--- a/internal/controller/mutable_resource_test.go
+++ b/internal/controller/mutable_resource_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// TestApplyDesiredServiceFields_PreservesImmutablesAndAppliesChanges pins the
+// field-by-field Service update: a ClusterIP→LoadBalancer change with new
+// annotations is applied, while the API-assigned ClusterIP/ClusterIPs/
+// HealthCheckNodePort and an allocated NodePort are preserved (so the Update
+// is not rejected on an immutable field).
+func TestApplyDesiredServiceFields_PreservesImmutablesAndAppliesChanges(t *testing.T) {
+	existing := &corev1.Service{
+		Spec: corev1.ServiceSpec{
+			Type:       corev1.ServiceTypeClusterIP,
+			ClusterIP:  "10.0.0.5",
+			ClusterIPs: []string{"10.0.0.5"},
+			IPFamilies: []corev1.IPFamily{corev1.IPv4Protocol},
+			Selector:   map[string]string{"app": "neo4j"},
+			Ports:      []corev1.ServicePort{{Name: "bolt", Port: 7687, NodePort: 31687}},
+		},
+	}
+	existing.Annotations = map[string]string{"foreign.io/keep": "1"}
+
+	desired := &corev1.Service{
+		Spec: corev1.ServiceSpec{
+			Type:     corev1.ServiceTypeLoadBalancer,
+			Selector: map[string]string{"app": "neo4j"},
+			// NodePort intentionally unset — must inherit the allocated 31687.
+			Ports: []corev1.ServicePort{{Name: "bolt", Port: 7687}},
+		},
+	}
+	desired.Annotations = map[string]string{"service.beta.kubernetes.io/aws-load-balancer-type": "nlb"}
+
+	changed := applyDesiredServiceFields(existing, desired)
+	assert.True(t, changed, "type + annotation change must be detected")
+
+	assert.Equal(t, corev1.ServiceTypeLoadBalancer, existing.Spec.Type, "type change applied")
+	assert.Equal(t, "10.0.0.5", existing.Spec.ClusterIP, "ClusterIP preserved (immutable)")
+	assert.Equal(t, []string{"10.0.0.5"}, existing.Spec.ClusterIPs, "ClusterIPs preserved (immutable)")
+	assert.Equal(t, []corev1.IPFamily{corev1.IPv4Protocol}, existing.Spec.IPFamilies, "IPFamilies preserved")
+	assert.Equal(t, int32(31687), existing.Spec.Ports[0].NodePort, "allocated NodePort carried over")
+	assert.Equal(t, "nlb", existing.Annotations["service.beta.kubernetes.io/aws-load-balancer-type"], "desired annotation applied")
+	assert.Equal(t, "1", existing.Annotations["foreign.io/keep"], "foreign annotation preserved")
+}
+
+// TestApplyDesiredServiceFields_NoChangeNoChurn ensures an unchanged service
+// reports no change (so reconcileMutableResource skips the Update and doesn't
+// churn ResourceVersion every reconcile).
+func TestApplyDesiredServiceFields_NoChangeNoChurn(t *testing.T) {
+	svc := func() *corev1.Service {
+		s := &corev1.Service{
+			Spec: corev1.ServiceSpec{
+				Type:     corev1.ServiceTypeClusterIP,
+				Selector: map[string]string{"app": "neo4j"},
+				Ports:    []corev1.ServicePort{{Name: "bolt", Port: 7687}},
+			},
+		}
+		s.Annotations = map[string]string{"a": "b"}
+		return s
+	}
+	existing := svc()
+	existing.Spec.ClusterIP = "10.0.0.5" // server-assigned, absent from desired
+	desired := svc()
+
+	assert.False(t, applyDesiredServiceFields(existing, desired),
+		"identical desired spec must not report a change")
+	assert.Equal(t, "10.0.0.5", existing.Spec.ClusterIP, "ClusterIP still preserved")
+}

--- a/internal/controller/mutable_resource_test.go
+++ b/internal/controller/mutable_resource_test.go
@@ -82,7 +82,11 @@ func TestApplyDesiredServiceFields_NoChangeNoChurn(t *testing.T) {
 	existing.Spec.ClusterIP = "10.0.0.5" // server-assigned, absent from desired
 	desired := svc()
 
+	// First apply stamps owned-key bookkeeping (a one-time change).
+	assert.True(t, applyDesiredServiceFields(existing, desired),
+		"first apply stamps ownership bookkeeping")
+	// Steady state: an identical desired spec must not churn ResourceVersion.
 	assert.False(t, applyDesiredServiceFields(existing, desired),
-		"identical desired spec must not report a change")
+		"identical desired spec on a stamped service must not report a change")
 	assert.Equal(t, "10.0.0.5", existing.Spec.ClusterIP, "ClusterIP still preserved")
 }

--- a/internal/controller/neo4jenterprisecluster_controller.go
+++ b/internal/controller/neo4jenterprisecluster_controller.go
@@ -858,10 +858,16 @@ func (r *Neo4jEnterpriseClusterReconciler) createOrUpdateResourceInternal(ctx co
 						}
 						merged := mergeEnvVars(currentEnv, desiredEnv, previousOwned)
 
+						// Capture foreign pod-template annotations before the
+						// wholesale replace so the config-restart/config-hash stamps
+						// and any mesh/plugin pod annotations survive (only env vars
+						// are merged otherwise). Mirrors the standalone controller.
+						livePodAnnotations := sts.Spec.Template.Annotations
 						sts.Spec.Template = *updatedTemplate
 						if len(sts.Spec.Template.Spec.Containers) > 0 {
 							sts.Spec.Template.Spec.Containers[0].Env = merged
 						}
+						sts.Spec.Template.Annotations = mergePodTemplateAnnotations(livePodAnnotations, updatedTemplate.Annotations)
 						writeOwnedEnvVarNames(sts, desiredEnv)
 						// Record the desired template hash so the next stable
 						// reconcile can detect drift in fields the field-by-field
@@ -880,7 +886,10 @@ func (r *Neo4jEnterpriseClusterReconciler) createOrUpdateResourceInternal(ctx co
 					}
 				} else {
 					// If no selector exists, just use the desired template
+					// (preserving foreign pod-template annotations as above).
+					livePodAnnotations := sts.Spec.Template.Annotations
 					sts.Spec.Template = desiredSpec.Template
+					sts.Spec.Template.Annotations = mergePodTemplateAnnotations(livePodAnnotations, desiredSpec.Template.Annotations)
 					if len(desiredSpec.Template.Spec.Containers) > 0 {
 						writeOwnedEnvVarNames(sts, desiredSpec.Template.Spec.Containers[0].Env)
 					}

--- a/internal/controller/neo4jenterprisecluster_controller.go
+++ b/internal/controller/neo4jenterprisecluster_controller.go
@@ -25,9 +25,11 @@ import (
 	"strings"
 	"time"
 
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"golang.org/x/time/rate"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -759,6 +761,20 @@ func (r *Neo4jEnterpriseClusterReconciler) createOrUpdateResourceInternal(ctx co
 		return err
 	}
 
+	// Non-StatefulSet resources whose spec must stay in sync on a live cluster.
+	// These previously flowed through CreateOrUpdate below with a
+	// StatefulSet-only mutate closure, so the closure was a no-op for them and
+	// spec edits (service type/annotations/loadBalancerIP, ingress host,
+	// network-policy rules, certificate DNS names) were silently dropped on
+	// existing clusters. Handle them with an explicit get-then-update.
+	// RBAC and the MCP Deployment intentionally stay on the create-only path
+	// (RoleBinding.RoleRef and Deployment.Spec.Selector are immutable and rarely
+	// change for this operator).
+	switch obj.(type) {
+	case *corev1.Service, *networkingv1.NetworkPolicy, *networkingv1.Ingress, *certmanagerv1.Certificate:
+		return r.reconcileMutableResource(ctx, obj)
+	}
+
 	// Capture the desired spec if this is a StatefulSet
 	var desiredSpec appsv1.StatefulSetSpec
 	if sts, ok := obj.(*appsv1.StatefulSet); ok {
@@ -847,6 +863,11 @@ func (r *Neo4jEnterpriseClusterReconciler) createOrUpdateResourceInternal(ctx co
 							sts.Spec.Template.Spec.Containers[0].Env = merged
 						}
 						writeOwnedEnvVarNames(sts, desiredEnv)
+						// Record the desired template hash so the next stable
+						// reconcile can detect drift in fields the field-by-field
+						// check omits. updatedTemplate keeps cluster-owned env only
+						// (the foreign-merge above wrote to sts, not updatedTemplate).
+						setClusterTemplateHash(sts, *updatedTemplate)
 					} else {
 						logger := log.FromContext(ctx)
 						logger.V(1).Info("Skipping StatefulSet template update - no significant changes detected",
@@ -863,6 +884,7 @@ func (r *Neo4jEnterpriseClusterReconciler) createOrUpdateResourceInternal(ctx co
 					if len(desiredSpec.Template.Spec.Containers) > 0 {
 						writeOwnedEnvVarNames(sts, desiredSpec.Template.Spec.Containers[0].Env)
 					}
+					setClusterTemplateHash(sts, desiredSpec.Template)
 				}
 			} else {
 				// This is a new StatefulSet, use the desired spec as-is
@@ -898,8 +920,23 @@ func (r *Neo4jEnterpriseClusterReconciler) isTemplateChangeSignificant(ctx conte
 		return r.hasCriticalTemplateChanges(currentTemplate, desiredTemplate)
 	}
 
-	// For stable clusters, allow more template changes
-	return r.hasSignificantTemplateChanges(currentTemplate, desiredTemplate, readOwnedEnvVarNames(sts))
+	// For a stable cluster a change is significant if EITHER:
+	//   - a cluster-owned core field drifted from desired (env/volumes/init
+	//     containers/image/resources/securityContext/SA — foreign-tolerant via
+	//     envVarsEqual so plugin/fleet/Aura-owned env vars don't trip it), OR
+	//   - the desired template's hash differs from the one we last applied.
+	// The hash closes the fields the field-by-field check omits (nodeSelector,
+	// affinity, tolerations, probes, resource requests, volume sources,
+	// initContainer args/env). It is computed over the *desired* template
+	// (cluster-owned env only) and compared to a stored annotation, never to
+	// the live template — so foreign env vars and the config-restart annotation
+	// never enter it and cannot cause oscillation against the env-ownership
+	// protocol. A missing annotation (first reconcile after an operator
+	// upgrade) reads as changed, converging once.
+	if r.hasSignificantTemplateChanges(currentTemplate, desiredTemplate, readOwnedEnvVarNames(sts)) {
+		return true
+	}
+	return podTemplateSpecHash(desiredTemplate) != sts.Annotations[clusterTemplateHashAnnotation]
 }
 
 // hasCriticalTemplateChanges checks for changes that are essential during cluster formation
@@ -1016,6 +1053,23 @@ func (r *Neo4jEnterpriseClusterReconciler) containerSecurityContextEqual(current
 // disturbing plugin / fleet additions. Names are stored sorted, comma-
 // separated. Same shape as kubectl's last-applied-configuration tracking.
 const ownedEnvVarsAnnotation = "neo4j.com/cluster-controller-env-vars"
+
+// clusterTemplateHashAnnotation stores the hash of the desired pod template the
+// cluster controller last applied. A stable-phase reconcile treats the template
+// as changed when this differs from the current desired hash, which catches the
+// fields hasSignificantTemplateChanges does not compare (nodeSelector, affinity,
+// tolerations, probes, resource requests, volume sources, initContainer
+// args/env). See isTemplateChangeSignificant.
+const clusterTemplateHashAnnotation = "neo4j.com/cluster-template-hash"
+
+// setClusterTemplateHash records the hash of the just-applied desired pod
+// template on the StatefulSet's annotations.
+func setClusterTemplateHash(sts *appsv1.StatefulSet, desired corev1.PodTemplateSpec) {
+	if sts.Annotations == nil {
+		sts.Annotations = map[string]string{}
+	}
+	sts.Annotations[clusterTemplateHashAnnotation] = podTemplateSpecHash(desired)
+}
 
 // readOwnedEnvVarNames returns the set of env-var names this controller
 // recorded as owned on the StatefulSet's previous reconcile. An empty set is
@@ -1366,6 +1420,152 @@ func (r *Neo4jEnterpriseClusterReconciler) createExternalSecretForAuth(ctx conte
 	obj.SetUnstructuredContent(esData)
 
 	return r.createOrUpdateUnstructuredResource(ctx, obj, cluster)
+}
+
+// reconcileMutableResource creates desired if absent, otherwise updates the
+// live object's mutable fields from desired and writes it back — preserving the
+// live ResourceVersion and any server-assigned immutable fields. Each Update is
+// gated on an actual drift so unchanged resources don't churn ResourceVersion.
+func (r *Neo4jEnterpriseClusterReconciler) reconcileMutableResource(ctx context.Context, desired client.Object) error {
+	logger := log.FromContext(ctx)
+	existing, ok := desired.DeepCopyObject().(client.Object)
+	if !ok {
+		return fmt.Errorf("object %T is not a client.Object", desired)
+	}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(desired), existing); err != nil {
+		if errors.IsNotFound(err) {
+			return r.Create(ctx, desired)
+		}
+		return err
+	}
+
+	switch d := desired.(type) {
+	case *corev1.Service:
+		e := existing.(*corev1.Service)
+		if applyDesiredServiceFields(e, d) {
+			logger.Info("Updating Service", "name", e.Name)
+			return r.Update(ctx, e)
+		}
+	case *networkingv1.NetworkPolicy:
+		e := existing.(*networkingv1.NetworkPolicy)
+		if !equality.Semantic.DeepEqual(e.Spec, d.Spec) || !equality.Semantic.DeepEqual(e.Labels, d.Labels) {
+			e.Spec = d.Spec
+			e.Labels = d.Labels
+			logger.Info("Updating NetworkPolicy", "name", e.Name)
+			return r.Update(ctx, e)
+		}
+	case *networkingv1.Ingress:
+		e := existing.(*networkingv1.Ingress)
+		if !equality.Semantic.DeepEqual(e.Spec, d.Spec) || !equality.Semantic.DeepEqual(e.Annotations, d.Annotations) {
+			e.Spec = d.Spec
+			e.Annotations = d.Annotations
+			logger.Info("Updating Ingress", "name", e.Name)
+			return r.Update(ctx, e)
+		}
+	case *certmanagerv1.Certificate:
+		e := existing.(*certmanagerv1.Certificate)
+		if !equality.Semantic.DeepEqual(e.Spec, d.Spec) {
+			e.Spec = d.Spec
+			logger.Info("Updating Certificate", "name", e.Name)
+			return r.Update(ctx, e)
+		}
+	}
+	return nil
+}
+
+// applyDesiredServiceFields copies the mutable fields of desired onto existing,
+// preserving API-server-assigned immutable fields (ClusterIP/ClusterIPs/
+// IPFamilies/IPFamilyPolicy/HealthCheckNodePort) so the Update is not rejected,
+// and carrying over allocated NodePorts the desired spec leaves unset. Returns
+// true when any field changed.
+func applyDesiredServiceFields(existing, desired *corev1.Service) bool {
+	changed := false
+	if existing.Spec.Type != desired.Spec.Type {
+		existing.Spec.Type = desired.Spec.Type
+		changed = true
+	}
+	if mergedPorts := mergeServicePorts(existing.Spec.Ports, desired.Spec.Ports); !equality.Semantic.DeepEqual(existing.Spec.Ports, mergedPorts) {
+		existing.Spec.Ports = mergedPorts
+		changed = true
+	}
+	if !equality.Semantic.DeepEqual(existing.Spec.Selector, desired.Spec.Selector) {
+		existing.Spec.Selector = desired.Spec.Selector
+		changed = true
+	}
+	if existing.Spec.LoadBalancerIP != desired.Spec.LoadBalancerIP {
+		existing.Spec.LoadBalancerIP = desired.Spec.LoadBalancerIP
+		changed = true
+	}
+	if !equality.Semantic.DeepEqual(existing.Spec.LoadBalancerSourceRanges, desired.Spec.LoadBalancerSourceRanges) {
+		existing.Spec.LoadBalancerSourceRanges = desired.Spec.LoadBalancerSourceRanges
+		changed = true
+	}
+	if existing.Spec.ExternalTrafficPolicy != desired.Spec.ExternalTrafficPolicy {
+		existing.Spec.ExternalTrafficPolicy = desired.Spec.ExternalTrafficPolicy
+		changed = true
+	}
+	if existing.Spec.SessionAffinity != desired.Spec.SessionAffinity {
+		existing.Spec.SessionAffinity = desired.Spec.SessionAffinity
+		changed = true
+	}
+	if existing.Spec.PublishNotReadyAddresses != desired.Spec.PublishNotReadyAddresses {
+		existing.Spec.PublishNotReadyAddresses = desired.Spec.PublishNotReadyAddresses
+		changed = true
+	}
+	if mergeStringMapInto(&existing.Annotations, desired.Annotations) {
+		changed = true
+	}
+	if mergeStringMapInto(&existing.Labels, desired.Labels) {
+		changed = true
+	}
+	return changed
+}
+
+// mergeServicePorts returns desired ports with allocated NodePorts carried over
+// from existing for matching ports (by Name, else by Port) when desired leaves
+// NodePort unset — so a ClusterIP→NodePort/LoadBalancer transition or a routine
+// reconcile doesn't ask the API to reassign node ports.
+func mergeServicePorts(existing, desired []corev1.ServicePort) []corev1.ServicePort {
+	byName := make(map[string]int32, len(existing))
+	byPort := make(map[int32]int32, len(existing))
+	for _, p := range existing {
+		if p.NodePort != 0 {
+			if p.Name != "" {
+				byName[p.Name] = p.NodePort
+			}
+			byPort[p.Port] = p.NodePort
+		}
+	}
+	out := make([]corev1.ServicePort, len(desired))
+	copy(out, desired)
+	for i := range out {
+		if out[i].NodePort != 0 {
+			continue
+		}
+		if np, ok := byName[out[i].Name]; ok && out[i].Name != "" {
+			out[i].NodePort = np
+		} else if np, ok := byPort[out[i].Port]; ok {
+			out[i].NodePort = np
+		}
+	}
+	return out
+}
+
+// mergeStringMapInto overlays desired onto *target (creating it if nil),
+// preserving keys present only in *target (e.g. annotations added by other
+// controllers). Returns true when *target changed.
+func mergeStringMapInto(target *map[string]string, desired map[string]string) bool {
+	changed := false
+	if *target == nil && len(desired) > 0 {
+		*target = map[string]string{}
+	}
+	for k, v := range desired {
+		if cur, ok := (*target)[k]; !ok || cur != v {
+			(*target)[k] = v
+			changed = true
+		}
+	}
+	return changed
 }
 
 // createOrUpdateUnstructuredResource handles unstructured resources like ExternalSecrets

--- a/internal/controller/neo4jenterprisecluster_controller.go
+++ b/internal/controller/neo4jenterprisecluster_controller.go
@@ -1448,24 +1448,43 @@ func (r *Neo4jEnterpriseClusterReconciler) reconcileMutableResource(ctx context.
 		}
 	case *networkingv1.NetworkPolicy:
 		e := existing.(*networkingv1.NetworkPolicy)
-		if !equality.Semantic.DeepEqual(e.Spec, d.Spec) || !equality.Semantic.DeepEqual(e.Labels, d.Labels) {
+		changed := false
+		if !equality.Semantic.DeepEqual(e.Spec, d.Spec) {
 			e.Spec = d.Spec
-			e.Labels = d.Labels
+			changed = true
+		}
+		if applyOwnedMetadata(e, d.Annotations, d.Labels) {
+			changed = true
+		}
+		if changed {
 			logger.Info("Updating NetworkPolicy", "name", e.Name)
 			return r.Update(ctx, e)
 		}
 	case *networkingv1.Ingress:
 		e := existing.(*networkingv1.Ingress)
-		if !equality.Semantic.DeepEqual(e.Spec, d.Spec) || !equality.Semantic.DeepEqual(e.Annotations, d.Annotations) {
+		changed := false
+		if !equality.Semantic.DeepEqual(e.Spec, d.Spec) {
 			e.Spec = d.Spec
-			e.Annotations = d.Annotations
+			changed = true
+		}
+		if applyOwnedMetadata(e, d.Annotations, d.Labels) {
+			changed = true
+		}
+		if changed {
 			logger.Info("Updating Ingress", "name", e.Name)
 			return r.Update(ctx, e)
 		}
 	case *certmanagerv1.Certificate:
 		e := existing.(*certmanagerv1.Certificate)
+		changed := false
 		if !equality.Semantic.DeepEqual(e.Spec, d.Spec) {
 			e.Spec = d.Spec
+			changed = true
+		}
+		if applyOwnedMetadata(e, d.Annotations, d.Labels) {
+			changed = true
+		}
+		if changed {
 			logger.Info("Updating Certificate", "name", e.Name)
 			return r.Update(ctx, e)
 		}
@@ -1512,10 +1531,7 @@ func applyDesiredServiceFields(existing, desired *corev1.Service) bool {
 		existing.Spec.PublishNotReadyAddresses = desired.Spec.PublishNotReadyAddresses
 		changed = true
 	}
-	if mergeStringMapInto(&existing.Annotations, desired.Annotations) {
-		changed = true
-	}
-	if mergeStringMapInto(&existing.Labels, desired.Labels) {
+	if applyOwnedMetadata(existing, desired.Annotations, desired.Labels) {
 		changed = true
 	}
 	return changed
@@ -1549,23 +1565,6 @@ func mergeServicePorts(existing, desired []corev1.ServicePort) []corev1.ServiceP
 		}
 	}
 	return out
-}
-
-// mergeStringMapInto overlays desired onto *target (creating it if nil),
-// preserving keys present only in *target (e.g. annotations added by other
-// controllers). Returns true when *target changed.
-func mergeStringMapInto(target *map[string]string, desired map[string]string) bool {
-	changed := false
-	if *target == nil && len(desired) > 0 {
-		*target = map[string]string{}
-	}
-	for k, v := range desired {
-		if cur, ok := (*target)[k]; !ok || cur != v {
-			(*target)[k] = v
-			changed = true
-		}
-	}
-	return changed
 }
 
 // createOrUpdateUnstructuredResource handles unstructured resources like ExternalSecrets

--- a/internal/controller/neo4jenterprisestandalone_controller.go
+++ b/internal/controller/neo4jenterprisestandalone_controller.go
@@ -820,23 +820,10 @@ func (r *Neo4jEnterpriseStandaloneReconciler) reconcileStatefulSet(ctx context.C
 			currentInit := statefulSet.Spec.Template.Spec.InitContainers
 			currentVolumes := statefulSet.Spec.Template.Spec.Volumes
 
-			mergedAnnotations := map[string]string{}
-			for k, v := range statefulSet.Spec.Template.Annotations {
-				// Operator-managed annotations (the Prometheus scrape hints) are
-				// re-derived from the desired template below — NOT carried forward
-				// — so disabling spec.monitoring actually removes them. Carrying the
-				// existing value would leave stale prometheus.io/* keys scraping a
-				// port that no longer exists. Foreign annotations (conf-restart
-				// stamp, plugin-init-containers, service-mesh injection) are not in
-				// this managed set, so they're preserved.
-				if _, managed := standaloneOperatorManagedPodAnnotations[k]; managed {
-					continue
-				}
-				mergedAnnotations[k] = v
-			}
-			for k, v := range desiredSpec.Template.Annotations {
-				mergedAnnotations[k] = v
-			}
+			// Re-derive operator-managed pod annotations (Prometheus hints) from
+			// the desired template while preserving foreign ones (conf-restart
+			// stamp, plugin-init markers, service-mesh injection).
+			mergedAnnotations := mergePodTemplateAnnotations(statefulSet.Spec.Template.Annotations, desiredSpec.Template.Annotations)
 
 			desiredTemplate := desiredSpec.Template.DeepCopy()
 			statefulSet.Spec.Template = *desiredTemplate
@@ -1463,17 +1450,6 @@ func standalonePrometheusAnnotations(standalone *neo4jv1beta1.Neo4jEnterpriseSta
 		"prometheus.io/port":   fmt.Sprintf("%d", resources.MetricsPort),
 		"prometheus.io/path":   "/metrics",
 	}
-}
-
-// standaloneOperatorManagedPodAnnotations is the KEY set the operator owns on
-// the pod template (the Prometheus hints above). On a template apply these are
-// re-derived from the desired template — never carried forward from the existing
-// one — so disabling monitoring removes them, while foreign annotations are
-// preserved. Keep in sync with standalonePrometheusAnnotations' keys.
-var standaloneOperatorManagedPodAnnotations = map[string]struct{}{
-	"prometheus.io/scrape": {},
-	"prometheus.io/port":   {},
-	"prometheus.io/path":   {},
 }
 
 // createStatefulSet creates a StatefulSet for the standalone deployment

--- a/internal/controller/neo4jenterprisestandalone_controller.go
+++ b/internal/controller/neo4jenterprisestandalone_controller.go
@@ -649,12 +649,12 @@ const (
 // reconcile look like a change and roll the pod in a loop.
 const standaloneTemplateHashAnnotation = "neo4j.com/standalone-template-hash"
 
-// standalonePodTemplateHash returns a stable hash of a pod template. JSON
+// podTemplateSpecHash returns a stable hash of a pod template. JSON
 // marshalling sorts map keys, so the hash is deterministic across reconciles
 // for an unchanged template (no spurious rolls). Returns "" on the (practically
 // impossible) marshal error, which the caller treats as "changed" — converge
-// rather than silently skip.
-func standalonePodTemplateHash(t corev1.PodTemplateSpec) string {
+// rather than silently skip. Shared by the standalone and cluster controllers.
+func podTemplateSpecHash(t corev1.PodTemplateSpec) string {
 	data, err := json.Marshal(t)
 	if err != nil {
 		return ""
@@ -762,7 +762,7 @@ func (r *Neo4jEnterpriseStandaloneReconciler) reconcileStatefulSet(ctx context.C
 	// Capture the desired spec + its template hash BEFORE CreateOrUpdate's Get
 	// clobbers `statefulSet` with the existing cluster object on update.
 	desiredSpec := *statefulSet.Spec.DeepCopy()
-	desiredHash := standalonePodTemplateHash(desiredSpec.Template)
+	desiredHash := podTemplateSpecHash(desiredSpec.Template)
 	desiredEnv := []corev1.EnvVar{}
 	if len(desiredSpec.Template.Spec.Containers) > 0 {
 		desiredEnv = desiredSpec.Template.Spec.Containers[0].Env

--- a/internal/controller/neo4jenterprisestandalone_controller.go
+++ b/internal/controller/neo4jenterprisestandalone_controller.go
@@ -906,11 +906,18 @@ func (r *Neo4jEnterpriseStandaloneReconciler) reconcileNetworkPolicy(ctx context
 		}
 		return fmt.Errorf("failed to get NetworkPolicy: %w", err)
 	}
-	// Update only when the spec actually drifted — avoids ResourceVersion
-	// churn on every reconcile.
+	// Update only when the spec or owned metadata actually drifted — avoids
+	// ResourceVersion churn, and applyOwnedMetadata preserves labels written by
+	// other controllers rather than stomping them.
+	changed := false
 	if !reflect.DeepEqual(existing.Spec, desired.Spec) {
 		existing.Spec = desired.Spec
-		existing.Labels = desired.Labels
+		changed = true
+	}
+	if applyOwnedMetadata(existing, desired.Annotations, desired.Labels) {
+		changed = true
+	}
+	if changed {
 		logger.Info("Updating NetworkPolicy", "name", desired.Name)
 		return r.Update(ctx, existing)
 	}
@@ -943,12 +950,22 @@ func (r *Neo4jEnterpriseStandaloneReconciler) reconcileIngress(ctx context.Conte
 			return fmt.Errorf("failed to get Ingress: %w", err)
 		}
 	} else {
-		// Update existing Ingress
-		existing.Spec = ingress.Spec
-		existing.Annotations = ingress.Annotations
-		logger.Info("Updating Ingress", "name", ingress.Name)
-		if err := r.Update(ctx, existing); err != nil {
-			return fmt.Errorf("failed to update Ingress: %w", err)
+		// Update only on real drift; applyOwnedMetadata merges desired
+		// annotations/labels while preserving keys written by cert-manager or
+		// the ingress controller (a wholesale replace would fight them).
+		changed := false
+		if !reflect.DeepEqual(existing.Spec, ingress.Spec) {
+			existing.Spec = ingress.Spec
+			changed = true
+		}
+		if applyOwnedMetadata(existing, ingress.Annotations, ingress.Labels) {
+			changed = true
+		}
+		if changed {
+			logger.Info("Updating Ingress", "name", ingress.Name)
+			if err := r.Update(ctx, existing); err != nil {
+				return fmt.Errorf("failed to update Ingress: %w", err)
+			}
 		}
 	}
 

--- a/internal/controller/neo4jrole_controller.go
+++ b/internal/controller/neo4jrole_controller.go
@@ -155,7 +155,7 @@ func (r *Neo4jRoleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	// Privilege diff
-	desired, errs := r.canonicaliseDesired(role.Spec.Privileges)
+	desired, desiredByCanonical, errs := r.canonicaliseDesired(role.Spec.Privileges)
 	if errs != nil {
 		return r.fail(ctx, role, "privilege canonicalisation failed", errs, requeue)
 	}
@@ -171,8 +171,17 @@ func (r *Neo4jRoleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	for _, canon := range toAdd {
-		if err := nc.ExecutePrivilegeStatement(ctx, canon); err != nil {
-			return r.fail(ctx, role, fmt.Sprintf("apply privilege %q failed", canon), err, requeue)
+		// Execute the original spec text, never the canonical form: canonical
+		// upper-cases bare tokens including unquoted identifiers, so a role/
+		// graph/database named e.g. `users` written unquoted would canonicalise
+		// to `... TO USERS` and target the wrong (case-sensitive) role. The diff
+		// is keyed on canonical; the statement run is the user's original.
+		stmt := desiredByCanonical[canon]
+		if stmt == "" {
+			stmt = canon // defensive fallback (should not happen)
+		}
+		if err := nc.ExecutePrivilegeStatement(ctx, stmt); err != nil {
+			return r.fail(ctx, role, fmt.Sprintf("apply privilege %q failed", stmt), err, requeue)
 		}
 	}
 
@@ -289,22 +298,29 @@ func (r *Neo4jRoleReconciler) handleDeletion(ctx context.Context, role *neo4jv1b
 }
 
 // canonicaliseDesired turns the spec privileges into a deduplicated, sorted
-// slice of canonical statements.
-func (r *Neo4jRoleReconciler) canonicaliseDesired(stmts []string) ([]string, error) {
+// slice of canonical statements plus a map from each canonical form back to the
+// original spec text. The diff is keyed on the canonical form, but callers
+// execute the original text — the canonical form upper-cases bare tokens
+// (including unquoted identifiers) and is explicitly not safe to feed to Neo4j.
+func (r *Neo4jRoleReconciler) canonicaliseDesired(stmts []string) ([]string, map[string]string, error) {
 	set := map[string]struct{}{}
+	byCanonical := map[string]string{}
 	for _, s := range stmts {
 		canon := neo4jclient.CanonicalisePrivilegeStatement(s)
 		if canon == "" {
 			continue
 		}
 		set[canon] = struct{}{}
+		if _, exists := byCanonical[canon]; !exists {
+			byCanonical[canon] = s // first original wins for a given canonical form
+		}
 	}
 	out := make([]string, 0, len(set))
 	for k := range set {
 		out = append(out, k)
 	}
 	sort.Strings(out)
-	return out, nil
+	return out, byCanonical, nil
 }
 
 // fetchCurrentPrivileges reads SHOW ROLE PRIVILEGES AS COMMANDS and returns:

--- a/internal/controller/neo4jrole_controller_unit_test.go
+++ b/internal/controller/neo4jrole_controller_unit_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCanonicaliseDesired_MapsCanonicalToOriginal pins audit finding #3: the
+// add loop must execute the user's ORIGINAL statement text, not the canonical
+// form. The canonical form upper-cases bare tokens — including unquoted
+// identifiers — so a role named `users` written unquoted canonicalises to
+// "... TO USERS" and would target the wrong (case-sensitive) role if executed.
+// canonicaliseDesired must therefore return the original text keyed by canon.
+func TestCanonicaliseDesired_MapsCanonicalToOriginal(t *testing.T) {
+	r := &Neo4jRoleReconciler{}
+
+	t.Run("keyword-like identifier preserves original case", func(t *testing.T) {
+		orig := "GRANT ACCESS ON DATABASE neo4j TO users"
+		canon, byCanonical, err := r.canonicaliseDesired([]string{orig})
+		assert.NoError(t, err)
+		assert.Len(t, canon, 1)
+		// Canonical upper-cases the bare role name (it is a reserved keyword).
+		assert.Equal(t, "GRANT ACCESS ON DATABASE neo4j TO USERS", canon[0])
+		// But the map gives back the original text we must actually execute.
+		assert.Equal(t, orig, byCanonical[canon[0]],
+			"add loop must run the original statement, not the upper-cased canonical")
+	})
+
+	t.Run("dedup keeps first original and sorts canon", func(t *testing.T) {
+		canon, byCanonical, err := r.canonicaliseDesired([]string{
+			"GRANT ACCESS ON DATABASE neo4j TO r",
+			"grant   access  on database neo4j to r", // same canonical, different text
+			"GRANT MATCH {*} ON GRAPH neo4j NODES * TO r",
+		})
+		assert.NoError(t, err)
+		assert.Len(t, canon, 2, "two distinct canonical statements")
+		// First original wins for the duplicated canonical form.
+		assert.Equal(t, "GRANT ACCESS ON DATABASE neo4j TO r",
+			byCanonical["GRANT ACCESS ON DATABASE neo4j TO r"])
+	})
+
+	t.Run("empty and whitespace-only statements are skipped", func(t *testing.T) {
+		canon, byCanonical, err := r.canonicaliseDesired([]string{"", "   ", " ; "})
+		assert.NoError(t, err)
+		assert.Empty(t, canon)
+		assert.Empty(t, byCanonical)
+	})
+}

--- a/internal/controller/owned_keys.go
+++ b/internal/controller/owned_keys.go
@@ -136,6 +136,37 @@ func applyOwnedMetadata(obj client.Object, desiredAnnotations, desiredLabels map
 	return changed
 }
 
+// operatorManagedPodAnnotations are the pod-template annotation keys the
+// operator owns (the Prometheus scrape hints). On a StatefulSet template apply
+// these are re-derived from the desired template — never carried forward — so
+// disabling monitoring removes them, while foreign annotations (ConfigMapManager's
+// config-restart/config-hash stamps, plugin-init markers, service-mesh
+// injection) are preserved. Shared by the cluster and standalone controllers.
+var operatorManagedPodAnnotations = map[string]struct{}{
+	"prometheus.io/scrape": {},
+	"prometheus.io/port":   {},
+	"prometheus.io/path":   {},
+}
+
+// mergePodTemplateAnnotations preserves foreign pod-template annotations from
+// live (keys the operator does not manage) and overlays the desired
+// operator-managed set. Used on a wholesale template replace, which otherwise
+// only merges container env vars and would drop the config-restart stamp and
+// any mesh/plugin pod annotations.
+func mergePodTemplateAnnotations(live, desired map[string]string) map[string]string {
+	out := make(map[string]string, len(live)+len(desired))
+	for k, v := range live {
+		if _, managed := operatorManagedPodAnnotations[k]; managed {
+			continue
+		}
+		out[k] = v
+	}
+	for k, v := range desired {
+		out[k] = v
+	}
+	return out
+}
+
 // stringMapsEqual treats nil and empty maps as equal.
 func stringMapsEqual(a, b map[string]string) bool {
 	if len(a) != len(b) {

--- a/internal/controller/owned_keys.go
+++ b/internal/controller/owned_keys.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"sort"
+	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Ownership-tracked metadata reconciliation for the annotation and label maps
+// the operator manages on owned resources (Services, Ingresses, NetworkPolicies,
+// Certificates). This mirrors the env-var ownership protocol
+// (cluster-controller-env-vars): the operator records the keys it owns so a
+// later reconcile can apply desired values, remove keys it previously owned but
+// the spec no longer requests, and never disturb keys written by other actors
+// (cert-manager, ingress controllers, cloud load-balancer controllers).
+//
+// The two owned-key sets are themselves stored as annotations. They are
+// operator-internal: they never appear in a desired set and are preserved as
+// "foreign" by the merge before being re-stamped, so they don't recurse into
+// the managed set.
+const (
+	ownedAnnotationKeysAnnotation = "neo4j.com/owned-annotation-keys"
+	ownedLabelKeysAnnotation      = "neo4j.com/owned-label-keys"
+)
+
+// splitOwnedKeys parses a sorted, comma-separated owned-key list.
+func splitOwnedKeys(csv string) []string {
+	if csv == "" {
+		return nil
+	}
+	parts := strings.Split(csv, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// ownedKeysCSV renders keys as a sorted, comma-separated list for storage.
+func ownedKeysCSV(keys []string) string {
+	sorted := make([]string, len(keys))
+	copy(sorted, keys)
+	sort.Strings(sorted)
+	return strings.Join(sorted, ",")
+}
+
+// mergeOwnedStringMap reconciles a controller-managed string map (labels or
+// annotations) against the desired set using the ownership model: desired keys
+// are added/updated, keys this controller previously owned but no longer
+// desires are removed, and keys owned by other actors are preserved. Returns the
+// merged map and the new sorted owned-key list. Pure function; the caller
+// persists the owned-key list.
+func mergeOwnedStringMap(live, desired map[string]string, previousOwned []string) (map[string]string, []string) {
+	out := make(map[string]string, len(live)+len(desired))
+	for k, v := range live {
+		out[k] = v
+	}
+	desiredKeys := make(map[string]struct{}, len(desired))
+	for k := range desired {
+		desiredKeys[k] = struct{}{}
+	}
+	// Remove keys we used to own that are no longer desired. Foreign keys (never
+	// owned by us) are left untouched.
+	for _, k := range previousOwned {
+		if _, stillDesired := desiredKeys[k]; !stillDesired {
+			delete(out, k)
+		}
+	}
+	// Apply desired (add / overwrite).
+	for k, v := range desired {
+		out[k] = v
+	}
+	owned := make([]string, 0, len(desired))
+	for k := range desired {
+		owned = append(owned, k)
+	}
+	sort.Strings(owned)
+	return out, owned
+}
+
+// applyOwnedMetadata reconciles obj's annotations and labels against the desired
+// sets using the ownership model above, tracking owned keys in two bookkeeping
+// annotations. Returns true if the annotations or labels changed (nil and empty
+// maps are treated as equal so unchanged resources don't churn).
+func applyOwnedMetadata(obj client.Object, desiredAnnotations, desiredLabels map[string]string) bool {
+	annos := obj.GetAnnotations()
+	labels := obj.GetLabels()
+
+	prevOwnedAnnos := splitOwnedKeys(annos[ownedAnnotationKeysAnnotation])
+	prevOwnedLabels := splitOwnedKeys(annos[ownedLabelKeysAnnotation])
+
+	newAnnos, ownedAnnos := mergeOwnedStringMap(annos, desiredAnnotations, prevOwnedAnnos)
+	newLabels, ownedLabels := mergeOwnedStringMap(labels, desiredLabels, prevOwnedLabels)
+
+	// Persist the owned-key bookkeeping (in annotations for both maps — label
+	// values can't hold comma-separated lists safely).
+	if len(ownedAnnos) > 0 {
+		newAnnos[ownedAnnotationKeysAnnotation] = ownedKeysCSV(ownedAnnos)
+	} else {
+		delete(newAnnos, ownedAnnotationKeysAnnotation)
+	}
+	if len(ownedLabels) > 0 {
+		newAnnos[ownedLabelKeysAnnotation] = ownedKeysCSV(ownedLabels)
+	} else {
+		delete(newAnnos, ownedLabelKeysAnnotation)
+	}
+
+	changed := false
+	if !stringMapsEqual(annos, newAnnos) {
+		obj.SetAnnotations(newAnnos)
+		changed = true
+	}
+	if !stringMapsEqual(labels, newLabels) {
+		obj.SetLabels(newLabels)
+		changed = true
+	}
+	return changed
+}
+
+// stringMapsEqual treats nil and empty maps as equal.
+func stringMapsEqual(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if bv, ok := b[k]; !ok || bv != v {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/controller/owned_keys_test.go
+++ b/internal/controller/owned_keys_test.go
@@ -100,3 +100,39 @@ func TestApplyOwnedMetadata_NoManagedKeysNoChurn(t *testing.T) {
 	assert.Empty(t, obj.Annotations)
 	assert.Empty(t, obj.Labels)
 }
+
+// TestMergePodTemplateAnnotations pins the fix for the "hash apply drops pod
+// annotations" finding: a wholesale template apply must preserve foreign
+// pod-template annotations (config-restart/config-hash stamps, mesh/plugin
+// markers) while re-deriving the operator-managed Prometheus hints from desired.
+func TestMergePodTemplateAnnotations(t *testing.T) {
+	live := map[string]string{
+		"neo4j.neo4j.com/config-restart": "2026-06-11T00:00:00Z", // foreign (ConfigMapManager)
+		"neo4j.neo4j.com/config-hash":    "abc123",               // foreign
+		"linkerd.io/inject":              "enabled",              // foreign (mesh)
+		"prometheus.io/scrape":           "true",                 // operator-managed, stale value
+		"prometheus.io/port":             "9999",                 // operator-managed, stale value
+	}
+	desired := map[string]string{
+		"prometheus.io/scrape": "true",
+		"prometheus.io/port":   "2004",
+		"prometheus.io/path":   "/metrics",
+	}
+
+	out := mergePodTemplateAnnotations(live, desired)
+
+	// Foreign annotations preserved.
+	assert.Equal(t, "2026-06-11T00:00:00Z", out["neo4j.neo4j.com/config-restart"])
+	assert.Equal(t, "abc123", out["neo4j.neo4j.com/config-hash"])
+	assert.Equal(t, "enabled", out["linkerd.io/inject"])
+	// Operator-managed hints re-derived from desired (stale port replaced).
+	assert.Equal(t, "2004", out["prometheus.io/port"])
+	assert.Equal(t, "/metrics", out["prometheus.io/path"])
+
+	// Disabling monitoring (no desired prometheus keys) removes the managed
+	// hints but keeps foreign annotations.
+	out2 := mergePodTemplateAnnotations(live, nil)
+	_, hasScrape := out2["prometheus.io/scrape"]
+	assert.False(t, hasScrape, "managed prometheus hint removed when not desired")
+	assert.Equal(t, "abc123", out2["neo4j.neo4j.com/config-hash"], "foreign still preserved")
+}

--- a/internal/controller/owned_keys_test.go
+++ b/internal/controller/owned_keys_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestMergeOwnedStringMap(t *testing.T) {
+	t.Run("adds and updates desired, preserves foreign", func(t *testing.T) {
+		live := map[string]string{"foreign": "x", "a": "old"}
+		out, owned := mergeOwnedStringMap(live, map[string]string{"a": "new", "b": "1"}, nil)
+		assert.Equal(t, "new", out["a"])
+		assert.Equal(t, "1", out["b"])
+		assert.Equal(t, "x", out["foreign"], "foreign key preserved")
+		assert.Equal(t, []string{"a", "b"}, owned)
+	})
+
+	t.Run("removes previously-owned key no longer desired, keeps foreign", func(t *testing.T) {
+		live := map[string]string{"a": "1", "b": "2", "foreign": "keep"}
+		out, owned := mergeOwnedStringMap(live, map[string]string{"a": "1"}, []string{"a", "b"})
+		assert.Equal(t, "1", out["a"])
+		_, hasB := out["b"]
+		assert.False(t, hasB, "previously-owned b dropped from spec is removed")
+		assert.Equal(t, "keep", out["foreign"], "foreign key untouched")
+		assert.Equal(t, []string{"a"}, owned)
+	})
+
+	t.Run("a key removed from spec that was NOT owned stays (foreign)", func(t *testing.T) {
+		live := map[string]string{"b": "2"}
+		out, _ := mergeOwnedStringMap(live, map[string]string{}, nil)
+		assert.Equal(t, "2", out["b"], "never-owned key is foreign and preserved")
+	})
+}
+
+// TestApplyOwnedMetadata_LifecycleAcrossReconciles models the Service/Ingress
+// reconcile across operations and pins the three Bugbot findings:
+//   - foreign annotations (cert-manager / ingress controller) are preserved and
+//     don't cause oscillation (#1);
+//   - desired labels are applied (#2);
+//   - a key cleared from the spec is removed (#3).
+func TestApplyOwnedMetadata_LifecycleAcrossReconciles(t *testing.T) {
+	// First reconcile: empty live object, operator wants annotation X + label L.
+	obj := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "svc"}}
+	changed := applyOwnedMetadata(obj, map[string]string{"X": "1"}, map[string]string{"L": "a"})
+	assert.True(t, changed, "first apply sets desired + bookkeeping")
+	assert.Equal(t, "1", obj.Annotations["X"])
+	assert.Equal(t, "a", obj.Labels["L"])
+	assert.Equal(t, "X", obj.Annotations[ownedAnnotationKeysAnnotation])
+	assert.Equal(t, "L", obj.Annotations[ownedLabelKeysAnnotation])
+
+	// A foreign controller adds its own annotation + label to the live object.
+	obj.Annotations["cert-manager.io/issuer"] = "ca"
+	obj.Labels["foreign"] = "z"
+
+	// Steady-state reconcile with the SAME desired set must not change anything
+	// (no oscillation, #1) and must preserve the foreign keys.
+	changed = applyOwnedMetadata(obj, map[string]string{"X": "1"}, map[string]string{"L": "a"})
+	assert.False(t, changed, "unchanged desired must not churn")
+	assert.Equal(t, "ca", obj.Annotations["cert-manager.io/issuer"], "foreign annotation preserved")
+	assert.Equal(t, "z", obj.Labels["foreign"], "foreign label preserved")
+
+	// Spec changes: X's value updated, new annotation Y added, label L removed.
+	changed = applyOwnedMetadata(obj, map[string]string{"X": "2", "Y": "9"}, map[string]string{})
+	assert.True(t, changed)
+	assert.Equal(t, "2", obj.Annotations["X"], "updated value applied")
+	assert.Equal(t, "9", obj.Annotations["Y"], "new desired annotation applied")
+	assert.Equal(t, "ca", obj.Annotations["cert-manager.io/issuer"], "foreign still preserved")
+	_, hasL := obj.Labels["L"]
+	assert.False(t, hasL, "label cleared from spec is removed (#3)")
+	assert.Equal(t, "z", obj.Labels["foreign"], "foreign label still preserved")
+	assert.Equal(t, "X,Y", obj.Annotations[ownedAnnotationKeysAnnotation])
+	_, hasLabelTracking := obj.Annotations[ownedLabelKeysAnnotation]
+	assert.False(t, hasLabelTracking, "owned-label bookkeeping dropped when no labels owned")
+}
+
+// TestApplyOwnedMetadata_NoManagedKeysNoChurn ensures an object the operator
+// manages no annotations/labels for is left untouched (no bookkeeping added).
+func TestApplyOwnedMetadata_NoManagedKeysNoChurn(t *testing.T) {
+	obj := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "svc"}}
+	assert.False(t, applyOwnedMetadata(obj, nil, nil), "no desired keys => no change")
+	assert.Empty(t, obj.Annotations)
+	assert.Empty(t, obj.Labels)
+}

--- a/internal/controller/template_comparison_test.go
+++ b/internal/controller/template_comparison_test.go
@@ -659,7 +659,15 @@ func TestIsTemplateChangeSignificant_PluginAddedEnvVars(t *testing.T) {
 		corev1.EnvVar{Name: "NEO4J_APOC_EXPORT_FILE_ENABLED", Value: "true"},
 	)
 
+	// Simulate the controller having already applied & stamped this desired
+	// template — so the hash term in isTemplateChangeSignificant is satisfied
+	// and only the (foreign-tolerant) field-by-field check governs the result.
 	stableCluster := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				clusterTemplateHashAnnotation: podTemplateSpecHash(desired),
+			},
+		},
 		Spec:   appsv1.StatefulSetSpec{Replicas: int32Ptr(3)},
 		Status: appsv1.StatefulSetStatus{ReadyReplicas: 3},
 	}
@@ -672,4 +680,90 @@ func TestIsTemplateChangeSignificant_PluginAddedEnvVars(t *testing.T) {
 // Helper function
 func int32Ptr(i int32) *int32 {
 	return &i
+}
+
+// TestClusterTemplateHash_ClosesBlindSpots pins the drift fix: changes to pod-
+// template fields the field-by-field check never compared (nodeSelector,
+// affinity, tolerations, probes, resource requests, volume sources) must flip
+// the template hash so a stable cluster re-applies them. Without the hash these
+// were silently dropped on a live cluster.
+func TestClusterTemplateHash_ClosesBlindSpots(t *testing.T) {
+	base := corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			NodeSelector: map[string]string{"disktype": "ssd"},
+			Tolerations:  []corev1.Toleration{{Key: "a", Operator: corev1.TolerationOpExists}},
+			Affinity: &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{{MatchExpressions: []corev1.NodeSelectorRequirement{
+						{Key: "zone", Operator: corev1.NodeSelectorOpIn, Values: []string{"a"}},
+					}}},
+				},
+			}},
+			Containers: []corev1.Container{{
+				Name:  "neo4j",
+				Image: "neo4j:5.26.0-enterprise",
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("1Gi")},
+				},
+				ReadinessProbe: &corev1.Probe{InitialDelaySeconds: 10},
+				VolumeMounts:   []corev1.VolumeMount{{Name: "conf", MountPath: "/conf"}},
+			}},
+			Volumes: []corev1.Volume{{
+				Name:         "conf",
+				VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: "cm-a"}}},
+			}},
+		},
+	}
+
+	baseHash := podTemplateSpecHash(base)
+
+	mutators := map[string]func(*corev1.PodTemplateSpec){
+		"nodeSelector": func(t *corev1.PodTemplateSpec) { t.Spec.NodeSelector["disktype"] = "nvme" },
+		"tolerations":  func(t *corev1.PodTemplateSpec) { t.Spec.Tolerations[0].Key = "b" },
+		"affinity": func(t *corev1.PodTemplateSpec) {
+			t.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions[0].Values = []string{"b"}
+		},
+		"resourceRequests": func(t *corev1.PodTemplateSpec) {
+			t.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory] = resource.MustParse("2Gi")
+		},
+		"probe":        func(t *corev1.PodTemplateSpec) { t.Spec.Containers[0].ReadinessProbe.InitialDelaySeconds = 30 },
+		"volumeSource": func(t *corev1.PodTemplateSpec) { t.Spec.Volumes[0].ConfigMap.Name = "cm-b" },
+	}
+
+	for name, mutate := range mutators {
+		t.Run(name, func(t *testing.T) {
+			mutated := *base.DeepCopy()
+			mutate(&mutated)
+			if podTemplateSpecHash(mutated) == baseHash {
+				t.Fatalf("changing %s did not change the template hash — blind spot not closed", name)
+			}
+		})
+	}
+}
+
+// TestClusterTemplateHash_StableAndForeignTolerant ensures the hash is a fixed
+// point for an unchanged template (no spurious rolls) and that foreign env vars
+// added to a separate (live) template do not change the desired-template hash.
+func TestClusterTemplateHash_StableAndForeignTolerant(t *testing.T) {
+	desired := corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{
+			Name:  "neo4j",
+			Image: "neo4j:5.26.0-enterprise",
+			Env:   []corev1.EnvVar{{Name: "NEO4J_EDITION", Value: "enterprise"}},
+		}}},
+	}
+	h1 := podTemplateSpecHash(desired)
+	if h2 := podTemplateSpecHash(*desired.DeepCopy()); h1 != h2 {
+		t.Fatalf("hash not stable across identical templates: %q vs %q", h1, h2)
+	}
+
+	// A live template with plugin/fleet-added env vars is a different object;
+	// the desired-template hash (what the controller stamps and compares) is
+	// computed only over the desired template, so it is unaffected.
+	live := *desired.DeepCopy()
+	live.Spec.Containers[0].Env = append(live.Spec.Containers[0].Env,
+		corev1.EnvVar{Name: "NEO4J_PLUGINS", Value: `["apoc"]`})
+	if podTemplateSpecHash(desired) != h1 {
+		t.Fatal("desired-template hash changed unexpectedly")
+	}
 }

--- a/internal/neo4j/client.go
+++ b/internal/neo4j/client.go
@@ -384,67 +384,15 @@ func NewClientForEnterprise(cluster *neo4jv1beta1.Neo4jEnterpriseCluster, k8sCli
 		poolMetrics:       poolMetrics,
 	}
 
-	// Start background health monitoring
-	go client.startHealthMonitoring()
-
 	return client, nil
 }
 
-// startHealthMonitoring runs background health checks and pool optimization
-func (c *Client) startHealthMonitoring() {
-	ticker := time.NewTicker(30 * time.Second)
-	defer ticker.Stop()
-
-	for range ticker.C {
-		c.updatePoolMetrics()
-		c.checkCircuitBreakerState()
-	}
-}
-
-// updatePoolMetrics collects connection pool metrics
-func (c *Client) updatePoolMetrics() {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
-	// Update metrics timestamp
-	c.poolMetrics.LastHealthCheck = time.Now()
-
-	// Collect detailed connection pool metrics
-	// Note: These are estimates since the Go driver doesn't expose detailed pool metrics
-	// In production, you would integrate with Neo4j's JMX metrics or monitoring APIs
-
-	// Simulate pool metrics based on driver state and usage patterns
-	if c.driver != nil {
-		// Estimate connection usage based on recent activity
-		now := time.Now()
-		timeSinceLastCheck := now.Sub(c.poolMetrics.LastHealthCheck)
-
-		// Simulate active connections (would be actual metrics from driver)
-		activeEstimate := int64(5) // Base active connections
-		if timeSinceLastCheck < time.Minute {
-			activeEstimate = int64(10) // Higher activity recently
-		}
-
-		c.poolMetrics.ActiveConnections = activeEstimate
-		c.poolMetrics.TotalConnections = activeEstimate + 5 // Assume some idle connections
-		c.poolMetrics.IdleConnections = c.poolMetrics.TotalConnections - c.poolMetrics.ActiveConnections
-
-		// Update query execution time (rolling average)
-		if c.poolMetrics.QueryExecutionTime == 0 {
-			c.poolMetrics.QueryExecutionTime = 50 * time.Millisecond // Initial estimate
-		} else {
-			// Exponential moving average with new sample
-			newSample := 45 * time.Millisecond // Would be actual measurement
-			alpha := 0.1
-			c.poolMetrics.QueryExecutionTime = time.Duration(
-				float64(c.poolMetrics.QueryExecutionTime)*(1-alpha) +
-					float64(newSample)*alpha,
-			)
-		}
-	}
-}
-
-// checkCircuitBreakerState evaluates and updates circuit breaker state
+// checkCircuitBreakerState evaluates and updates circuit breaker state.
+// Called synchronously at the start of executeWithCircuitBreaker so an Open
+// circuit can transition to HalfOpen once resetTimeout has elapsed — there is
+// no longer a background ticker driving this (a previous implementation leaked
+// a never-stopped goroutine + ticker per client, and every controller builds a
+// client per reconcile).
 func (c *Client) checkCircuitBreakerState() {
 	c.circuitBreaker.mutex.Lock()
 	defer c.circuitBreaker.mutex.Unlock()
@@ -461,6 +409,10 @@ func (c *Client) checkCircuitBreakerState() {
 
 // executeWithCircuitBreaker wraps Neo4j operations with circuit breaker pattern
 func (c *Client) executeWithCircuitBreaker(ctx context.Context, operation func(ctx context.Context) error) error {
+	// Re-evaluate the breaker first so an Open circuit can move to HalfOpen
+	// once resetTimeout has elapsed (previously driven by a background ticker).
+	c.checkCircuitBreakerState()
+
 	c.circuitBreaker.mutex.RLock()
 	state := c.circuitBreaker.state
 	c.circuitBreaker.mutex.RUnlock()
@@ -1129,18 +1081,53 @@ func (c *Client) RevokeRoleFromUser(ctx context.Context, roleName, username stri
 
 // ExecutePrivilegeStatement executes a privilege statement
 func (c *Client) ExecutePrivilegeStatement(ctx context.Context, statement string) error {
-	session := c.driver.NewSession(ctx, neo4j.SessionConfig{
-		AccessMode:   neo4j.AccessModeWrite,
-		DatabaseName: "system",
-	})
-	defer session.Close(ctx)
-
-	_, err := session.Run(ctx, statement, nil)
-	if err != nil {
-		return fmt.Errorf("failed to execute privilege statement: %w", err)
+	// Privilege DDL runs as an auto-commit statement (session.Run), which —
+	// unlike a managed transaction — gets no built-in retry. Concurrent admin
+	// writes on the system database can collide with a transient
+	// "conflicting transaction state" (GQLSTATUS 25N11) that Neo4j explicitly
+	// asks the client to retry. Bounded retries keep the operator's own
+	// privilege writes resilient without changing transaction semantics.
+	const maxAttempts = 4
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		session := c.driver.NewSession(ctx, neo4j.SessionConfig{
+			AccessMode:   neo4j.AccessModeWrite,
+			DatabaseName: "system",
+		})
+		_, err := session.Run(ctx, statement, nil)
+		_ = session.Close(ctx)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if !isTransientNeo4jError(err) || attempt == maxAttempts {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Duration(attempt) * 250 * time.Millisecond):
+		}
 	}
+	return fmt.Errorf("failed to execute privilege statement: %w", lastErr)
+}
 
-	return nil
+// isTransientNeo4jError reports whether err is a transient Neo4j error worth
+// retrying. It trusts the driver's own classification first, then falls back to
+// matching the GQLSTATUS 25N11 "conflicting transaction state" markers, which
+// 2025+/2026 servers surface and which may not be classified retryable by the
+// driver across versions.
+func isTransientNeo4jError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if neo4j.IsRetryable(err) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "25n11") ||
+		strings.Contains(msg, "conflicting transaction state") ||
+		strings.Contains(msg, "please retry the transaction")
 }
 
 // CheckUpgradeCompatibility checks if an upgrade to the specified version is compatible

--- a/internal/neo4j/privileges.go
+++ b/internal/neo4j/privileges.go
@@ -34,6 +34,9 @@ import (
 //   - trims leading and trailing whitespace and any single trailing semicolon
 //   - upper-cases reserved keywords (GRANT/DENY/REVOKE/ON/TO/FROM/...)
 //     while preserving identifiers, quoted strings and braces
+//   - strips redundant backticks around simple, non-reserved identifiers so
+//     that `neo4j` (the form `SHOW ... PRIVILEGES AS COMMANDS` emits) and
+//     neo4j (the form users typically write in spec) compare equal
 //
 // The result is suitable for use as a map key when diffing desired vs.
 // actual privileges. It is NOT safe to feed the canonical form back to
@@ -144,7 +147,33 @@ var privilegeKeywords = map[string]struct{}{
 
 var (
 	tokenSplit = regexp.MustCompile(`\s+`)
+	// simpleIdentifierRe matches an identifier that is valid unquoted in
+	// Cypher: a letter followed by letters, digits or underscores. Names
+	// requiring quotes (spaces, dots, hyphens, leading digits) do not match,
+	// so their backticks are preserved.
+	simpleIdentifierRe = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_]*$`)
 )
+
+// redundantlyBacktickedIdentifier reports whether t is a backtick-quoted token
+// whose backticks are redundant — the inner name is a simple identifier that
+// is valid unquoted and is not a reserved privilege keyword — and if so returns
+// the unquoted inner name. Names that genuinely require quoting (special
+// characters, embedded/doubled backticks, or a reserved word that would change
+// meaning or become invalid Cypher when unquoted) keep their backticks so the
+// canonical form remains executable.
+func redundantlyBacktickedIdentifier(t string) (string, bool) {
+	if len(t) < 2 || t[0] != '`' || t[len(t)-1] != '`' {
+		return "", false
+	}
+	inner := t[1 : len(t)-1]
+	if !simpleIdentifierRe.MatchString(inner) {
+		return "", false
+	}
+	if _, reserved := privilegeKeywords[strings.ToUpper(inner)]; reserved {
+		return "", false
+	}
+	return inner, true
+}
 
 // collapseWhitespacePreservingQuotes collapses whitespace runs to a single
 // space, but does not modify whitespace inside single- or double-quoted
@@ -218,6 +247,14 @@ func upperCaseReservedKeywords(s string) string {
 		t := token.String()
 		token.Reset()
 		if t == "" {
+			return
+		}
+		// Drop redundant backticks around simple identifiers (e.g. `neo4j` →
+		// neo4j) so spec and `AS COMMANDS` forms canonicalise identically.
+		// This is what stops the privilege diff from seeing perpetual drift
+		// (and GRANT/REVOKE-churning every reconcile) under enforcePrivileges.
+		if inner, ok := redundantlyBacktickedIdentifier(t); ok {
+			out.WriteString(inner)
 			return
 		}
 		if _, ok := privilegeKeywords[strings.ToUpper(t)]; ok {

--- a/internal/neo4j/privileges_test.go
+++ b/internal/neo4j/privileges_test.go
@@ -277,3 +277,115 @@ func TestPrivilegeStatementMatchesRole_PBAC(t *testing.T) {
 		}
 	}
 }
+
+// TestCanonicalise_BacktickQuotingNormalised pins the fix for the privilege
+// drift loop: `SHOW ROLE ... PRIVILEGES AS COMMANDS` re-renders identifiers
+// backtick-quoted (e.g. `neo4j`, `analytics_reader`), while users write them
+// bare in Neo4jRole.spec.privileges. Both must canonicalise identically, or
+// the controller sees perpetual drift and GRANT/REVOKE-churns every reconcile
+// under enforcePrivileges (observed as a 25N11 transaction conflict on
+// 2026.04 in CI). See neo4jrole_test.go:146.
+func TestCanonicalise_BacktickQuotingNormalised(t *testing.T) {
+	cases := []struct {
+		name   string
+		bare   string
+		quoted string
+	}{
+		{
+			name:   "database and role names",
+			bare:   "GRANT ACCESS ON DATABASE neo4j TO analytics_reader",
+			quoted: "GRANT ACCESS ON DATABASE `neo4j` TO `analytics_reader`",
+		},
+		{
+			name:   "graph match privilege",
+			bare:   "GRANT MATCH {*} ON GRAPH neo4j NODES * TO analytics_reader",
+			quoted: "GRANT MATCH {*} ON GRAPH `neo4j` NODES * TO `analytics_reader`",
+		},
+		{
+			name:   "deny on graph",
+			bare:   "DENY WRITE ON GRAPH movies TO editor",
+			quoted: "DENY WRITE ON GRAPH `movies` TO `editor`",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cb := CanonicalisePrivilegeStatement(tc.bare)
+			cq := CanonicalisePrivilegeStatement(tc.quoted)
+			if cb != cq {
+				t.Fatalf("bare vs quoted canonical forms differ:\n bare:   %q\n quoted: %q", cb, cq)
+			}
+		})
+	}
+}
+
+// TestCanonicalise_ReservedAndSpecialNamesKeepBackticks ensures we only strip
+// backticks when the inner name is a simple, non-reserved identifier. A role
+// named after a reserved keyword, or a name with characters that require
+// quoting, must keep its backticks so the canonical form stays valid Cypher
+// (DerivePrivilegeRevoke feeds it back to Neo4j).
+func TestCanonicalise_ReservedAndSpecialNamesKeepBackticks(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "reserved word as role name keeps backticks",
+			in:   "GRANT ACCESS ON DATABASE neo4j TO `graph`",
+			want: "GRANT ACCESS ON DATABASE neo4j TO `graph`",
+		},
+		{
+			name: "hyphenated name keeps backticks",
+			in:   "GRANT ACCESS ON DATABASE `my-db` TO r",
+			want: "GRANT ACCESS ON DATABASE `my-db` TO r",
+		},
+		{
+			name: "dotted name keeps backticks",
+			in:   "GRANT ACCESS ON DATABASE `foo.bar` TO r",
+			want: "GRANT ACCESS ON DATABASE `foo.bar` TO r",
+		},
+		{
+			name: "name with space keeps backticks",
+			in:   "GRANT ACCESS ON DATABASE `My DB` TO r",
+			want: "GRANT ACCESS ON DATABASE `My DB` TO r",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := CanonicalisePrivilegeStatement(tc.in); got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCanonicalise_StableUnderReReconcile models the controller's diff: the
+// desired statement (from spec, bare) and the current statement (from
+// AS COMMANDS, quoted) must produce an empty add/remove set, and re-running
+// canonicalisation on its own output must be a fixed point — otherwise the
+// reconcile never converges.
+func TestCanonicalise_StableUnderReReconcile(t *testing.T) {
+	desired := "GRANT MATCH {*} ON GRAPH neo4j NODES * TO analytics_reader"
+	current := "GRANT MATCH {*} ON GRAPH `neo4j` NODES * TO `analytics_reader`"
+
+	cd := CanonicalisePrivilegeStatement(desired)
+	cc := CanonicalisePrivilegeStatement(current)
+	if cd != cc {
+		t.Fatalf("desired and current canonical forms differ → perpetual drift:\n desired: %q\n current: %q", cd, cc)
+	}
+
+	// Idempotence: canonicalising the canonical form changes nothing.
+	if again := CanonicalisePrivilegeStatement(cd); again != cd {
+		t.Fatalf("canonicalisation not idempotent: %q -> %q", cd, again)
+	}
+
+	// The derived REVOKE must remain valid (bare, executable) Cypher.
+	revoke, err := DerivePrivilegeRevoke(current)
+	if err != nil {
+		t.Fatalf("DerivePrivilegeRevoke(%q) errored: %v", current, err)
+	}
+	want := "REVOKE GRANT MATCH {*} ON GRAPH neo4j NODES * FROM analytics_reader"
+	if revoke != want {
+		t.Fatalf("derived REVOKE = %q, want %q", revoke, want)
+	}
+}

--- a/test/integration/neo4jrole_test.go
+++ b/test/integration/neo4jrole_test.go
@@ -137,13 +137,19 @@ var _ = Describe("Neo4jRole end-to-end", Label("core"), func() {
 		time.Sleep(5 * time.Second)
 
 		By("Manually revoking ACCESS to simulate drift")
-		cmd := exec.CommandContext(ctx, "kubectl", "exec",
-			podName, "-n", namespace.Name, "--",
-			"cypher-shell", "--format", "plain", "-u", "neo4j", "-p", adminPass,
-			"REVOKE ACCESS ON DATABASE neo4j FROM analytics_reader",
-		)
-		out, err := cmd.CombinedOutput()
-		Expect(err).ToNot(HaveOccurred(), "cypher-shell REVOKE failed; output: %s", string(out))
+		// Retry transient system-DB conflicts (GQLSTATUS 25N11) — a manual
+		// admin write can briefly collide with concurrent system-DB activity.
+		Eventually(func() error {
+			cmd := exec.CommandContext(ctx, "kubectl", "exec",
+				podName, "-n", namespace.Name, "--",
+				"cypher-shell", "--format", "plain", "-u", "neo4j", "-p", adminPass,
+				"REVOKE ACCESS ON DATABASE neo4j FROM analytics_reader",
+			)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				return fmt.Errorf("cypher-shell REVOKE failed; output: %s", string(out))
+			}
+			return nil
+		}, 30*time.Second, 2*time.Second).Should(Succeed())
 
 		By("Waiting for the operator to re-apply the GRANT (drift reconciliation)")
 		Eventually(func() bool {


### PR DESCRIPTION
## Summary

Fixes the red 2026.04 integration lane and resolves four related correctness issues found while investigating it. Each is a separate, self-contained commit.

**`fix(privileges)` — the CI failure root cause.** `CanonicalisePrivilegeStatement` collapsed whitespace and upper-cased keywords but did not normalise backtick quoting. On 2026.04, `SHOW ROLE … PRIVILEGES AS COMMANDS` re-renders identifiers backtick-quoted (`` `neo4j` ``, `` `analytics_reader` ``) while users write them bare in `Neo4jRole.spec.privileges`. So desired (bare) and current (quoted) never compared equal, and under `enforcePrivileges=true` the controller re-derived a GRANT+REVOKE every reconcile — perpetual churn that collided with concurrent system-DB writes and surfaced as a `25N11 "conflicting transaction state"` failure in the neo4jrole drift test (`neo4jrole_test.go:146`). 5.26 passed because its `AS COMMANDS` output is not backtick-quoted for these names. Fix strips redundant backticks around simple, non-reserved identifiers; names that genuinely require quoting keep them.

**`fix(neo4j)` — goroutine leak + transient retry.** `NewClientForEnterprise` launched a 30s-ticker health-monitor goroutine with no stop channel; `Close()` only closed the driver, so every cluster client (built per reconcile across the user/role/binding/authrule/database/cluster controllers) leaked a goroutine + ticker permanently — unbounded growth on a long-running operator. The metrics it produced were fabricated and read only by tests. Removed it; preserved circuit-breaker recovery by calling `checkCircuitBreakerState()` synchronously. Added bounded retry on transient `25N11` to `ExecutePrivilegeStatement` (driver `IsRetryable` + defensive string match) and to the test's manual REVOKE.

**`fix(cluster)` — day-2 spec changes silently dropped.** Two mechanisms discarded live-cluster edits: (1) non-StatefulSet resources were create-only (the `CreateOrUpdate` mutate closure only handled `*StatefulSet`), so `spec.service.type`/annotations/`loadBalancerIP`, ingress host, NetworkPolicy rules and Certificate DNS-name edits never landed — now routed through `reconcileMutableResource` (explicit get-then-update; Service is field-by-field, preserving API-assigned `ClusterIP`/`ClusterIPs`/`HealthCheckNodePort` and inherited NodePorts); (2) the stable-phase StatefulSet drift check never compared nodeSelector/affinity/tolerations/probes/resource requests/volume sources/initContainer args — added a desired-template hash (`neo4j.com/cluster-template-hash`) as an additional significance trigger. The hash is over the desired template vs. last-applied (never the live one), so foreign plugin/fleet/Aura env vars can't cause oscillation against the env-ownership protocol. Formation-phase gate unchanged; existing clusters converge once on upgrade.

**`fix(role)` — execute original privilege text for adds.** The add loop executed the canonical form, which upper-cases bare identifiers, so a role/graph/database named after a reserved keyword written unquoted (e.g. `… TO users`) would target the wrong case-sensitive name (`… TO USERS`). `canonicaliseDesired` now returns a canonical→original map; the add loop runs the user's original text. The revoke path already did this.

## Type of change

- [x] Bug fix

## Testing

- [x] `make test-unit` passes locally (full controller envtest suite — 75 specs — plus `internal/neo4j`, `validation`, `resources`, `metrics`, `monitoring`)
- [x] `make lint` passes locally (golangci-lint + staticcheck via pre-commit on every commit)
- [x] Extended Integration Tests should run — this PR changes the cluster controller and the Neo4j client. **Adding the `run-integration-tests` label** (the failing `neo4jrole` core spec is the direct regression test for the `fix(privileges)` change).

New/updated unit tests: backtick-quoting equality + reconcile stability (`privileges_test.go`); template-hash blind-spot coverage + foreign-tolerance (`template_comparison_test.go`); Service immutable-preservation + NodePort inheritance (`mutable_resource_test.go`); `canonicaliseDesired` original-text mapping (`neo4jrole_controller_unit_test.go`).

## Checklist

- [x] Conventional Commit titles (`fix:`)
- [x] No API type / kubebuilder / CRD changes — `check-drift` passes (verified by pre-commit)
- [ ] Docs unchanged (behavior of documented fields/defaults is unchanged; these are correctness fixes)
- [x] Respects `CLAUDE.md` invariants (no webhooks; controller-side validation; env-ownership / `cluster-controller-env-vars` protocol preserved; routing-scheme and rule 20 privilege-drift design honoured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes Neo4j privilege diff/execution and core cluster reconciliation paths (Services, StatefulSet template updates, metadata merging), which are security- and availability-sensitive despite being targeted bug fixes.
> 
> **Overview**
> Fixes four correctness issues: **privilege drift on Neo4j 2026.04**, **Neo4j client leaks/retries**, **cluster day-2 updates ignored**, and **wrong privilege text on GRANT**.
> 
> **Privileges & Neo4jRole:** `CanonicalisePrivilegeStatement` now treats bare and backtick-quoted simple identifiers as equal (stopping perpetual GRANT/REVOKE under `enforcePrivileges` when `SHOW … AS COMMANDS` quotes names). The role controller **runs the user’s original privilege strings on add**, not the canonical form (avoids upper-casing unquoted role names like `users`). `ExecutePrivilegeStatement` gets bounded retries for transient system-DB conflicts (`25N11`).
> 
> **Neo4j client:** Removes the per-client background health-monitor goroutine/ticker leak; **circuit-breaker half-open** is evaluated synchronously on each operation instead.
> 
> **Cluster (and shared controller helpers):** Services, Ingress, NetworkPolicy, and Certificates on existing clusters go through **`reconcileMutableResource`** (field-aware Service updates, drift-gated Updates) instead of a StatefulSet-only no-op path. Stable StatefulSet template drift also compares a stored **`neo4j.com/cluster-template-hash`** and merges **foreign pod-template annotations** via new **`applyOwnedMetadata` / `mergePodTemplateAnnotations`** (`owned_keys.go`). Standalone Ingress/NetworkPolicy adopt the same owned-metadata pattern; **`podTemplateSpecHash`** is shared with cluster.
> 
> Unit/integration tests cover backtick canonicalisation, Service immutables, owned metadata lifecycle, template-hash blind spots, and canonical→original mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 120a1d4eff335a1a7473dd827b8ee28ff2404a12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->