### PR TITLE
fix(security): close CR-field injection (restore shell, database Cypher, neo4j.conf newline)

### DIFF
--- a/api/v1beta1/neo4jrestore_types.go
+++ b/api/v1beta1/neo4jrestore_types.go
@@ -32,7 +32,11 @@ type Neo4jRestoreSpec struct {
 	Source RestoreSource `json:"source"`
 
 	// +kubebuilder:validation:Required
-	// Database to restore to
+	// +kubebuilder:validation:Pattern=`^[a-zA-Z][a-zA-Z0-9.\-]*$`
+	// +kubebuilder:validation:MaxLength=65
+	// Database to restore to. Must be a valid Neo4j database name (starts with a
+	// letter; letters, digits, dots, dashes only) — the name is interpolated
+	// into the restore Job's shell command and Cypher.
 	DatabaseName string `json:"databaseName"`
 
 	// Restore options

--- a/bundle/manifests/neo4j.neo4j.com_neo4jrestores.yaml
+++ b/bundle/manifests/neo4j.neo4j.com_neo4jrestores.yaml
@@ -69,7 +69,12 @@ spec:
                   to
                 type: string
               databaseName:
-                description: Database to restore to
+                description: |-
+                  Database to restore to. Must be a valid Neo4j database name (starts with a
+                  letter; letters, digits, dots, dashes only) — the name is interpolated
+                  into the restore Job's shell command and Cypher.
+                maxLength: 65
+                pattern: ^[a-zA-Z][a-zA-Z0-9.\-]*$
                 type: string
               force:
                 description: Force restore even if database exists

--- a/charts/neo4j-operator/crds/neo4j.neo4j.com_neo4jrestores.yaml
+++ b/charts/neo4j-operator/crds/neo4j.neo4j.com_neo4jrestores.yaml
@@ -69,7 +69,12 @@ spec:
                   to
                 type: string
               databaseName:
-                description: Database to restore to
+                description: |-
+                  Database to restore to. Must be a valid Neo4j database name (starts with a
+                  letter; letters, digits, dots, dashes only) — the name is interpolated
+                  into the restore Job's shell command and Cypher.
+                maxLength: 65
+                pattern: ^[a-zA-Z][a-zA-Z0-9.\-]*$
                 type: string
               force:
                 description: Force restore even if database exists

--- a/config/crd/bases/neo4j.neo4j.com_neo4jrestores.yaml
+++ b/config/crd/bases/neo4j.neo4j.com_neo4jrestores.yaml
@@ -69,7 +69,12 @@ spec:
                   to
                 type: string
               databaseName:
-                description: Database to restore to
+                description: |-
+                  Database to restore to. Must be a valid Neo4j database name (starts with a
+                  letter; letters, digits, dots, dashes only) — the name is interpolated
+                  into the restore Job's shell command and Cypher.
+                maxLength: 65
+                pattern: ^[a-zA-Z][a-zA-Z0-9.\-]*$
                 type: string
               force:
                 description: Force restore even if database exists

--- a/internal/controller/neo4jdatabase_controller_test.go
+++ b/internal/controller/neo4jdatabase_controller_test.go
@@ -325,7 +325,7 @@ var _ = Describe("Neo4jDatabase Controller", func() {
 			foundValidationError := false
 
 			for _, msg := range errorMessages {
-				if Contains(msg, "restoreUntil must be RFC3339 timestamp") {
+				if Contains(msg, "restoreUntil must be an RFC3339 timestamp") {
 					foundRestoreUntilError = true
 				}
 				if Contains(msg, "compression") && Contains(msg, "supported values") {

--- a/internal/controller/neo4jrestore_cloud_test.go
+++ b/internal/controller/neo4jrestore_cloud_test.go
@@ -791,8 +791,8 @@ func TestBuildPITRRestoreCommand_CloudBaseBackupNoFixups(t *testing.T) {
 	cmd, err := r.buildPITRRestoreCommand(context.Background(), restore, cluster)
 	require.NoError(t, err)
 
-	assert.Contains(t, cmd, "--from-path=s3://my-bucket/neo4j-backups/neo4j-2026-01-01.backup",
-		"cloud PITR must pass the cloud URI unchanged")
+	assert.Contains(t, cmd, "--from-path='s3://my-bucket/neo4j-backups/neo4j-2026-01-01.backup'",
+		"cloud PITR must pass the cloud URI, shell-quoted to prevent injection")
 	assert.NotContains(t, cmd, "$(ls",
 		"cloud PITR must NOT use shell substitution")
 	assert.NotContains(t, cmd, "rm -rf /tmp/restore-tmp",

--- a/internal/controller/neo4jrestore_controller.go
+++ b/internal/controller/neo4jrestore_controller.go
@@ -636,6 +636,14 @@ func (r *Neo4jRestoreReconciler) validateRestore(ctx context.Context, restore *n
 	if restore.Spec.DatabaseName == "" {
 		return fmt.Errorf("databaseName is required")
 	}
+	// The database name is interpolated into the restore Job's shell command
+	// and Cypher; restrict it to the Neo4j database-name grammar (no shell or
+	// Cypher metacharacters) so it can't inject either. Defense-in-depth on top
+	// of the CRD Pattern marker.
+	if !validation.IsValidDatabaseName(restore.Spec.DatabaseName) {
+		return fmt.Errorf("databaseName %q is invalid: must start with a letter, contain only letters, digits, dots or dashes, and be at most %d characters",
+			restore.Spec.DatabaseName, validation.MaxDatabaseNameLength)
+	}
 
 	// Sharded databases must NOT be restored via Neo4jRestore — the Cypher
 	// shape (`CREATE DATABASE … SET GRAPH SHARD … SET PROPERTY SHARDS …`)
@@ -1181,6 +1189,12 @@ func (r *Neo4jRestoreReconciler) buildRestoreCommand(ctx context.Context, restor
 	// glob naturally selects only the requested DB's file.
 	if resolved := buildLocalRestoreFilePath(restore, backupPath); resolved != "" {
 		backupPath = resolved
+	} else if !isLocalPVCRestoreSource(restore) && backupPath != "" {
+		// Cloud --from-path (s3://, gs://, azb://): quote the whole URI so a
+		// crafted spec.source.{bucket,path,backupPath} can't break out of
+		// /bin/sh -c. PVC sources take the branch above ($(ls …)), which must
+		// stay unquoted to execute the command substitution.
+		backupPath = shellQuote(backupPath)
 	}
 
 	// Extract Neo4j version from cluster image
@@ -1213,7 +1227,7 @@ func (r *Neo4jRestoreReconciler) buildRestoreCommand(ctx context.Context, restor
 	case restore.Spec.Options != nil && restore.Spec.Options.TempStorage != nil:
 		cmd += " --temp-path=/tmp/neo4j-staging"
 	case restore.Spec.Options != nil && restore.Spec.Options.TempPath != "":
-		cmd += " --temp-path=" + restore.Spec.Options.TempPath
+		cmd += " --temp-path=" + shellQuote(restore.Spec.Options.TempPath)
 	case isLocalPVCRestoreSource(restore):
 		// Default for PVC sources. neo4j-admin's restore needs a
 		// writable scratch dir to extract the artifact; if not told
@@ -1235,9 +1249,13 @@ func (r *Neo4jRestoreReconciler) buildRestoreCommand(ctx context.Context, restor
 		cmd += fmt.Sprintf(` --restore-until="%s"`, t.Format("2006-01-02 15:04:05"))
 	}
 
-	// Add additional arguments if specified
+	// Add additional arguments if specified. Each arg is shell-quoted (the
+	// pod runs the command via /bin/sh -c and holds the admin password), as
+	// the backup path already does.
 	if restore.Spec.Options != nil && len(restore.Spec.Options.AdditionalArgs) > 0 {
-		cmd += " " + strings.Join(restore.Spec.Options.AdditionalArgs, " ")
+		for _, arg := range restore.Spec.Options.AdditionalArgs {
+			cmd += " " + shellQuote(arg)
+		}
 	}
 
 	return cmd, nil
@@ -1331,6 +1349,10 @@ func (r *Neo4jRestoreReconciler) buildPITRRestoreCommand(ctx context.Context, re
 	isPVC := isPVCBackupPath(backupPath)
 	if isPVC {
 		backupPath = resolveLocalPVCFromPath(backupPath, restore.Spec.DatabaseName)
+	} else if backupPath != "" {
+		// Cloud --from-path URI: quote so spec.source.{bucket,path,backupPath}
+		// can't break out of /bin/sh -c (PVC takes the $(ls …) branch above).
+		backupPath = shellQuote(backupPath)
 	}
 	preludeCmd := ""
 	if isPVC {
@@ -1352,7 +1374,7 @@ func (r *Neo4jRestoreReconciler) buildPITRRestoreCommand(ctx context.Context, re
 	case restore.Spec.Options != nil && restore.Spec.Options.TempStorage != nil:
 		cmd += " --temp-path=/tmp/neo4j-staging"
 	case restore.Spec.Options != nil && restore.Spec.Options.TempPath != "":
-		cmd += " --temp-path=" + restore.Spec.Options.TempPath
+		cmd += " --temp-path=" + shellQuote(restore.Spec.Options.TempPath)
 	case isPVC:
 		cmd += " --temp-path=/tmp/restore-tmp"
 	}

--- a/internal/neo4j/client.go
+++ b/internal/neo4j/client.go
@@ -23,6 +23,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -475,6 +476,52 @@ func (c *Client) formatOptionKey(key string) string {
 	return cleanKey
 }
 
+// buildOptionsClause builds a `OPTIONS { … }` clause in which every value is a
+// driver parameter, returning the clause text (with a leading space, empty if
+// no options) and the params map to pass to session.Run. Keys are interpolated
+// — they come from the operator/validator-controlled set (option keys are
+// enum-validated; seedURI is a literal) — while values are ALWAYS parameters so
+// user-controlled input (seedURI, option values) can never break out of the
+// Cypher. seedURI, when non-empty, is added as the documented `seedURI` option
+// key (replacing the non-grammar `FROM '<uri>'` clause; see issue #169).
+func (c *Client) buildOptionsClause(options map[string]string, seedURI string) (string, map[string]any) {
+	merged := make(map[string]string, len(options)+1)
+	for k, v := range options {
+		merged[c.formatOptionKey(k)] = v
+	}
+	if seedURI != "" {
+		merged["seedURI"] = seedURI
+	}
+	if len(merged) == 0 {
+		return "", nil
+	}
+	keys := make([]string, 0, len(merged))
+	for k := range merged {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys) // deterministic clause order
+	params := make(map[string]any, len(merged))
+	parts := make([]string, 0, len(merged))
+	for _, k := range keys {
+		p := "opt_" + k
+		parts = append(parts, fmt.Sprintf("%s: $%s", k, p))
+		params[p] = merged[k]
+	}
+	return " OPTIONS {" + strings.Join(parts, ", ") + "}", params
+}
+
+// cypherLanguageClause returns the ` DEFAULT LANGUAGE CYPHER <v>` clause only
+// for the two valid language versions, so an unexpected value can never be
+// interpolated into the statement (the validator already constrains it).
+func cypherLanguageClause(cypherVersion string) string {
+	switch cypherVersion {
+	case "5", "25":
+		return " DEFAULT LANGUAGE CYPHER " + cypherVersion
+	default:
+		return ""
+	}
+}
+
 // closeSession safely closes a Neo4j session and logs any errors
 func (c *Client) closeSession(ctx context.Context, session neo4j.SessionWithContext) {
 	if err := session.Close(ctx); err != nil {
@@ -614,16 +661,9 @@ func (c *Client) CreateDatabase(ctx context.Context, databaseName string, option
 		query = fmt.Sprintf("CREATE DATABASE `%s` IF NOT EXISTS", databaseName)
 	}
 
-	// Add options if provided
-	if len(options) > 0 {
-		var optionParts []string
-		for key, value := range options {
-			// Quote dotted keys for proper Neo4j OPTIONS syntax
-			formattedKey := c.formatOptionKey(key)
-			optionParts = append(optionParts, fmt.Sprintf("%s: '%s'", formattedKey, value))
-		}
-		query += " OPTIONS {" + strings.Join(optionParts, ", ") + "}"
-	}
+	// Add options (values are driver parameters — never interpolated)
+	optClause, params := c.buildOptionsClause(options, "")
+	query += optClause
 
 	// Add WAIT or NOWAIT
 	if wait {
@@ -633,7 +673,7 @@ func (c *Client) CreateDatabase(ctx context.Context, databaseName string, option
 	}
 
 	// Use timeout protection for WAIT operations
-	err := c.executeWithWaitTimeout(ctx, session, query, nil, wait, 300)
+	err := c.executeWithWaitTimeout(ctx, session, query, params, wait, 300)
 	if err != nil {
 		// Check if database was created despite connection drop or timeout.
 		// With WAIT, Neo4j holds the Bolt connection open until the database is fully online.
@@ -665,10 +705,8 @@ func (c *Client) CreateDatabaseWithTopology(ctx context.Context, databaseName st
 		query = fmt.Sprintf("CREATE DATABASE `%s` IF NOT EXISTS", databaseName)
 	}
 
-	// Add Cypher language version for Neo4j 2025.x
-	if cypherVersion != "" {
-		query += fmt.Sprintf(" DEFAULT LANGUAGE CYPHER %s", cypherVersion)
-	}
+	// Add Cypher language version for Neo4j 2025.x (only "5"/"25" are emitted)
+	query += cypherLanguageClause(cypherVersion)
 
 	// Add topology if specified
 	if primaries > 0 || secondaries > 0 {
@@ -692,16 +730,9 @@ func (c *Client) CreateDatabaseWithTopology(ctx context.Context, databaseName st
 		}
 	}
 
-	// Add options if provided
-	if len(options) > 0 {
-		var optionParts []string
-		for key, value := range options {
-			// Quote dotted keys for proper Neo4j OPTIONS syntax
-			formattedKey := c.formatOptionKey(key)
-			optionParts = append(optionParts, fmt.Sprintf("%s: '%s'", formattedKey, value))
-		}
-		query += " OPTIONS {" + strings.Join(optionParts, ", ") + "}"
-	}
+	// Add options (values are driver parameters — never interpolated)
+	optClause, params := c.buildOptionsClause(options, "")
+	query += optClause
 
 	// Add WAIT or NOWAIT
 	if wait {
@@ -711,7 +742,7 @@ func (c *Client) CreateDatabaseWithTopology(ctx context.Context, databaseName st
 	}
 
 	// Use timeout protection for WAIT operations
-	err := c.executeWithWaitTimeout(ctx, session, query, nil, wait, 300)
+	err := c.executeWithWaitTimeout(ctx, session, query, params, wait, 300)
 	if err != nil {
 		// Check if database was created despite connection drop or timeout.
 		if wait && (errors.Is(err, context.DeadlineExceeded) || strings.Contains(err.Error(), "EOF") || strings.Contains(err.Error(), "ConnectivityError")) {
@@ -2405,15 +2436,12 @@ func (c *Client) CreateDatabaseFromSeedURI(ctx context.Context, databaseName, se
 		query = fmt.Sprintf("CREATE DATABASE `%s` IF NOT EXISTS", databaseName)
 	}
 
-	// Add Cypher language version for Neo4j 2025.x
-	if cypherVersion != "" {
-		query += fmt.Sprintf(" DEFAULT LANGUAGE CYPHER %s", cypherVersion)
-	}
+	// Add Cypher language version for Neo4j 2025.x (only "5"/"25" are emitted)
+	query += cypherLanguageClause(cypherVersion)
 
-	// Add seed URI
-	query += fmt.Sprintf(" FROM '%s'", seedURI)
-
-	// Add seed configuration options
+	// Legacy SEED CONFIG clause (S3SeedProvider-era; vestigial under
+	// CloudSeedProvider — see issue #169). seedConfig values are validated
+	// upstream so they cannot inject.
 	if seedConfig != nil {
 		seedOptions := c.buildSeedOptions(seedConfig)
 		if len(seedOptions) > 0 {
@@ -2421,14 +2449,11 @@ func (c *Client) CreateDatabaseFromSeedURI(ctx context.Context, databaseName, se
 		}
 	}
 
-	// Add general options if provided
-	if len(options) > 0 {
-		var optionParts []string
-		for key, value := range options {
-			optionParts = append(optionParts, fmt.Sprintf("%s: '%s'", key, value))
-		}
-		query += " OPTIONS {" + strings.Join(optionParts, ", ") + "}"
-	}
+	// Seed URI + general options as one OPTIONS map; seedURI and every option
+	// value is a driver parameter (replaces the non-grammar `FROM '<uri>'`
+	// clause — see issue #169).
+	optClause, params := c.buildOptionsClause(options, seedURI)
+	query += optClause
 
 	// Add WAIT or NOWAIT
 	if wait {
@@ -2437,7 +2462,7 @@ func (c *Client) CreateDatabaseFromSeedURI(ctx context.Context, databaseName, se
 		query += " NOWAIT"
 	}
 
-	_, err := session.Run(ctx, query, nil)
+	_, err := session.Run(ctx, query, params)
 	if err != nil {
 		return fmt.Errorf("failed to create database %s from seed URI: %w", databaseName, err)
 	}
@@ -2460,10 +2485,8 @@ func (c *Client) CreateDatabaseFromSeedURIWithTopology(ctx context.Context, data
 		query = fmt.Sprintf("CREATE DATABASE `%s` IF NOT EXISTS", databaseName)
 	}
 
-	// Add Cypher language version for Neo4j 2025.x
-	if cypherVersion != "" {
-		query += fmt.Sprintf(" DEFAULT LANGUAGE CYPHER %s", cypherVersion)
-	}
+	// Add Cypher language version for Neo4j 2025.x (only "5"/"25" are emitted)
+	query += cypherLanguageClause(cypherVersion)
 
 	// Add topology if specified
 	if primaries > 0 || secondaries > 0 {
@@ -2487,10 +2510,9 @@ func (c *Client) CreateDatabaseFromSeedURIWithTopology(ctx context.Context, data
 		}
 	}
 
-	// Add seed URI
-	query += fmt.Sprintf(" FROM '%s'", seedURI)
-
-	// Add seed configuration options
+	// Legacy SEED CONFIG clause (S3SeedProvider-era; vestigial under
+	// CloudSeedProvider — see issue #169). seedConfig values are validated
+	// upstream so they cannot inject.
 	if seedConfig != nil {
 		seedOptions := c.buildSeedOptions(seedConfig)
 		if len(seedOptions) > 0 {
@@ -2498,14 +2520,11 @@ func (c *Client) CreateDatabaseFromSeedURIWithTopology(ctx context.Context, data
 		}
 	}
 
-	// Add general options if provided
-	if len(options) > 0 {
-		var optionParts []string
-		for key, value := range options {
-			optionParts = append(optionParts, fmt.Sprintf("%s: '%s'", key, value))
-		}
-		query += " OPTIONS {" + strings.Join(optionParts, ", ") + "}"
-	}
+	// Seed URI + general options as one OPTIONS map; seedURI and every option
+	// value is a driver parameter (replaces the non-grammar `FROM '<uri>'`
+	// clause — see issue #169).
+	optClause, params := c.buildOptionsClause(options, seedURI)
+	query += optClause
 
 	// Add WAIT or NOWAIT
 	if wait {
@@ -2514,7 +2533,7 @@ func (c *Client) CreateDatabaseFromSeedURIWithTopology(ctx context.Context, data
 		query += " NOWAIT"
 	}
 
-	_, err := session.Run(ctx, query, nil)
+	_, err := session.Run(ctx, query, params)
 	if err != nil {
 		return fmt.Errorf("failed to create database %s with topology from seed URI: %w", databaseName, err)
 	}

--- a/internal/neo4j/database_options_test.go
+++ b/internal/neo4j/database_options_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package neo4j
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBuildOptionsClause_ParameterisesValues pins the Cypher-injection defense:
+// seedURI and every option VALUE must become a driver parameter, never appear
+// in the clause text. Keys are interpolated (operator/enum-controlled).
+func TestBuildOptionsClause_ParameterisesValues(t *testing.T) {
+	c := &Client{}
+	evil := "s3://b/x' OR '1'='1 //"
+	clause, params := c.buildOptionsClause(map[string]string{"existingData": "use"}, evil)
+
+	if strings.Contains(clause, "s3://") || strings.Contains(clause, "1'='1") {
+		t.Fatalf("seedURI value leaked into clause text: %q", clause)
+	}
+	if !strings.Contains(clause, "seedURI: $opt_seedURI") {
+		t.Fatalf("expected parameterised seedURI, got: %q", clause)
+	}
+	if !strings.Contains(clause, "existingData: $opt_existingData") {
+		t.Fatalf("expected parameterised option, got: %q", clause)
+	}
+	if params["opt_seedURI"] != evil {
+		t.Fatalf("seedURI must be carried verbatim as a param, got: %v", params["opt_seedURI"])
+	}
+	if params["opt_existingData"] != "use" {
+		t.Fatalf("option value missing from params: %v", params)
+	}
+}
+
+// TestBuildOptionsClause_Deterministic ensures the clause order is stable
+// (keys sorted) so the same input doesn't churn.
+func TestBuildOptionsClause_Deterministic(t *testing.T) {
+	c := &Client{}
+	opts := map[string]string{"existingData": "use", "storeFormat": "block"}
+	first, _ := c.buildOptionsClause(opts, "s3://b/x")
+	for i := 0; i < 20; i++ {
+		got, _ := c.buildOptionsClause(opts, "s3://b/x")
+		if got != first {
+			t.Fatalf("clause order not deterministic: %q vs %q", first, got)
+		}
+	}
+}
+
+// TestBuildOptionsClause_Empty returns no clause when there are no options.
+func TestBuildOptionsClause_Empty(t *testing.T) {
+	c := &Client{}
+	if clause, params := c.buildOptionsClause(nil, ""); clause != "" || params != nil {
+		t.Fatalf("expected empty clause/params, got %q / %v", clause, params)
+	}
+}
+
+func TestCypherLanguageClause_OnlyValidVersions(t *testing.T) {
+	if got := cypherLanguageClause("25"); got != " DEFAULT LANGUAGE CYPHER 25" {
+		t.Errorf("25: got %q", got)
+	}
+	if got := cypherLanguageClause("5"); got != " DEFAULT LANGUAGE CYPHER 5" {
+		t.Errorf("5: got %q", got)
+	}
+	for _, bad := range []string{"", "6", "25; DROP DATABASE neo4j", "5 OPTIONS{}"} {
+		if got := cypherLanguageClause(bad); got != "" {
+			t.Errorf("expected empty clause for %q, got %q", bad, got)
+		}
+	}
+}

--- a/internal/neo4j/version.go
+++ b/internal/neo4j/version.go
@@ -189,7 +189,12 @@ func GetBackupCommand(version *Version, databaseName string, backupPath string, 
 	return cmd
 }
 
-// GetRestoreCommand generates the correct restore command based on version
+// GetRestoreCommand generates the correct restore command based on version.
+// The database name is shell-quoted as defense-in-depth (callers also validate
+// it against the Neo4j database-name pattern). backupPath is NOT quoted here: it
+// is sometimes a deliberate `$(ls … | tail -1)` command substitution for PVC
+// sources (rule 44) and sometimes a pre-quoted cloud URI — the caller owns that
+// quoting decision.
 func GetRestoreCommand(version *Version, databaseName string, backupPath string) string {
 	// Base command is the same for both versions
 	cmd := "neo4j-admin database restore"
@@ -198,9 +203,16 @@ func GetRestoreCommand(version *Version, databaseName string, backupPath string)
 	cmd += " --from-path=" + backupPath
 
 	// Add database name
-	cmd += " " + databaseName
+	cmd += " " + shellQuoteArg(databaseName)
 
 	return cmd
+}
+
+// shellQuoteArg wraps s in single quotes for safe use inside `/bin/sh -c`,
+// escaping any embedded single quotes. Mirrors the controller's shellQuote;
+// duplicated here to keep the neo4j package free of a controller import.
+func shellQuoteArg(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
 // SupportsMetadataOption checks if version supports --include-metadata option

--- a/internal/neo4j/version_test.go
+++ b/internal/neo4j/version_test.go
@@ -469,3 +469,20 @@ func containsStr(s, sub string) bool {
 		return false
 	}()
 }
+
+// TestGetRestoreCommand_QuotesDatabaseName pins the shell-injection defense:
+// the database name is the positional arg to neo4j-admin in a /bin/sh -c
+// command, so it must be single-quoted.
+func TestGetRestoreCommand_QuotesDatabaseName(t *testing.T) {
+	v, _ := ParseVersion("5.26.0-enterprise")
+	cmd := GetRestoreCommand(v, "mydb", "/backups/mydb")
+	if !containsStr(cmd, "'mydb'") {
+		t.Errorf("expected single-quoted database name, got: %q", cmd)
+	}
+	// A name with shell metacharacters (which validation rejects upstream)
+	// must still be neutralised by quoting at this sink.
+	evil := GetRestoreCommand(v, "db; rm -rf /data", "/backups/x")
+	if !containsStr(evil, `'db; rm -rf /data'`) {
+		t.Errorf("expected metacharacters contained within quotes, got: %q", evil)
+	}
+}

--- a/internal/resources/cluster.go
+++ b/internal/resources/cluster.go
@@ -1717,7 +1717,7 @@ server.metrics.csv.enabled=false
 
 		// Add configuration in sorted order
 		for _, key := range keys {
-			config += fmt.Sprintf("%s=%s\n", key, cluster.Spec.Config[key])
+			config += fmt.Sprintf("%s=%s\n", key, sanitizeConfValue(cluster.Spec.Config[key]))
 		}
 	}
 
@@ -1882,6 +1882,19 @@ func DedupeNeo4jConf(conf string) string {
 //     never clobbered (matching the plugin path's "add if not present" intent).
 //
 // Keys are processed in sorted order for deterministic output.
+// sanitizeConfValue strips newline and carriage-return characters from a
+// neo4j.conf value. Defense-in-depth: validators reject control characters in
+// user config on admission (ConfigValueHasControlChars), but stripping at the
+// render sink guarantees a single value can never forge an extra config line
+// even if a validation gap is introduced. neo4j.conf values are single-line by
+// definition, so this never alters a legitimate value.
+func sanitizeConfValue(v string) string {
+	if !strings.ContainsAny(v, "\n\r") {
+		return v
+	}
+	return strings.NewReplacer("\n", "", "\r", "").Replace(v)
+}
+
 func UpsertNeo4jConfSettings(conf string, settings map[string]string) string {
 	if len(settings) == 0 {
 		return conf
@@ -1914,7 +1927,7 @@ func UpsertNeo4jConfSettings(conf string, settings map[string]string) string {
 	sort.Strings(keys)
 
 	for _, k := range keys {
-		v := settings[k]
+		v := sanitizeConfValue(settings[k])
 		idx, present := keyIdx[k]
 		switch {
 		case additiveConfKeys[k] && present:

--- a/internal/resources/conf_sanitize_internal_test.go
+++ b/internal/resources/conf_sanitize_internal_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import "testing"
+
+func TestSanitizeConfValue(t *testing.T) {
+	cases := map[string]string{
+		"block":                                 "block",
+		"":                                      "",
+		"OFF\ndbms.security.auth_enabled=false": "OFFdbms.security.auth_enabled=false",
+		"a\r\nb":                                "ab",
+	}
+	for in, want := range cases {
+		if got := sanitizeConfValue(in); got != want {
+			t.Errorf("sanitizeConfValue(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/validation/config_validator.go
+++ b/internal/validation/config_validator.go
@@ -25,6 +25,15 @@ import (
 	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
 )
 
+// ConfigValueHasControlChars reports whether a neo4j.conf value contains a
+// newline or carriage return. Such characters would let a value forge an extra
+// config line when rendered as `key=value\n`, so they are rejected for every
+// user-supplied config map (cluster spec.config, standalone spec.config,
+// Neo4jPlugin spec.config).
+func ConfigValueHasControlChars(value string) bool {
+	return strings.ContainsAny(value, "\n\r")
+}
+
 // ConfigValidator validates Neo4j configuration settings
 type ConfigValidator struct{}
 
@@ -84,6 +93,17 @@ func (v *ConfigValidator) Validate(cluster *neo4jv1beta1.Neo4jEnterpriseCluster)
 	}
 
 	for configKey, configValue := range cluster.Spec.Config {
+		// Reject control characters: config is rendered into neo4j.conf as
+		// `key=value\n`, so a newline in a value would forge an additional
+		// config line (e.g. dbms.security.auth_enabled=false).
+		if ConfigValueHasControlChars(configValue) {
+			allErrs = append(allErrs, field.Invalid(
+				configPath.Child(configKey),
+				configValue,
+				"value may not contain newline or carriage-return characters",
+			))
+		}
+
 		// Special handling for dbms.cluster.discovery.version.
 		// In 5.26.x this setting controls the discovery protocol (V1 vs V2); the operator
 		// requires V2_ONLY. In 2025.x+ the setting does not exist (V2 is the only protocol).

--- a/internal/validation/config_validator_test.go
+++ b/internal/validation/config_validator_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package validation
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -341,5 +342,39 @@ func TestConfigValidator_ValidDiscoveryVersion(t *testing.T) {
 			hasErrors := len(errors) > 0
 			assert.Equal(t, tt.expectErrors, hasErrors, "Error expectation mismatch for version %s: %v", tt.version, errors)
 		})
+	}
+}
+
+func TestConfigValueHasControlChars(t *testing.T) {
+	for _, s := range []string{"OFF\ndbms.security.auth_enabled=false", "x\r\ny", "line\nbreak"} {
+		if !ConfigValueHasControlChars(s) {
+			t.Errorf("expected %q to be flagged", s)
+		}
+	}
+	for _, s := range []string{"block", "true", "gds.*", "1.5", ""} {
+		if ConfigValueHasControlChars(s) {
+			t.Errorf("expected %q to be clean", s)
+		}
+	}
+}
+
+func TestConfigValidator_RejectsNewlineInValue(t *testing.T) {
+	v := NewConfigValidator()
+	cluster := &neo4jv1beta1.Neo4jEnterpriseCluster{
+		Spec: neo4jv1beta1.Neo4jEnterpriseClusterSpec{
+			Config: map[string]string{
+				"db.logs.query.threshold": "0\ndbms.security.auth_enabled=false",
+			},
+		},
+	}
+	errs := v.Validate(cluster)
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e.Error(), "newline or carriage-return") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected newline rejection, got: %v", errs)
 	}
 }

--- a/internal/validation/database_validator.go
+++ b/internal/validation/database_validator.go
@@ -57,6 +57,19 @@ var neo4jDatabaseNamePattern = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9.\-]*$`)
 
 const maxDatabaseNameLength = 65
 
+// MaxDatabaseNameLength is the maximum length of a Neo4j database name, exported
+// for callers (e.g. the restore validator) that enforce the same constraint.
+const MaxDatabaseNameLength = maxDatabaseNameLength
+
+// IsValidDatabaseName reports whether name is a syntactically valid Neo4j
+// database name (starts with a letter; only letters, digits, dots, dashes; at
+// most MaxDatabaseNameLength chars). The character set contains no shell or
+// Cypher metacharacters, so a name that passes is safe to interpolate into
+// either context. Exported for the inline Neo4jRestore validator.
+func IsValidDatabaseName(name string) bool {
+	return name != "" && len(name) <= maxDatabaseNameLength && neo4jDatabaseNamePattern.MatchString(name)
+}
+
 // validateDatabaseName checks that the database name follows Neo4j naming rules.
 func validateDatabaseName(name string, fldPath *field.Path) (field.ErrorList, []string) {
 	var allErrs field.ErrorList

--- a/internal/validation/database_validator.go
+++ b/internal/validation/database_validator.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -60,6 +61,25 @@ const maxDatabaseNameLength = 65
 // MaxDatabaseNameLength is the maximum length of a Neo4j database name, exported
 // for callers (e.g. the restore validator) that enforce the same constraint.
 const MaxDatabaseNameLength = maxDatabaseNameLength
+
+// restoreUntilTxIDPattern matches the transaction-id form of seedConfig
+// restoreUntil ("txId:<positive integer>").
+var restoreUntilTxIDPattern = regexp.MustCompile(`^[0-9]+$`)
+
+// isRFC3339Timestamp reports whether s parses as an RFC3339 timestamp. Used to
+// validate seedConfig restoreUntil, which is string-interpolated into Cypher.
+func isRFC3339Timestamp(s string) bool {
+	_, err := time.Parse(time.RFC3339, s)
+	return err == nil
+}
+
+// cypherLiteralUnsafe reports whether s contains characters that could break out
+// of a single-quoted Cypher string literal (quote, backtick, newline). Used for
+// the legacy seedConfig values still string-interpolated into the SEED CONFIG
+// clause (issue #169); values that reach parameterised positions don't need it.
+func cypherLiteralUnsafe(s string) bool {
+	return strings.ContainsAny(s, "'`\n\r")
+}
 
 // IsValidDatabaseName reports whether name is a syntactically valid Neo4j
 // database name (starts with a letter; only letters, digits, dots, dashes; at
@@ -405,22 +425,27 @@ func (v *DatabaseValidator) validateSeedConfiguration(database *neo4jv1beta1.Neo
 		restoreUntilPath := seedConfigPath.Child("restoreUntil")
 		restoreUntil := seedConfig.RestoreUntil
 
-		// Check for supported formats: RFC3339 timestamp or txId:number
-		if strings.HasPrefix(restoreUntil, "txId:") {
-			// Validate transaction ID format
+		// Check for supported formats: RFC3339 timestamp or txId:number.
+		// restoreUntil is string-interpolated into the legacy SEED CONFIG clause
+		// (txId: form is unquoted), so the format checks double as the injection
+		// guard — only digits or an RFC3339 timestamp are accepted, neither of
+		// which can contain Cypher metacharacters.
+		switch {
+		case strings.HasPrefix(restoreUntil, "txId:"):
 			txId := strings.TrimPrefix(restoreUntil, "txId:")
-			if txId == "" {
+			if !restoreUntilTxIDPattern.MatchString(txId) {
 				result.Errors = append(result.Errors, field.Invalid(
 					restoreUntilPath,
 					restoreUntil,
-					"transaction ID cannot be empty when using txId: format"))
+					"txId: format requires a positive integer (e.g., 'txId:12345')"))
 			}
-			// Assume RFC3339 format and validate basic structure.
-		} else if !strings.Contains(restoreUntil, "T") || !strings.Contains(restoreUntil, ":") {
+		case isRFC3339Timestamp(restoreUntil):
+			// ok
+		default:
 			result.Errors = append(result.Errors, field.Invalid(
 				restoreUntilPath,
 				restoreUntil,
-				"restoreUntil must be RFC3339 timestamp (e.g., '2025-01-15T10:30:00Z') or transaction ID (e.g., 'txId:12345')"))
+				"restoreUntil must be an RFC3339 timestamp (e.g., '2025-01-15T10:30:00Z') or a transaction ID (e.g., 'txId:12345')"))
 		}
 	}
 
@@ -428,6 +453,15 @@ func (v *DatabaseValidator) validateSeedConfiguration(database *neo4jv1beta1.Neo
 	if seedConfig.Config != nil {
 		configPath := seedConfigPath.Child("config")
 		for key, value := range seedConfig.Config {
+			// seedConfig values are string-interpolated into the legacy SEED
+			// CONFIG clause (issue #169), so reject anything that could break
+			// out of the single-quoted Cypher literal.
+			if cypherLiteralUnsafe(value) {
+				result.Errors = append(result.Errors, field.Invalid(
+					configPath.Key(key),
+					value,
+					"value may not contain quote, backtick or newline characters"))
+			}
 			// Validate known configuration keys
 			switch key {
 			case "compression":

--- a/internal/validation/database_validator_test.go
+++ b/internal/validation/database_validator_test.go
@@ -1033,3 +1033,37 @@ func TestValidateDatabaseName(t *testing.T) {
 		})
 	}
 }
+
+// TestIsValidDatabaseName covers the exported helper the Neo4jRestore validator
+// uses to reject shell/Cypher-injecting database names.
+func TestIsValidDatabaseName(t *testing.T) {
+	valid := []string{"neo4j", "mydb", "my.db", "my-db", "Db123"}
+	for _, n := range valid {
+		if !IsValidDatabaseName(n) {
+			t.Errorf("expected %q to be valid", n)
+		}
+	}
+	invalid := []string{
+		"",                 // empty
+		"1db",              // leading digit
+		"db; rm -rf /data", // shell injection
+		"db' OR '1'='1",    // quote
+		"db`whoami`",       // backtick
+		"db\nmore",         // newline
+		"db$(curl evil)",   // command substitution
+		"db with space",
+	}
+	for _, n := range invalid {
+		if IsValidDatabaseName(n) {
+			t.Errorf("expected %q to be rejected", n)
+		}
+	}
+	// Over-length is rejected.
+	long := "a"
+	for i := 0; i < MaxDatabaseNameLength; i++ {
+		long += "a"
+	}
+	if IsValidDatabaseName(long) {
+		t.Errorf("expected over-length name to be rejected")
+	}
+}

--- a/internal/validation/database_validator_test.go
+++ b/internal/validation/database_validator_test.go
@@ -597,7 +597,7 @@ func TestDatabaseValidator_ValidateSeedConfiguration(t *testing.T) {
 			},
 			expectedErrors:     1,
 			expectedWarnings:   2, // System auth warning + point-in-time recovery warning
-			shouldContainError: "restoreUntil must be RFC3339 timestamp",
+			shouldContainError: "restoreUntil must be an RFC3339 timestamp",
 		},
 		{
 			name: "empty transaction ID",
@@ -606,7 +606,7 @@ func TestDatabaseValidator_ValidateSeedConfiguration(t *testing.T) {
 			},
 			expectedErrors:     1,
 			expectedWarnings:   2, // System auth warning + point-in-time recovery warning
-			shouldContainError: "transaction ID cannot be empty when using txId: format",
+			shouldContainError: "txId: format requires a positive integer",
 		},
 		{
 			name: "valid compression config",
@@ -1066,4 +1066,43 @@ func TestIsValidDatabaseName(t *testing.T) {
 	if IsValidDatabaseName(long) {
 		t.Errorf("expected over-length name to be rejected")
 	}
+}
+
+// TestSeedConfigInjectionGuards covers the helpers that protect the legacy
+// string-interpolated SEED CONFIG clause (issue #169) from Cypher injection.
+func TestSeedConfigInjectionGuards(t *testing.T) {
+	t.Run("cypherLiteralUnsafe rejects break-out chars", func(t *testing.T) {
+		for _, s := range []string{"x'", "a`b", "line\nbreak", "carriage\rreturn", "use' } DROP DATABASE neo4j //"} {
+			if !cypherLiteralUnsafe(s) {
+				t.Errorf("expected %q to be flagged unsafe", s)
+			}
+		}
+		for _, s := range []string{"use", "region=eu-west-1", "block", ""} {
+			if cypherLiteralUnsafe(s) {
+				t.Errorf("expected %q to be safe", s)
+			}
+		}
+	})
+
+	t.Run("restoreUntil txId requires positive integer", func(t *testing.T) {
+		if !restoreUntilTxIDPattern.MatchString("12345") {
+			t.Error("expected 12345 to match")
+		}
+		for _, bad := range []string{"", "abc", "12345} DROP", "1.5", "-1"} {
+			if restoreUntilTxIDPattern.MatchString(bad) {
+				t.Errorf("expected %q to be rejected", bad)
+			}
+		}
+	})
+
+	t.Run("isRFC3339Timestamp", func(t *testing.T) {
+		if !isRFC3339Timestamp("2025-01-15T10:30:00Z") {
+			t.Error("expected valid RFC3339 to pass")
+		}
+		for _, bad := range []string{"2025-01-15", "not-a-time", "2025'T:}"} {
+			if isRFC3339Timestamp(bad) {
+				t.Errorf("expected %q to be rejected", bad)
+			}
+		}
+	})
 }

--- a/internal/validation/plugin_validator.go
+++ b/internal/validation/plugin_validator.go
@@ -32,6 +32,11 @@ import (
 // against a malicious upstream demands a collision-resistant hash.
 var checksumPattern = regexp.MustCompile(`^(sha256:[a-fA-F0-9]{64}|sha512:[a-fA-F0-9]{128})$`)
 
+// pluginConfigKeyPattern constrains Neo4jPlugin.spec.config keys: they become
+// neo4j.conf keys / env-var names, so only letters, digits, dots, underscores
+// and dashes are allowed.
+var pluginConfigKeyPattern = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+
 // PluginValidator validates Neo4j plugin configuration for Neo4j 5.26+ compatibility
 type PluginValidator struct{}
 
@@ -101,6 +106,29 @@ func (v *PluginValidator) Validate(plugin *neo4jv1beta1.Neo4jPlugin) *PluginVali
 
 	// Cross-field gates for installMode: VerifiedDownload.
 	result.Errors = append(result.Errors, v.validateVerifiedDownloadMode(plugin)...)
+
+	// Validate plugin config: keys become neo4j.conf keys / env-var names and
+	// values are rendered into neo4j.conf as `key=value` (standalone) or env
+	// vars, so constrain keys to a safe identifier set and reject control
+	// characters in values that could forge an extra config line. This map was
+	// previously unvalidated entirely.
+	configPath := field.NewPath("spec", "config")
+	for key, value := range plugin.Spec.Config {
+		if !pluginConfigKeyPattern.MatchString(key) {
+			result.Errors = append(result.Errors, field.Invalid(
+				configPath.Key(key),
+				key,
+				"config key may contain only letters, digits, dots, underscores and dashes",
+			))
+		}
+		if ConfigValueHasControlChars(value) {
+			result.Errors = append(result.Errors, field.Invalid(
+				configPath.Key(key),
+				value,
+				"value may not contain newline or carriage-return characters",
+			))
+		}
+	}
 
 	return result
 }

--- a/internal/validation/plugin_validator_test.go
+++ b/internal/validation/plugin_validator_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
 )
@@ -647,4 +648,46 @@ func TestPluginValidator_VerifiedDownloadGates(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPluginValidator_ValidatesConfig(t *testing.T) {
+	v := NewPluginValidator()
+	base := func(cfg map[string]string) *neo4jv1beta1.Neo4jPlugin {
+		return &neo4jv1beta1.Neo4jPlugin{
+			Spec: neo4jv1beta1.Neo4jPluginSpec{
+				Name:    "apoc",
+				Version: "5.26.0",
+				Config:  cfg,
+			},
+		}
+	}
+
+	// Newline in a value forges an extra neo4j.conf line.
+	res := v.Validate(base(map[string]string{
+		"dbms.security.procedures.unrestricted": "apoc.*\ndbms.security.auth_enabled=false",
+	}))
+	if !hasErrContaining(res.Errors, "newline or carriage-return") {
+		t.Errorf("expected newline rejection, got: %v", res.Errors)
+	}
+
+	// Malicious key.
+	res = v.Validate(base(map[string]string{"bad key$(x)": "v"}))
+	if !hasErrContaining(res.Errors, "config key may contain only") {
+		t.Errorf("expected key rejection, got: %v", res.Errors)
+	}
+
+	// Clean config passes the config checks.
+	res = v.Validate(base(map[string]string{"dbms.security.procedures.unrestricted": "apoc.*"}))
+	if hasErrContaining(res.Errors, "newline or carriage-return") || hasErrContaining(res.Errors, "config key may contain only") {
+		t.Errorf("clean config should not trip config validation: %v", res.Errors)
+	}
+}
+
+func hasErrContaining(errs field.ErrorList, sub string) bool {
+	for _, e := range errs {
+		if strings.Contains(e.Error(), sub) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/validation/standalone_validator.go
+++ b/internal/validation/standalone_validator.go
@@ -282,13 +282,22 @@ func (v *StandaloneValidator) validateConfig(standalone *neo4jv1beta1.Neo4jEnter
 	// ConfigValidator — server.config.strict_validation.enabled=false
 	// means Neo4j silently honours later duplicates, so without this
 	// rejection a user could silently downgrade TLS posture via spec.config.
-	for key := range standalone.Spec.Config {
+	for key, value := range standalone.Spec.Config {
 		if strings.HasPrefix(key, "dbms.ssl.policy.") ||
 			key == "server.bolt.tls_level" ||
 			key == "server.directories.certificates" {
 			allErrs = append(allErrs, field.Forbidden(
 				configPath.Key(key),
 				"TLS / SSL policy is managed by the operator via spec.tls; do not set dbms.ssl.policy.*, server.bolt.tls_level, or server.directories.certificates in spec.config",
+			))
+		}
+		// Reject control characters: spec.config is rendered into neo4j.conf as
+		// `key=value\n`; a newline in a value would forge an extra config line.
+		if ConfigValueHasControlChars(value) {
+			allErrs = append(allErrs, field.Invalid(
+				configPath.Key(key),
+				value,
+				"value may not contain newline or carriage-return characters",
 			))
 		}
 	}

--- a/test/integration/backup_integration_test.go
+++ b/test/integration/backup_integration_test.go
@@ -488,14 +488,14 @@ var _ = Describe("Backup Integration Tests", Label("extended"), Ordered, func() 
 				"A regression in jobToBackupRun (e.g. dropping `BackupsPath: chainRoot(backup)`) "+
 				"would silently leave this empty.")
 
-		By("Verifying the recorded RunID is the Job's UID (orthogonal contract from #118)")
+		By("Verifying the recorded RunID is the Job's name (#158/#160, rule 40)")
 		// Bonus assertion: while we're already verifying history, also
-		// pin the RunID = job.UID invariant. The two fields together
+		// pin the RunID = job.Name invariant. The two fields together
 		// give a user the full "which Job, where are its files" answer.
 		latest := &neo4jv1beta1.Neo4jBackup{}
 		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(backup), latest)).To(Succeed())
-		Expect(latest.Status.History[0].RunID).To(Equal(string(job.UID)),
-			"RunID must equal job.UID — the per-attempt identifier for retry tracking")
+		Expect(latest.Status.History[0].RunID).To(Equal(job.Name),
+			"RunID must equal the Job's name (not its opaque UID) — see #158/#160 and rule 40")
 		Expect(latest.Status.History[0].Status).To(Equal("Succeeded"),
 			"a Job with Succeeded>0 must produce a history entry with Status=\"Succeeded\"")
 	})
@@ -564,8 +564,9 @@ var _ = Describe("Backup Integration Tests", Label("extended"), Ordered, func() 
 				return false
 			}
 			// Find the run for THIS Job (not any earlier run from other tests).
+			// RunID is the Job's name (#158/#160, rule 40).
 			for _, run := range latest.Status.History {
-				if run.RunID == string(job.UID) {
+				if run.RunID == job.Name {
 					// BackupsPath is the chain root (CR name) under the
 					// shared-directory layout (rule 40), not the Job name.
 					return run.Status == "Failed" && run.BackupsPath == backup.Name


### PR DESCRIPTION
## Summary

Closes three classes of injection reachable from CR fields by anyone with namespace write to a `Neo4jRestore`, `Neo4jDatabase`, or `Neo4jPlugin`. The reconciler runs with far higher privilege (admin Bolt connection, `/data` RW pods holding `NEO4J_ADMIN_PASSWORD`, cloud creds), so each was a privilege-escalation vector. Four self-contained commits.

**1. `fix(restore)` — shell injection in the restore Job (`/bin/sh -c`).**
- `spec.databaseName`: add CRD `Pattern`/`MaxLength` + `validation.IsValidDatabaseName` in `validateRestore`, and shell-quote it at the `GetRestoreCommand` sink.
- Cloud `--from-path` URIs (built from `spec.source.{bucket,path,backupPath}`) are shell-quoted as a unit in both `buildRestoreCommand` and `buildPITRRestoreCommand`; PVC sources keep the unquoted `$(ls … | tail -1)` substitution (rule 44).
- `spec.options.tempPath` and each `spec.options.additionalArgs` element are shell-quoted (mirrors the backup path).

**2. `fix(database)` — Cypher injection in `CREATE DATABASE` (system DB).**
- `seedURI` and every `spec.options` value now flow through `buildOptionsClause` as **driver parameters** (`$opt_<key>`); keys stay interpolated (enum-validated). seedURI is emitted as the documented `OPTIONS { seedURI: $uri }` form, replacing the non-grammar `FROM '<uri>'` clause.
- `DEFAULT LANGUAGE CYPHER` only ever emits the validated `5`/`25` tokens.
- The legacy `SEED CONFIG` clause (S3SeedProvider-era, vestigial under CloudSeedProvider) is left in place but its values are now injection-guarded: `validateSeedConfiguration` rejects quote/backtick/newline in seedConfig values and constrains `restoreUntil` to a positive-integer `txId` or RFC3339 timestamp.

**3. `fix(config)` — neo4j.conf newline injection.**
- A newline in a config value forged an extra `key=value` line (e.g. `dbms.security.auth_enabled=false`). Reject `\n`/`\r` in values across `ConfigValidator` (cluster), `StandaloneValidator` (standalone), and **`PluginValidator`** (`Neo4jPlugin.spec.config` — previously unvalidated; now also enforces a key charset). Defense-in-depth `sanitizeConfValue` strips control chars at the render sinks.

**4. `test`** — assertion updates for the restore from-path quoting and the clarified `restoreUntil` message.

## Docs basis

The seed-syntax decisions follow the Neo4j 5.x + CalVer docs (clustering/databases, database-administration/syntax, seed-from-uri): `CREATE DATABASE` has no `FROM`/`SEED CONFIG` clause — seeding is entirely in `OPTIONS { seedURI, existingData, seedConfig, seedCredentials, … }`, and `seedConfig`/`seedCredentials` are S3SeedProvider requirements the operator no longer needs under CloudSeedProvider.

## Out of scope (tracked separately)

- **#169** — migrate the seed CREATE syntax fully to the documented `OPTIONS{}` form (remove the non-grammar `SEED CONFIG`), verified against a live cluster.
- **#170** — sweep backup/restore/seed paths (LTS + CalVer) to drop all S3SeedProvider remnants and align on CloudSeedProvider.

This PR is the **security** (injection) slice; #169/#170 are the **correctness/cleanup** follow-ups.

## Type of change

- [x] Bug fix (security)

## Testing

- [x] `make test-unit` equivalents pass locally: full controller envtest suite (75 specs) + `internal/{neo4j,validation,resources,metrics,monitoring}`.
- [x] `make lint` (golangci-lint + staticcheck) green on every commit; `check-drift` green (CRD `databaseName` Pattern regenerated into config/crd, helm and bundle).
- New unit tests: `IsValidDatabaseName` + `GetRestoreCommand` quoting; `buildOptionsClause`/`cypherLanguageClause` parameterization; seedConfig injection guards; `ConfigValueHasControlChars`, plugin-config validation, `sanitizeConfValue`.
- [x] Add the `run-integration-tests` / `run-extended` labels — touches the restore/database/plugin runtime paths.

## Checklist

- [x] Conventional Commit titles
- [x] Ran `make manifests` + helm/bundle sync for the new CRD marker (`check-drift` passes)
- [x] Respects `CLAUDE.md` invariants (no webhooks; controller-side validation; CloudSeedProvider/rule 59; routing scheme)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Security-sensitive changes to restore Job command construction, system-database Cypher, and config admission; incorrect quoting or parameterization could break restores/seeding or leave residual injection paths.
> 
> **Overview**
> Hardens **Neo4jRestore**, **Neo4jDatabase**, and **config/plugin** CR paths against injection from namespace writers, where the reconciler runs with admin Bolt, restore Jobs (`/bin/sh -c`), and neo4j.conf rendering.
> 
> **Restore:** `spec.databaseName` gets CRD **pattern/maxLength**, controller `IsValidDatabaseName`, and shell-quoting in `GetRestoreCommand`. Cloud `--from-path` URIs, `tempPath`, and `additionalArgs` are shell-quoted; PVC restore keeps unquoted `$(ls …)` substitution.
> 
> **Database Cypher:** `seedURI` and option values use **`buildOptionsClause`** with driver parameters instead of string literals; `FROM '<uri>'` is replaced by `OPTIONS { seedURI: $… }`. `DEFAULT LANGUAGE CYPHER` only emits `5`/`25`. Legacy **SEED CONFIG** values get stricter `restoreUntil` and `cypherLiteralUnsafe` checks.
> 
> **neo4j.conf:** Newlines in cluster/standalone/plugin `spec.config` are rejected at validation; **`sanitizeConfValue`** strips `\n`/`\r` when rendering. **Neo4jPlugin** config keys are now validated.
> 
> Tests and integration expectations are updated (restore quoting, `restoreUntil` messages, backup `RunID` = Job name).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e57933b3973d4a4c69fff97ccb4cc7ffda716e2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->