### PR TITLE
fix(seed): documented OPTIONS seed form + CloudSeedProvider alignment (closes #169, #170)

### DIFF
--- a/api/v1beta1/neo4jdatabase_types.go
+++ b/api/v1beta1/neo4jdatabase_types.go
@@ -156,17 +156,16 @@ type SeedConfiguration struct {
 	// Only available with Neo4j 2025.x and CloudSeedProvider.
 	RestoreUntil string `json:"restoreUntil,omitempty"`
 
-	// Additional seed provider configuration options
+	// Seed-provider configuration, rendered into the documented `seedConfig`
+	// OPTIONS string as comma-separated key=value pairs (e.g. region=eu-west-1).
 	//
-	// Common configuration options:
-	// - "compression": "gzip" | "lz4" | "none"
-	// - "validation": "strict" | "lenient"
-	// - "bufferSize": Buffer size for seed operations
+	// This is consumed by the S3SeedProvider; CloudSeedProvider (the operator's
+	// default for s3://, gs:// and azb://) resolves credentials and region from
+	// the environment / SDK default chain instead (see spec.extraEnvFrom), so
+	// most deployments leave this empty.
 	//
-	// Cloud-specific options:
-	// - S3: "region", "endpoint", "pathStyleAccess"
-	// - GCS: "project", "location"
-	// - Azure: "endpoint", "containerName"
+	// Keys and values must be simple (no ',', '=', quote, backtick or newline).
+	// Common S3SeedProvider key: "region".
 	Config map[string]string `json:"config,omitempty"`
 }
 

--- a/bundle/manifests/neo4j.neo4j.com_neo4jdatabases.yaml
+++ b/bundle/manifests/neo4j.neo4j.com_neo4jdatabases.yaml
@@ -204,17 +204,16 @@ spec:
                     additionalProperties:
                       type: string
                     description: |-
-                      Additional seed provider configuration options
+                      Seed-provider configuration, rendered into the documented `seedConfig`
+                      OPTIONS string as comma-separated key=value pairs (e.g. region=eu-west-1).
 
-                      Common configuration options:
-                      - "compression": "gzip" | "lz4" | "none"
-                      - "validation": "strict" | "lenient"
-                      - "bufferSize": Buffer size for seed operations
+                      This is consumed by the S3SeedProvider; CloudSeedProvider (the operator's
+                      default for s3://, gs:// and azb://) resolves credentials and region from
+                      the environment / SDK default chain instead (see spec.extraEnvFrom), so
+                      most deployments leave this empty.
 
-                      Cloud-specific options:
-                      - S3: "region", "endpoint", "pathStyleAccess"
-                      - GCS: "project", "location"
-                      - Azure: "endpoint", "containerName"
+                      Keys and values must be simple (no ',', '=', quote, backtick or newline).
+                      Common S3SeedProvider key: "region".
                     type: object
                   restoreUntil:
                     description: |-

--- a/bundle/manifests/neo4j.neo4j.com_neo4jshardeddatabases.yaml
+++ b/bundle/manifests/neo4j.neo4j.com_neo4jshardeddatabases.yaml
@@ -206,17 +206,16 @@ spec:
                     additionalProperties:
                       type: string
                     description: |-
-                      Additional seed provider configuration options
+                      Seed-provider configuration, rendered into the documented `seedConfig`
+                      OPTIONS string as comma-separated key=value pairs (e.g. region=eu-west-1).
 
-                      Common configuration options:
-                      - "compression": "gzip" | "lz4" | "none"
-                      - "validation": "strict" | "lenient"
-                      - "bufferSize": Buffer size for seed operations
+                      This is consumed by the S3SeedProvider; CloudSeedProvider (the operator's
+                      default for s3://, gs:// and azb://) resolves credentials and region from
+                      the environment / SDK default chain instead (see spec.extraEnvFrom), so
+                      most deployments leave this empty.
 
-                      Cloud-specific options:
-                      - S3: "region", "endpoint", "pathStyleAccess"
-                      - GCS: "project", "location"
-                      - Azure: "endpoint", "containerName"
+                      Keys and values must be simple (no ',', '=', quote, backtick or newline).
+                      Common S3SeedProvider key: "region".
                     type: object
                   restoreUntil:
                     description: |-

--- a/charts/neo4j-operator/crds/neo4j.neo4j.com_neo4jdatabases.yaml
+++ b/charts/neo4j-operator/crds/neo4j.neo4j.com_neo4jdatabases.yaml
@@ -204,17 +204,16 @@ spec:
                     additionalProperties:
                       type: string
                     description: |-
-                      Additional seed provider configuration options
+                      Seed-provider configuration, rendered into the documented `seedConfig`
+                      OPTIONS string as comma-separated key=value pairs (e.g. region=eu-west-1).
 
-                      Common configuration options:
-                      - "compression": "gzip" | "lz4" | "none"
-                      - "validation": "strict" | "lenient"
-                      - "bufferSize": Buffer size for seed operations
+                      This is consumed by the S3SeedProvider; CloudSeedProvider (the operator's
+                      default for s3://, gs:// and azb://) resolves credentials and region from
+                      the environment / SDK default chain instead (see spec.extraEnvFrom), so
+                      most deployments leave this empty.
 
-                      Cloud-specific options:
-                      - S3: "region", "endpoint", "pathStyleAccess"
-                      - GCS: "project", "location"
-                      - Azure: "endpoint", "containerName"
+                      Keys and values must be simple (no ',', '=', quote, backtick or newline).
+                      Common S3SeedProvider key: "region".
                     type: object
                   restoreUntil:
                     description: |-

--- a/charts/neo4j-operator/crds/neo4j.neo4j.com_neo4jshardeddatabases.yaml
+++ b/charts/neo4j-operator/crds/neo4j.neo4j.com_neo4jshardeddatabases.yaml
@@ -206,17 +206,16 @@ spec:
                     additionalProperties:
                       type: string
                     description: |-
-                      Additional seed provider configuration options
+                      Seed-provider configuration, rendered into the documented `seedConfig`
+                      OPTIONS string as comma-separated key=value pairs (e.g. region=eu-west-1).
 
-                      Common configuration options:
-                      - "compression": "gzip" | "lz4" | "none"
-                      - "validation": "strict" | "lenient"
-                      - "bufferSize": Buffer size for seed operations
+                      This is consumed by the S3SeedProvider; CloudSeedProvider (the operator's
+                      default for s3://, gs:// and azb://) resolves credentials and region from
+                      the environment / SDK default chain instead (see spec.extraEnvFrom), so
+                      most deployments leave this empty.
 
-                      Cloud-specific options:
-                      - S3: "region", "endpoint", "pathStyleAccess"
-                      - GCS: "project", "location"
-                      - Azure: "endpoint", "containerName"
+                      Keys and values must be simple (no ',', '=', quote, backtick or newline).
+                      Common S3SeedProvider key: "region".
                     type: object
                   restoreUntil:
                     description: |-

--- a/config/crd/bases/neo4j.neo4j.com_neo4jdatabases.yaml
+++ b/config/crd/bases/neo4j.neo4j.com_neo4jdatabases.yaml
@@ -204,17 +204,16 @@ spec:
                     additionalProperties:
                       type: string
                     description: |-
-                      Additional seed provider configuration options
+                      Seed-provider configuration, rendered into the documented `seedConfig`
+                      OPTIONS string as comma-separated key=value pairs (e.g. region=eu-west-1).
 
-                      Common configuration options:
-                      - "compression": "gzip" | "lz4" | "none"
-                      - "validation": "strict" | "lenient"
-                      - "bufferSize": Buffer size for seed operations
+                      This is consumed by the S3SeedProvider; CloudSeedProvider (the operator's
+                      default for s3://, gs:// and azb://) resolves credentials and region from
+                      the environment / SDK default chain instead (see spec.extraEnvFrom), so
+                      most deployments leave this empty.
 
-                      Cloud-specific options:
-                      - S3: "region", "endpoint", "pathStyleAccess"
-                      - GCS: "project", "location"
-                      - Azure: "endpoint", "containerName"
+                      Keys and values must be simple (no ',', '=', quote, backtick or newline).
+                      Common S3SeedProvider key: "region".
                     type: object
                   restoreUntil:
                     description: |-

--- a/config/crd/bases/neo4j.neo4j.com_neo4jshardeddatabases.yaml
+++ b/config/crd/bases/neo4j.neo4j.com_neo4jshardeddatabases.yaml
@@ -206,17 +206,16 @@ spec:
                     additionalProperties:
                       type: string
                     description: |-
-                      Additional seed provider configuration options
+                      Seed-provider configuration, rendered into the documented `seedConfig`
+                      OPTIONS string as comma-separated key=value pairs (e.g. region=eu-west-1).
 
-                      Common configuration options:
-                      - "compression": "gzip" | "lz4" | "none"
-                      - "validation": "strict" | "lenient"
-                      - "bufferSize": Buffer size for seed operations
+                      This is consumed by the S3SeedProvider; CloudSeedProvider (the operator's
+                      default for s3://, gs:// and azb://) resolves credentials and region from
+                      the environment / SDK default chain instead (see spec.extraEnvFrom), so
+                      most deployments leave this empty.
 
-                      Cloud-specific options:
-                      - S3: "region", "endpoint", "pathStyleAccess"
-                      - GCS: "project", "location"
-                      - Azure: "endpoint", "containerName"
+                      Keys and values must be simple (no ',', '=', quote, backtick or newline).
+                      Common S3SeedProvider key: "region".
                     type: object
                   restoreUntil:
                     description: |-

--- a/internal/controller/neo4jdatabase_controller_test.go
+++ b/internal/controller/neo4jdatabase_controller_test.go
@@ -297,11 +297,8 @@ var _ = Describe("Neo4jDatabase Controller", func() {
 					Name:       "invalidconfigdb",
 					SeedURI:    "s3://my-backups/database.backup",
 					SeedConfig: &neo4jv1beta1.SeedConfiguration{
-						RestoreUntil: "invalid-timestamp",
-						Config: map[string]string{
-							"compression": "invalid-compression",
-							"validation":  "invalid-validation",
-						},
+						RestoreUntil: "invalid-timestamp",                // bad format
+						Config:       map[string]string{"region": "a,b"}, // comma breaks the seedConfig string
 					},
 				},
 			}
@@ -311,34 +308,24 @@ var _ = Describe("Neo4jDatabase Controller", func() {
 			validator := validation.NewDatabaseValidator(k8sClient)
 			result := validator.Validate(ctx, database)
 
-			// Should have multiple validation errors for invalid configuration
-			Expect(len(result.Errors)).To(BeNumerically(">=", 3)) // restoreUntil + compression + validation
-
-			// Check specific error messages
 			errorMessages := make([]string, len(result.Errors))
 			for i, err := range result.Errors {
 				errorMessages[i] = err.Error()
 			}
 
 			foundRestoreUntilError := false
-			foundCompressionError := false
-			foundValidationError := false
-
+			foundSeedConfigValueError := false
 			for _, msg := range errorMessages {
 				if Contains(msg, "restoreUntil must be an RFC3339 timestamp") {
 					foundRestoreUntilError = true
 				}
-				if Contains(msg, "compression") && Contains(msg, "supported values") {
-					foundCompressionError = true
-				}
-				if Contains(msg, "validation") && Contains(msg, "supported values") {
-					foundValidationError = true
+				if Contains(msg, "may not contain") {
+					foundSeedConfigValueError = true
 				}
 			}
 
-			Expect(foundRestoreUntilError).To(BeTrue())
-			Expect(foundCompressionError).To(BeTrue())
-			Expect(foundValidationError).To(BeTrue())
+			Expect(foundRestoreUntilError).To(BeTrue(), "errors: %v", errorMessages)
+			Expect(foundSeedConfigValueError).To(BeTrue(), "errors: %v", errorMessages)
 
 			// Cleanup
 			Expect(k8sClient.Delete(ctx, database)).To(Succeed())

--- a/internal/controller/neo4jshardeddatabase_controller.go
+++ b/internal/controller/neo4jshardeddatabase_controller.go
@@ -615,6 +615,9 @@ func buildShardedDatabaseOptions(shardedDB *neo4jv1beta1.Neo4jShardedDatabase) (
 	if shardedDB.Spec.SeedConfig != nil {
 		if restoreUntil := shardedDB.Spec.SeedConfig.RestoreUntil; restoreUntil != "" {
 			if txid, ok := strings.CutPrefix(restoreUntil, "txId:"); ok {
+				// The sharded validator (isValidRestoreUntilTxID) rejects a txId
+				// that doesn't fit int64, so ParseInt succeeds for any spec that
+				// reached here; the err==nil guard never silently drops it.
 				if n, err := strconv.ParseInt(txid, 10, 64); err == nil {
 					options = append(options, "seedRestoreUntil: $seed_restore_until")
 					params["seed_restore_until"] = n

--- a/internal/controller/neo4jshardeddatabase_controller.go
+++ b/internal/controller/neo4jshardeddatabase_controller.go
@@ -53,6 +53,7 @@ import (
 	stderrors "errors"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -519,8 +520,9 @@ func (r *Neo4jShardedDatabaseReconciler) createShardedDatabase(ctx context.Conte
 	}
 	query.WriteString(" }")
 
-	// Add supported options for sharded databases
-	options, err := buildShardedDatabaseOptions(shardedDB)
+	// Add supported options for sharded databases. Values are bound as driver
+	// parameters (params) so seed URIs / config can't inject Cypher (#170).
+	options, params, err := buildShardedDatabaseOptions(shardedDB)
 	if err != nil {
 		return err
 	}
@@ -541,8 +543,9 @@ func (r *Neo4jShardedDatabaseReconciler) createShardedDatabase(ctx context.Conte
 	// Execute the command with retry logic
 	maxRetries := 5
 	for attempt := 0; attempt < maxRetries; attempt++ {
-		// Execute against system database for DDL commands
-		err := (*client).ExecuteCypher(ctx, "system", queryStr)
+		// Execute against system database for DDL commands (params bind the
+		// user-supplied seed values — see buildShardedDatabaseOptions).
+		err := (*client).ExecuteCypherWithParams(ctx, "system", queryStr, params)
 		if err == nil {
 			logger.Info("Successfully created sharded database")
 			return nil
@@ -568,15 +571,25 @@ func (r *Neo4jShardedDatabaseReconciler) createShardedDatabase(ctx context.Conte
 	return fmt.Errorf("failed to create sharded database after %d attempts", maxRetries)
 }
 
-func buildShardedDatabaseOptions(shardedDB *neo4jv1beta1.Neo4jShardedDatabase) (string, error) {
+// buildShardedDatabaseOptions builds the inner OPTIONS entries for a sharded
+// CREATE DATABASE plus the driver parameters they reference. Every user-supplied
+// value (seedURI, per-shard seedURIs, seedSourceDatabase, seedConfig,
+// seedRestoreUntil, txLogEnrichment) is bound as a parameter so it cannot inject
+// Cypher (issue #170). Only the per-shard seedURI map KEYS are interpolated —
+// backtick-escaped, and constrained by the validator. seedConfig is the
+// documented comma-separated string and seedRestoreUntil follows the documented
+// integer/`datetime()` forms, matching the standard seed path.
+func buildShardedDatabaseOptions(shardedDB *neo4jv1beta1.Neo4jShardedDatabase) (string, map[string]any, error) {
 	var options []string
+	params := map[string]any{}
 
 	if shardedDB.Spec.SeedURI != "" && len(shardedDB.Spec.SeedURIs) > 0 {
-		return "", fmt.Errorf("seedURI and seedURIs cannot be specified together")
+		return "", nil, fmt.Errorf("seedURI and seedURIs cannot be specified together")
 	}
 
 	if shardedDB.Spec.SeedURI != "" {
-		options = append(options, fmt.Sprintf("seedURI: '%s'", shardedDB.Spec.SeedURI))
+		options = append(options, "seedURI: $seed_uri")
+		params["seed_uri"] = shardedDB.Spec.SeedURI
 	}
 
 	if len(shardedDB.Spec.SeedURIs) > 0 {
@@ -585,46 +598,45 @@ func buildShardedDatabaseOptions(shardedDB *neo4jv1beta1.Neo4jShardedDatabase) (
 			keys = append(keys, key)
 		}
 		sort.Strings(keys)
-		var entries []string
-		for _, key := range keys {
-			entries = append(entries, fmt.Sprintf("`%s`: '%s'", key, shardedDB.Spec.SeedURIs[key]))
+		entries := make([]string, 0, len(keys))
+		for i, key := range keys {
+			p := fmt.Sprintf("seed_uri_%d", i)
+			entries = append(entries, fmt.Sprintf("`%s`: $%s", neo4j.EscapeBackticks(key), p))
+			params[p] = shardedDB.Spec.SeedURIs[key]
 		}
 		options = append(options, "seedURI: { "+strings.Join(entries, ", ")+" }")
 	}
 
 	if shardedDB.Spec.SeedSourceDatabase != "" {
-		options = append(options, fmt.Sprintf("seedSourceDatabase: '%s'", shardedDB.Spec.SeedSourceDatabase))
+		options = append(options, "seedSourceDatabase: $seed_source_database")
+		params["seed_source_database"] = shardedDB.Spec.SeedSourceDatabase
 	}
 
 	if shardedDB.Spec.SeedConfig != nil {
-		if shardedDB.Spec.SeedConfig.RestoreUntil != "" {
-			restoreUntil := shardedDB.Spec.SeedConfig.RestoreUntil
-			if strings.HasPrefix(restoreUntil, "txId:") {
-				options = append(options, fmt.Sprintf("seedRestoreUntil: %s", restoreUntil))
+		if restoreUntil := shardedDB.Spec.SeedConfig.RestoreUntil; restoreUntil != "" {
+			if txid, ok := strings.CutPrefix(restoreUntil, "txId:"); ok {
+				if n, err := strconv.ParseInt(txid, 10, 64); err == nil {
+					options = append(options, "seedRestoreUntil: $seed_restore_until")
+					params["seed_restore_until"] = n
+				}
 			} else {
-				options = append(options, fmt.Sprintf("seedRestoreUntil: '%s'", restoreUntil))
+				options = append(options, "seedRestoreUntil: datetime($seed_restore_until)")
+				params["seed_restore_until"] = restoreUntil
 			}
 		}
 
-		if len(shardedDB.Spec.SeedConfig.Config) > 0 {
-			keys := make([]string, 0, len(shardedDB.Spec.SeedConfig.Config))
-			for key := range shardedDB.Spec.SeedConfig.Config {
-				keys = append(keys, key)
-			}
-			sort.Strings(keys)
-			var entries []string
-			for _, key := range keys {
-				entries = append(entries, fmt.Sprintf("%s: '%s'", key, shardedDB.Spec.SeedConfig.Config[key]))
-			}
-			options = append(options, "seedConfig: { "+strings.Join(entries, ", ")+" }")
+		if cfg := neo4j.SerializeSeedConfig(shardedDB.Spec.SeedConfig.Config); cfg != "" {
+			options = append(options, "seedConfig: $seed_config")
+			params["seed_config"] = cfg
 		}
 	}
 
 	if shardedDB.Spec.TxLogEnrichment != "" {
-		options = append(options, fmt.Sprintf("txLogEnrichment: '%s'", shardedDB.Spec.TxLogEnrichment))
+		options = append(options, "txLogEnrichment: $tx_log_enrichment")
+		params["tx_log_enrichment"] = shardedDB.Spec.TxLogEnrichment
 	}
 
-	return strings.Join(options, ", "), nil
+	return strings.Join(options, ", "), params, nil
 }
 
 // isTransientError checks if an error is transient and can be retried

--- a/internal/controller/sharded_options_internal_test.go
+++ b/internal/controller/sharded_options_internal_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
+)
+
+// TestBuildShardedDatabaseOptions_Parameterised pins issue #170: every
+// user-supplied seed value is bound as a driver parameter (no raw
+// interpolation), seedConfig is the documented comma-separated string, and
+// seedRestoreUntil uses the integer/datetime() forms — never a `SEED CONFIG`
+// clause or quoted literals.
+func TestBuildShardedDatabaseOptions_Parameterised(t *testing.T) {
+	sdb := &neo4jv1beta1.Neo4jShardedDatabase{
+		Spec: neo4jv1beta1.Neo4jShardedDatabaseSpec{
+			SeedURI:            "s3://b/x' OR '1'='1 //",
+			SeedSourceDatabase: "src' //",
+			SeedConfig: &neo4jv1beta1.SeedConfiguration{
+				RestoreUntil: "txId:99",
+				Config:       map[string]string{"region": "eu-west-1"},
+			},
+			TxLogEnrichment: "FULL",
+		},
+	}
+	clause, params, err := buildShardedDatabaseOptions(sdb)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// No raw value may appear in the clause text.
+	for _, leak := range []string{"s3://", "1'='1", "src'", "eu-west-1"} {
+		if strings.Contains(clause, leak) {
+			t.Fatalf("value leaked into clause %q (found %q)", clause, leak)
+		}
+	}
+	for _, want := range []string{
+		"seedURI: $seed_uri",
+		"seedSourceDatabase: $seed_source_database",
+		"seedConfig: $seed_config",
+		"seedRestoreUntil: $seed_restore_until",
+		"txLogEnrichment: $tx_log_enrichment",
+	} {
+		if !strings.Contains(clause, want) {
+			t.Fatalf("expected %q in clause %q", want, clause)
+		}
+	}
+	if params["seed_uri"] != "s3://b/x' OR '1'='1 //" {
+		t.Errorf("seed_uri param = %v", params["seed_uri"])
+	}
+	if params["seed_config"] != "region=eu-west-1" {
+		t.Errorf("seed_config param = %v", params["seed_config"])
+	}
+	if params["seed_restore_until"] != int64(99) {
+		t.Errorf("seed_restore_until param = %T %v", params["seed_restore_until"], params["seed_restore_until"])
+	}
+}
+
+func TestBuildShardedDatabaseOptions_PerShardSeedURIs(t *testing.T) {
+	sdb := &neo4jv1beta1.Neo4jShardedDatabase{
+		Spec: neo4jv1beta1.Neo4jShardedDatabaseSpec{
+			SeedURIs: map[string]string{"g000": "s3://b/g.backup", "p000": "s3://b/p.backup"},
+		},
+	}
+	clause, params, err := buildShardedDatabaseOptions(sdb)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Keys are interpolated (backticked); values are parameters.
+	if !strings.Contains(clause, "`g000`: $seed_uri_0") || !strings.Contains(clause, "`p000`: $seed_uri_1") {
+		t.Fatalf("expected per-shard backticked keys with param values, got %q", clause)
+	}
+	if strings.Contains(clause, "s3://") {
+		t.Fatalf("per-shard URI leaked into clause %q", clause)
+	}
+	if params["seed_uri_0"] != "s3://b/g.backup" || params["seed_uri_1"] != "s3://b/p.backup" {
+		t.Fatalf("per-shard URI params wrong: %v", params)
+	}
+}
+
+func TestBuildShardedDatabaseOptions_SeedURIMutex(t *testing.T) {
+	sdb := &neo4jv1beta1.Neo4jShardedDatabase{
+		Spec: neo4jv1beta1.Neo4jShardedDatabaseSpec{
+			SeedURI:  "s3://b/x",
+			SeedURIs: map[string]string{"g000": "s3://b/g"},
+		},
+	}
+	if _, _, err := buildShardedDatabaseOptions(sdb); err == nil {
+		t.Fatal("expected error when both seedURI and seedURIs are set")
+	}
+}

--- a/internal/neo4j/client.go
+++ b/internal/neo4j/client.go
@@ -484,30 +484,76 @@ func (c *Client) formatOptionKey(key string) string {
 // user-controlled input (seedURI, option values) can never break out of the
 // Cypher. seedURI, when non-empty, is added as the documented `seedURI` option
 // key (replacing the non-grammar `FROM '<uri>'` clause; see issue #169).
-func (c *Client) buildOptionsClause(options map[string]string, seedURI string) (string, map[string]any) {
-	merged := make(map[string]string, len(options)+1)
+func (c *Client) buildOptionsClause(options map[string]string, seedURI string, seedConfig *neo4jv1beta1.SeedConfiguration) (string, map[string]any) {
+	merged := make(map[string]string, len(options)+2)
 	for k, v := range options {
 		merged[c.formatOptionKey(k)] = v
 	}
 	if seedURI != "" {
 		merged["seedURI"] = seedURI
 	}
-	if len(merged) == 0 {
-		return "", nil
+	// seedConfig: the documented comma-separated provider-config string
+	// (e.g. "region=eu-west-1"). Carried as a driver parameter.
+	if seedConfig != nil {
+		if cfg := serializeSeedConfig(seedConfig.Config); cfg != "" {
+			merged["seedConfig"] = cfg
+		}
 	}
+
 	keys := make([]string, 0, len(merged))
 	for k := range merged {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys) // deterministic clause order
-	params := make(map[string]any, len(merged))
-	parts := make([]string, 0, len(merged))
+	params := make(map[string]any, len(merged)+1)
+	parts := make([]string, 0, len(merged)+1)
 	for _, k := range keys {
 		p := "opt_" + k
 		parts = append(parts, fmt.Sprintf("%s: $%s", k, p))
 		params[p] = merged[k]
 	}
+
+	// seedRestoreUntil (point-in-time) is expressed per the docs: an integer
+	// transaction id as `$p`, an RFC3339 timestamp as `datetime($p)`. CalVer-only
+	// — the validator rejects restoreUntil on 5.26. The value is a parameter
+	// either way, so it can't inject. Appended after the sorted entries.
+	if seedConfig != nil && seedConfig.RestoreUntil != "" {
+		if txid, ok := strings.CutPrefix(seedConfig.RestoreUntil, "txId:"); ok {
+			if n, err := strconv.ParseInt(txid, 10, 64); err == nil {
+				parts = append(parts, "seedRestoreUntil: $opt_seedRestoreUntil")
+				params["opt_seedRestoreUntil"] = n
+			}
+		} else {
+			parts = append(parts, "seedRestoreUntil: datetime($opt_seedRestoreUntil)")
+			params["opt_seedRestoreUntil"] = seedConfig.RestoreUntil
+		}
+	}
+
+	if len(parts) == 0 {
+		return "", nil
+	}
 	return " OPTIONS {" + strings.Join(parts, ", ") + "}", params
+}
+
+// serializeSeedConfig renders a seed-provider config map as the documented
+// comma-separated `key=value` string (e.g. "region=eu-west-1") used by the
+// seedConfig OPTIONS key. Keys are sorted for determinism. The result is passed
+// to Cypher as a driver parameter; the validator constrains keys/values so the
+// comma-separated form is unambiguous and injection-safe.
+func serializeSeedConfig(cfg map[string]string) string {
+	if len(cfg) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(cfg))
+	for k := range cfg {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(cfg))
+	for _, k := range keys {
+		parts = append(parts, k+"="+cfg[k])
+	}
+	return strings.Join(parts, ",")
 }
 
 // cypherLanguageClause returns the ` DEFAULT LANGUAGE CYPHER <v>` clause only
@@ -662,7 +708,7 @@ func (c *Client) CreateDatabase(ctx context.Context, databaseName string, option
 	}
 
 	// Add options (values are driver parameters — never interpolated)
-	optClause, params := c.buildOptionsClause(options, "")
+	optClause, params := c.buildOptionsClause(options, "", nil)
 	query += optClause
 
 	// Add WAIT or NOWAIT
@@ -731,7 +777,7 @@ func (c *Client) CreateDatabaseWithTopology(ctx context.Context, databaseName st
 	}
 
 	// Add options (values are driver parameters — never interpolated)
-	optClause, params := c.buildOptionsClause(options, "")
+	optClause, params := c.buildOptionsClause(options, "", nil)
 	query += optClause
 
 	// Add WAIT or NOWAIT
@@ -2439,20 +2485,11 @@ func (c *Client) CreateDatabaseFromSeedURI(ctx context.Context, databaseName, se
 	// Add Cypher language version for Neo4j 2025.x (only "5"/"25" are emitted)
 	query += cypherLanguageClause(cypherVersion)
 
-	// Legacy SEED CONFIG clause (S3SeedProvider-era; vestigial under
-	// CloudSeedProvider — see issue #169). seedConfig values are validated
-	// upstream so they cannot inject.
-	if seedConfig != nil {
-		seedOptions := c.buildSeedOptions(seedConfig)
-		if len(seedOptions) > 0 {
-			query += fmt.Sprintf(" SEED CONFIG %s", seedOptions)
-		}
-	}
-
-	// Seed URI + general options as one OPTIONS map; seedURI and every option
-	// value is a driver parameter (replaces the non-grammar `FROM '<uri>'`
-	// clause — see issue #169).
-	optClause, params := c.buildOptionsClause(options, seedURI)
+	// seedURI, seedConfig (provider-config string), seedRestoreUntil
+	// (point-in-time) and any general options are emitted as one documented
+	// OPTIONS map; every value is a driver parameter. This replaces the
+	// non-grammar `FROM '<uri>'` and `SEED CONFIG {…}` clauses (issue #169).
+	optClause, params := c.buildOptionsClause(options, seedURI, seedConfig)
 	query += optClause
 
 	// Add WAIT or NOWAIT
@@ -2510,20 +2547,11 @@ func (c *Client) CreateDatabaseFromSeedURIWithTopology(ctx context.Context, data
 		}
 	}
 
-	// Legacy SEED CONFIG clause (S3SeedProvider-era; vestigial under
-	// CloudSeedProvider — see issue #169). seedConfig values are validated
-	// upstream so they cannot inject.
-	if seedConfig != nil {
-		seedOptions := c.buildSeedOptions(seedConfig)
-		if len(seedOptions) > 0 {
-			query += fmt.Sprintf(" SEED CONFIG %s", seedOptions)
-		}
-	}
-
-	// Seed URI + general options as one OPTIONS map; seedURI and every option
-	// value is a driver parameter (replaces the non-grammar `FROM '<uri>'`
-	// clause — see issue #169).
-	optClause, params := c.buildOptionsClause(options, seedURI)
+	// seedURI, seedConfig (provider-config string), seedRestoreUntil
+	// (point-in-time) and any general options are emitted as one documented
+	// OPTIONS map; every value is a driver parameter. This replaces the
+	// non-grammar `FROM '<uri>'` and `SEED CONFIG {…}` clauses (issue #169).
+	optClause, params := c.buildOptionsClause(options, seedURI, seedConfig)
 	query += optClause
 
 	// Add WAIT or NOWAIT
@@ -2539,35 +2567,6 @@ func (c *Client) CreateDatabaseFromSeedURIWithTopology(ctx context.Context, data
 	}
 
 	return nil
-}
-
-// buildSeedOptions builds the seed configuration options string
-func (c *Client) buildSeedOptions(seedConfig *neo4jv1beta1.SeedConfiguration) string {
-	var parts []string
-
-	// Add restoreUntil if specified
-	if seedConfig.RestoreUntil != "" {
-		if strings.HasPrefix(seedConfig.RestoreUntil, "txId:") {
-			// Transaction ID format
-			parts = append(parts, fmt.Sprintf("restoreUntil: %s", seedConfig.RestoreUntil))
-		} else {
-			// RFC3339 timestamp format - quote it
-			parts = append(parts, fmt.Sprintf("restoreUntil: '%s'", seedConfig.RestoreUntil))
-		}
-	}
-
-	// Add custom configuration options
-	if seedConfig.Config != nil {
-		for key, value := range seedConfig.Config {
-			parts = append(parts, fmt.Sprintf("%s: '%s'", key, value))
-		}
-	}
-
-	if len(parts) > 0 {
-		return "{" + strings.Join(parts, ", ") + "}"
-	}
-
-	return ""
 }
 
 // PrepareCloudCredentials prepares cloud credentials for seed URI access

--- a/internal/neo4j/client.go
+++ b/internal/neo4j/client.go
@@ -495,7 +495,7 @@ func (c *Client) buildOptionsClause(options map[string]string, seedURI string, s
 	// seedConfig: the documented comma-separated provider-config string
 	// (e.g. "region=eu-west-1"). Carried as a driver parameter.
 	if seedConfig != nil {
-		if cfg := serializeSeedConfig(seedConfig.Config); cfg != "" {
+		if cfg := SerializeSeedConfig(seedConfig.Config); cfg != "" {
 			merged["seedConfig"] = cfg
 		}
 	}
@@ -535,12 +535,12 @@ func (c *Client) buildOptionsClause(options map[string]string, seedURI string, s
 	return " OPTIONS {" + strings.Join(parts, ", ") + "}", params
 }
 
-// serializeSeedConfig renders a seed-provider config map as the documented
+// SerializeSeedConfig renders a seed-provider config map as the documented
 // comma-separated `key=value` string (e.g. "region=eu-west-1") used by the
 // seedConfig OPTIONS key. Keys are sorted for determinism. The result is passed
 // to Cypher as a driver parameter; the validator constrains keys/values so the
 // comma-separated form is unambiguous and injection-safe.
-func serializeSeedConfig(cfg map[string]string) string {
+func SerializeSeedConfig(cfg map[string]string) string {
 	if len(cfg) == 0 {
 		return ""
 	}
@@ -2037,13 +2037,20 @@ func (c *Client) DatabaseExists(ctx context.Context, databaseName string) (bool,
 
 // ExecuteCypher executes a cypher statement on a specific database
 func (c *Client) ExecuteCypher(ctx context.Context, databaseName, statement string) error {
+	return c.ExecuteCypherWithParams(ctx, databaseName, statement, nil)
+}
+
+// ExecuteCypherWithParams executes a write statement with driver parameters, so
+// user-controlled values (e.g. the seed URIs / config in the sharded CREATE
+// DATABASE) are bound rather than interpolated and cannot inject Cypher.
+func (c *Client) ExecuteCypherWithParams(ctx context.Context, databaseName, statement string, params map[string]any) error {
 	session := c.driver.NewSession(ctx, neo4j.SessionConfig{
 		AccessMode:   neo4j.AccessModeWrite,
 		DatabaseName: databaseName,
 	})
 	defer session.Close(ctx)
 
-	_, err := session.Run(ctx, statement, nil)
+	_, err := session.Run(ctx, statement, params)
 	if err != nil {
 		return fmt.Errorf("failed to execute cypher: %w", err)
 	}

--- a/internal/neo4j/client.go
+++ b/internal/neo4j/client.go
@@ -519,6 +519,9 @@ func (c *Client) buildOptionsClause(options map[string]string, seedURI string, s
 	// either way, so it can't inject. Appended after the sorted entries.
 	if seedConfig != nil && seedConfig.RestoreUntil != "" {
 		if txid, ok := strings.CutPrefix(seedConfig.RestoreUntil, "txId:"); ok {
+			// The validator (isValidRestoreUntilTxID) rejects a txId that
+			// doesn't fit int64, so ParseInt succeeds for any spec that reached
+			// here; the err==nil guard never silently drops validated input.
 			if n, err := strconv.ParseInt(txid, 10, 64); err == nil {
 				parts = append(parts, "seedRestoreUntil: $opt_seedRestoreUntil")
 				params["opt_seedRestoreUntil"] = n

--- a/internal/neo4j/database_options_test.go
+++ b/internal/neo4j/database_options_test.go
@@ -130,10 +130,10 @@ func TestBuildOptionsClause_SeedConfigAndRestoreUntil(t *testing.T) {
 }
 
 func TestSerializeSeedConfig(t *testing.T) {
-	if got := serializeSeedConfig(nil); got != "" {
+	if got := SerializeSeedConfig(nil); got != "" {
 		t.Errorf("nil → %q", got)
 	}
-	if got := serializeSeedConfig(map[string]string{"b": "2", "a": "1"}); got != "a=1,b=2" {
+	if got := SerializeSeedConfig(map[string]string{"b": "2", "a": "1"}); got != "a=1,b=2" {
 		t.Errorf("sorted serialisation = %q, want a=1,b=2", got)
 	}
 }

--- a/internal/neo4j/database_options_test.go
+++ b/internal/neo4j/database_options_test.go
@@ -19,6 +19,8 @@ package neo4j
 import (
 	"strings"
 	"testing"
+
+	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
 )
 
 // TestBuildOptionsClause_ParameterisesValues pins the Cypher-injection defense:
@@ -27,7 +29,7 @@ import (
 func TestBuildOptionsClause_ParameterisesValues(t *testing.T) {
 	c := &Client{}
 	evil := "s3://b/x' OR '1'='1 //"
-	clause, params := c.buildOptionsClause(map[string]string{"existingData": "use"}, evil)
+	clause, params := c.buildOptionsClause(map[string]string{"existingData": "use"}, evil, nil)
 
 	if strings.Contains(clause, "s3://") || strings.Contains(clause, "1'='1") {
 		t.Fatalf("seedURI value leaked into clause text: %q", clause)
@@ -51,9 +53,9 @@ func TestBuildOptionsClause_ParameterisesValues(t *testing.T) {
 func TestBuildOptionsClause_Deterministic(t *testing.T) {
 	c := &Client{}
 	opts := map[string]string{"existingData": "use", "storeFormat": "block"}
-	first, _ := c.buildOptionsClause(opts, "s3://b/x")
+	first, _ := c.buildOptionsClause(opts, "s3://b/x", nil)
 	for i := 0; i < 20; i++ {
-		got, _ := c.buildOptionsClause(opts, "s3://b/x")
+		got, _ := c.buildOptionsClause(opts, "s3://b/x", nil)
 		if got != first {
 			t.Fatalf("clause order not deterministic: %q vs %q", first, got)
 		}
@@ -63,7 +65,7 @@ func TestBuildOptionsClause_Deterministic(t *testing.T) {
 // TestBuildOptionsClause_Empty returns no clause when there are no options.
 func TestBuildOptionsClause_Empty(t *testing.T) {
 	c := &Client{}
-	if clause, params := c.buildOptionsClause(nil, ""); clause != "" || params != nil {
+	if clause, params := c.buildOptionsClause(nil, "", nil); clause != "" || params != nil {
 		t.Fatalf("expected empty clause/params, got %q / %v", clause, params)
 	}
 }
@@ -79,5 +81,59 @@ func TestCypherLanguageClause_OnlyValidVersions(t *testing.T) {
 		if got := cypherLanguageClause(bad); got != "" {
 			t.Errorf("expected empty clause for %q, got %q", bad, got)
 		}
+	}
+}
+
+// TestBuildOptionsClause_SeedConfigAndRestoreUntil pins the documented seed
+// OPTIONS form (issue #169): seedConfig is a comma-separated key=value STRING
+// passed as a parameter, and seedRestoreUntil is an integer txId ($p) or an
+// RFC3339 timestamp wrapped in datetime($p) — never a `SEED CONFIG {…}` clause.
+func TestBuildOptionsClause_SeedConfigAndRestoreUntil(t *testing.T) {
+	c := &Client{}
+
+	t.Run("seedConfig serialised as comma-separated string param", func(t *testing.T) {
+		sc := &neo4jv1beta1.SeedConfiguration{Config: map[string]string{"region": "eu-west-1", "endpoint": "x"}}
+		clause, params := c.buildOptionsClause(nil, "s3://b/x", sc)
+		if !strings.Contains(clause, "seedConfig: $opt_seedConfig") {
+			t.Fatalf("expected parameterised seedConfig, got: %q", clause)
+		}
+		if strings.Contains(clause, "SEED CONFIG") {
+			t.Fatalf("must not emit the non-grammar SEED CONFIG clause: %q", clause)
+		}
+		// sorted, comma-separated key=value
+		if params["opt_seedConfig"] != "endpoint=x,region=eu-west-1" {
+			t.Fatalf("seedConfig serialisation = %v", params["opt_seedConfig"])
+		}
+	})
+
+	t.Run("restoreUntil txId is an integer param", func(t *testing.T) {
+		sc := &neo4jv1beta1.SeedConfiguration{RestoreUntil: "txId:12345"}
+		clause, params := c.buildOptionsClause(nil, "s3://b/x", sc)
+		if !strings.Contains(clause, "seedRestoreUntil: $opt_seedRestoreUntil") {
+			t.Fatalf("expected integer seedRestoreUntil param, got: %q", clause)
+		}
+		if params["opt_seedRestoreUntil"] != int64(12345) {
+			t.Fatalf("expected int64 12345, got %T %v", params["opt_seedRestoreUntil"], params["opt_seedRestoreUntil"])
+		}
+	})
+
+	t.Run("restoreUntil RFC3339 wrapped in datetime()", func(t *testing.T) {
+		sc := &neo4jv1beta1.SeedConfiguration{RestoreUntil: "2025-01-15T10:30:00Z"}
+		clause, params := c.buildOptionsClause(nil, "s3://b/x", sc)
+		if !strings.Contains(clause, "seedRestoreUntil: datetime($opt_seedRestoreUntil)") {
+			t.Fatalf("expected datetime()-wrapped seedRestoreUntil, got: %q", clause)
+		}
+		if params["opt_seedRestoreUntil"] != "2025-01-15T10:30:00Z" {
+			t.Fatalf("expected RFC3339 string param, got %v", params["opt_seedRestoreUntil"])
+		}
+	})
+}
+
+func TestSerializeSeedConfig(t *testing.T) {
+	if got := serializeSeedConfig(nil); got != "" {
+		t.Errorf("nil → %q", got)
+	}
+	if got := serializeSeedConfig(map[string]string{"b": "2", "a": "1"}); got != "a=1,b=2" {
+		t.Errorf("sorted serialisation = %q, want a=1,b=2", got)
 	}
 }

--- a/internal/neo4j/users.go
+++ b/internal/neo4j/users.go
@@ -626,6 +626,13 @@ func escapeBackticks(s string) string {
 	return strings.ReplaceAll(s, "`", "``")
 }
 
+// EscapeBackticks is the exported form of escapeBackticks, for callers in other
+// packages that build backtick-quoted Cypher identifiers (e.g. per-shard
+// seedURI map keys in the sharded-database controller).
+func EscapeBackticks(s string) string {
+	return escapeBackticks(s)
+}
+
 // stringValue safely extracts a string column from a record.
 func stringValue(rec *neo4j.Record, key string) string {
 	v, ok := rec.Get(key)

--- a/internal/validation/database_validator.go
+++ b/internal/validation/database_validator.go
@@ -30,6 +30,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/neo4j-partners/neo4j-kubernetes-operator/internal/neo4j"
+
 	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
 )
 
@@ -65,6 +67,11 @@ const MaxDatabaseNameLength = maxDatabaseNameLength
 // restoreUntilTxIDPattern matches the transaction-id form of seedConfig
 // restoreUntil ("txId:<positive integer>").
 var restoreUntilTxIDPattern = regexp.MustCompile(`^[0-9]+$`)
+
+// seedConfigKeyPattern constrains seedConfig.Config keys: they are serialised
+// into the comma/`=`-delimited seedConfig OPTIONS string (e.g. "region=..."),
+// so they must be simple identifiers.
+var seedConfigKeyPattern = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
 
 // isRFC3339Timestamp reports whether s parses as an RFC3339 timestamp. Used to
 // validate seedConfig restoreUntil, which is string-interpolated into Cypher.
@@ -181,8 +188,15 @@ func (v *DatabaseValidator) Validate(ctx context.Context, database *neo4jv1beta1
 	// Validate Cypher language version
 	v.validateCypherLanguage(database, result)
 
+	// Resolve the target image tag (cluster or standalone) so seed-config
+	// version gating (seedRestoreUntil is CalVer-only) can be enforced.
+	imageTag := cluster.Spec.Image.Tag
+	if standalone != nil {
+		imageTag = standalone.Spec.Image.Tag
+	}
+
 	// Validate seed URI configuration
-	v.validateSeedURI(ctx, database, result)
+	v.validateSeedURI(ctx, database, imageTag, result)
 
 	// Validate database options syntax
 	v.validateDatabaseOptions(database, result)
@@ -356,7 +370,7 @@ func (v *DatabaseValidator) validateCypherLanguage(database *neo4jv1beta1.Neo4jD
 	}
 }
 
-func (v *DatabaseValidator) validateSeedURI(ctx context.Context, database *neo4jv1beta1.Neo4jDatabase, result *DatabaseValidationResult) {
+func (v *DatabaseValidator) validateSeedURI(ctx context.Context, database *neo4jv1beta1.Neo4jDatabase, imageTag string, result *DatabaseValidationResult) {
 	seedURIPath := field.NewPath("spec", "seedURI")
 
 	// If no seed URI is specified, skip validation
@@ -404,7 +418,7 @@ func (v *DatabaseValidator) validateSeedURI(ctx context.Context, database *neo4j
 
 	// Validate seed configuration if provided
 	if database.Spec.SeedConfig != nil {
-		v.validateSeedConfiguration(database, result)
+		v.validateSeedConfiguration(database, imageTag, result)
 	}
 
 	// Validate seed credentials if provided
@@ -416,20 +430,18 @@ func (v *DatabaseValidator) validateSeedURI(ctx context.Context, database *neo4j
 	v.addSeedURIWarnings(database, result)
 }
 
-func (v *DatabaseValidator) validateSeedConfiguration(database *neo4jv1beta1.Neo4jDatabase, result *DatabaseValidationResult) {
+func (v *DatabaseValidator) validateSeedConfiguration(database *neo4jv1beta1.Neo4jDatabase, imageTag string, result *DatabaseValidationResult) {
 	seedConfigPath := field.NewPath("spec", "seedConfig")
 	seedConfig := database.Spec.SeedConfig
 
-	// Validate RestoreUntil format if specified
+	// Validate RestoreUntil (point-in-time) if specified. It maps to the
+	// documented seedRestoreUntil OPTIONS key, which is CalVer-only
+	// (CloudSeedProvider/FileSeedProvider) — 5.x has no point-in-time seed.
 	if seedConfig.RestoreUntil != "" {
 		restoreUntilPath := seedConfigPath.Child("restoreUntil")
 		restoreUntil := seedConfig.RestoreUntil
 
-		// Check for supported formats: RFC3339 timestamp or txId:number.
-		// restoreUntil is string-interpolated into the legacy SEED CONFIG clause
-		// (txId: form is unquoted), so the format checks double as the injection
-		// guard — only digits or an RFC3339 timestamp are accepted, neither of
-		// which can contain Cypher metacharacters.
+		// Format: a positive-integer txId, or an RFC3339 timestamp.
 		switch {
 		case strings.HasPrefix(restoreUntil, "txId:"):
 			txId := strings.TrimPrefix(restoreUntil, "txId:")
@@ -447,49 +459,35 @@ func (v *DatabaseValidator) validateSeedConfiguration(database *neo4jv1beta1.Neo
 				restoreUntil,
 				"restoreUntil must be an RFC3339 timestamp (e.g., '2025-01-15T10:30:00Z') or a transaction ID (e.g., 'txId:12345')"))
 		}
+
+		// Version gate: seedRestoreUntil is unavailable on 5.x LTS.
+		if parsed, err := neo4j.ParseVersion(imageTag); err == nil && !parsed.IsCalver {
+			result.Errors = append(result.Errors, field.Forbidden(
+				restoreUntilPath,
+				fmt.Sprintf("point-in-time seed (restoreUntil) requires Neo4j 2025.x+ (CalVer); target image %q is a 5.x LTS line", imageTag)))
+		}
 	}
 
-	// Validate configuration options
+	// Validate seedConfig.Config — the documented provider-config map serialised
+	// into the seedConfig OPTIONS string ("key=value,key2=value2", e.g.
+	// region=eu-west-1 for the S3SeedProvider). The serialisation is
+	// comma/`=`-delimited, so keys and values must not contain `,` or `=`, and
+	// (since the value is rendered into Cypher, albeit via a parameter) must not
+	// contain quote/backtick/newline.
 	if seedConfig.Config != nil {
 		configPath := seedConfigPath.Child("config")
 		for key, value := range seedConfig.Config {
-			// seedConfig values are string-interpolated into the legacy SEED
-			// CONFIG clause (issue #169), so reject anything that could break
-			// out of the single-quoted Cypher literal.
-			if cypherLiteralUnsafe(value) {
+			if !seedConfigKeyPattern.MatchString(key) {
+				result.Errors = append(result.Errors, field.Invalid(
+					configPath.Key(key),
+					key,
+					"seedConfig key may contain only letters, digits, dots, underscores and dashes"))
+			}
+			if strings.ContainsAny(value, ",=") || cypherLiteralUnsafe(value) {
 				result.Errors = append(result.Errors, field.Invalid(
 					configPath.Key(key),
 					value,
-					"value may not contain quote, backtick or newline characters"))
-			}
-			// Validate known configuration keys
-			switch key {
-			case "compression":
-				if !containsSlice([]string{"gzip", "lz4", "none"}, value) {
-					result.Errors = append(result.Errors, field.NotSupported(
-						configPath.Key(key),
-						value,
-						[]string{"gzip", "lz4", "none"}))
-				}
-			case "validation":
-				if !containsSlice([]string{"strict", "lenient"}, value) {
-					result.Errors = append(result.Errors, field.NotSupported(
-						configPath.Key(key),
-						value,
-						[]string{"strict", "lenient"}))
-				}
-			case "bufferSize":
-				if value == "" {
-					result.Errors = append(result.Errors, field.Invalid(
-						configPath.Key(key),
-						value,
-						"bufferSize cannot be empty"))
-				}
-			default:
-				// Allow unknown keys with warning
-				result.Warnings = append(result.Warnings,
-					fmt.Sprintf("Unknown seed configuration option '%s'. "+
-						"Refer to Neo4j CloudSeedProvider documentation for supported options.", key))
+					"seedConfig value may not contain ',', '=', quote, backtick or newline characters"))
 			}
 		}
 	}

--- a/internal/validation/database_validator.go
+++ b/internal/validation/database_validator.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -67,6 +68,20 @@ const MaxDatabaseNameLength = maxDatabaseNameLength
 // restoreUntilTxIDPattern matches the transaction-id form of seedConfig
 // restoreUntil ("txId:<positive integer>").
 var restoreUntilTxIDPattern = regexp.MustCompile(`^[0-9]+$`)
+
+// isValidRestoreUntilTxID reports whether s is an acceptable seedRestoreUntil
+// transaction id: digits only AND within int64. Neo4j transaction ids are
+// int64, and the OPTIONS builders pass the value via strconv.ParseInt(_, 10,
+// 64) — a digit-only value that overflows int64 makes ParseInt fail and the
+// builder SILENTLY drops the seedRestoreUntil option, so CREATE DATABASE seeds
+// past the requested point with no error. Reject overflow here at the gate.
+func isValidRestoreUntilTxID(s string) bool {
+	if !restoreUntilTxIDPattern.MatchString(s) {
+		return false
+	}
+	_, err := strconv.ParseInt(s, 10, 64)
+	return err == nil
+}
 
 // seedConfigKeyPattern constrains seedConfig.Config keys: they are serialised
 // into the comma/`=`-delimited seedConfig OPTIONS string (e.g. "region=..."),
@@ -445,11 +460,11 @@ func (v *DatabaseValidator) validateSeedConfiguration(database *neo4jv1beta1.Neo
 		switch {
 		case strings.HasPrefix(restoreUntil, "txId:"):
 			txId := strings.TrimPrefix(restoreUntil, "txId:")
-			if !restoreUntilTxIDPattern.MatchString(txId) {
+			if !isValidRestoreUntilTxID(txId) {
 				result.Errors = append(result.Errors, field.Invalid(
 					restoreUntilPath,
 					restoreUntil,
-					"txId: format requires a positive integer (e.g., 'txId:12345')"))
+					"txId: format requires a positive integer within int64 range (e.g., 'txId:12345')"))
 			}
 		case isRFC3339Timestamp(restoreUntil):
 			// ok

--- a/internal/validation/database_validator_test.go
+++ b/internal/validation/database_validator_test.go
@@ -609,37 +609,37 @@ func TestDatabaseValidator_ValidateSeedConfiguration(t *testing.T) {
 			shouldContainError: "txId: format requires a positive integer",
 		},
 		{
-			name: "valid compression config",
+			name: "arbitrary provider config keys accepted",
 			seedConfig: &neo4jv1beta1.SeedConfiguration{
 				Config: map[string]string{
-					"compression": "gzip",
-					"validation":  "strict",
+					"region":   "eu-west-1",
+					"endpoint": "s3.example.com",
 				},
 			},
 			expectedErrors:   0,
 			expectedWarnings: 1, // System auth warning
 		},
 		{
-			name: "invalid compression value",
+			name: "seedConfig value with comma rejected",
 			seedConfig: &neo4jv1beta1.SeedConfiguration{
 				Config: map[string]string{
-					"compression": "invalid-compression",
+					"region": "a,b",
 				},
 			},
 			expectedErrors:     1,
 			expectedWarnings:   1,
-			shouldContainError: "supported values:",
+			shouldContainError: "may not contain",
 		},
 		{
-			name: "unknown config option",
+			name: "seedConfig key with space rejected",
 			seedConfig: &neo4jv1beta1.SeedConfiguration{
 				Config: map[string]string{
-					"unknownOption": "someValue",
+					"bad key": "v",
 				},
 			},
-			expectedErrors:       0,
-			expectedWarnings:     2, // System auth + unknown option warnings
-			shouldContainWarning: "Unknown seed configuration option 'unknownOption'",
+			expectedErrors:     1,
+			expectedWarnings:   1,
+			shouldContainError: "seedConfig key may contain only",
 		},
 	}
 
@@ -1105,4 +1105,57 @@ func TestSeedConfigInjectionGuards(t *testing.T) {
 			}
 		}
 	})
+}
+
+// TestSeedConfig_RestoreUntilVersionGate pins that point-in-time seed
+// (restoreUntil → seedRestoreUntil) is rejected on the 5.x LTS line and
+// accepted on CalVer, since seedRestoreUntil is CalVer-only (issue #169).
+func TestSeedConfig_RestoreUntilVersionGate(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = neo4jv1beta1.AddToScheme(scheme)
+
+	mkCluster := func(name, tag string) *neo4jv1beta1.Neo4jEnterpriseCluster {
+		return &neo4jv1beta1.Neo4jEnterpriseCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Spec: neo4jv1beta1.Neo4jEnterpriseClusterSpec{
+				Image:    neo4jv1beta1.ImageSpec{Repo: "neo4j", Tag: tag},
+				Topology: neo4jv1beta1.TopologyConfiguration{Servers: 3},
+			},
+		}
+	}
+	lts := mkCluster("lts", "5.26.0-enterprise")
+	calver := mkCluster("calver", "2025.04.0-enterprise")
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(lts, calver).Build()
+	validator := NewDatabaseValidator(client)
+	ctx := context.Background()
+
+	mkDB := func(clusterRef string) *neo4jv1beta1.Neo4jDatabase {
+		return &neo4jv1beta1.Neo4jDatabase{
+			ObjectMeta: metav1.ObjectMeta{Name: "db", Namespace: "default"},
+			Spec: neo4jv1beta1.Neo4jDatabaseSpec{
+				ClusterRef: clusterRef,
+				Name:       "seededdb",
+				SeedURI:    "s3://bucket/backup.backup",
+				SeedConfig: &neo4jv1beta1.SeedConfiguration{RestoreUntil: "txId:12345"},
+			},
+		}
+	}
+
+	hasErr := func(errs field.ErrorList, sub string) bool {
+		for _, e := range errs {
+			if strings.Contains(e.Error(), sub) {
+				return true
+			}
+		}
+		return false
+	}
+
+	ltsRes := validator.Validate(ctx, mkDB("lts"))
+	if !hasErr(ltsRes.Errors, "requires Neo4j 2025.x+") {
+		t.Errorf("restoreUntil must be rejected on 5.x LTS, errors: %v", ltsRes.Errors)
+	}
+	calverRes := validator.Validate(ctx, mkDB("calver"))
+	if hasErr(calverRes.Errors, "requires Neo4j 2025.x+") {
+		t.Errorf("restoreUntil must be accepted on CalVer, errors: %v", calverRes.Errors)
+	}
 }

--- a/internal/validation/database_validator_test.go
+++ b/internal/validation/database_validator_test.go
@@ -609,6 +609,18 @@ func TestDatabaseValidator_ValidateSeedConfiguration(t *testing.T) {
 			shouldContainError: "txId: format requires a positive integer",
 		},
 		{
+			// Digit-only but overflows int64: previously passed the regex,
+			// then ParseInt failed in the OPTIONS builder and the
+			// seedRestoreUntil option was silently dropped (PITR bound lost).
+			name: "transaction ID overflowing int64 is rejected",
+			seedConfig: &neo4jv1beta1.SeedConfiguration{
+				RestoreUntil: "txId:99999999999999999999999999",
+			},
+			expectedErrors:     1,
+			expectedWarnings:   2, // System auth warning + point-in-time recovery warning
+			shouldContainError: "within int64 range",
+		},
+		{
 			name: "arbitrary provider config keys accepted",
 			seedConfig: &neo4jv1beta1.SeedConfiguration{
 				Config: map[string]string{

--- a/internal/validation/shardeddatabase_validator.go
+++ b/internal/validation/shardeddatabase_validator.go
@@ -231,10 +231,10 @@ func (v *ShardedDatabaseValidator) validatePropertyShardingConfig(shardedDB *neo
 		if ru := shardedDB.Spec.SeedConfig.RestoreUntil; ru != "" {
 			switch {
 			case strings.HasPrefix(ru, "txId:"):
-				if !restoreUntilTxIDPattern.MatchString(strings.TrimPrefix(ru, "txId:")) {
+				if !isValidRestoreUntilTxID(strings.TrimPrefix(ru, "txId:")) {
 					result.Errors = append(result.Errors, field.Invalid(
 						scPath.Child("restoreUntil"), ru,
-						"txId: format requires a positive integer (e.g., 'txId:12345')"))
+						"txId: format requires a positive integer within int64 range (e.g., 'txId:12345')"))
 				}
 			case isRFC3339Timestamp(ru):
 			default:

--- a/internal/validation/shardeddatabase_validator.go
+++ b/internal/validation/shardeddatabase_validator.go
@@ -211,6 +211,52 @@ func (v *ShardedDatabaseValidator) validatePropertyShardingConfig(shardedDB *neo
 			"seedCredentials requires seedURI, seedURIs, or seedBackupRef"))
 	}
 
+	// Per-shard seedURIs keys are interpolated (backtick-escaped) into the
+	// CREATE DATABASE OPTIONS; constrain them to a simple identifier set.
+	for key := range shardedDB.Spec.SeedURIs {
+		if !seedConfigKeyPattern.MatchString(key) {
+			result.Errors = append(result.Errors, field.Invalid(
+				specPath.Child("seedURIs").Key(key),
+				key,
+				"seedURIs key may contain only letters, digits, dots, underscores and dashes"))
+		}
+	}
+
+	// seedConfig is serialised into the documented comma-separated seedConfig
+	// OPTIONS string; restoreUntil maps to seedRestoreUntil. Constrain keys and
+	// values so the serialisation is unambiguous and injection-safe (the same
+	// rules as the standard Neo4jDatabase seed path).
+	if shardedDB.Spec.SeedConfig != nil {
+		scPath := specPath.Child("seedConfig")
+		if ru := shardedDB.Spec.SeedConfig.RestoreUntil; ru != "" {
+			switch {
+			case strings.HasPrefix(ru, "txId:"):
+				if !restoreUntilTxIDPattern.MatchString(strings.TrimPrefix(ru, "txId:")) {
+					result.Errors = append(result.Errors, field.Invalid(
+						scPath.Child("restoreUntil"), ru,
+						"txId: format requires a positive integer (e.g., 'txId:12345')"))
+				}
+			case isRFC3339Timestamp(ru):
+			default:
+				result.Errors = append(result.Errors, field.Invalid(
+					scPath.Child("restoreUntil"), ru,
+					"restoreUntil must be an RFC3339 timestamp or a transaction ID (e.g., 'txId:12345')"))
+			}
+		}
+		for key, value := range shardedDB.Spec.SeedConfig.Config {
+			if !seedConfigKeyPattern.MatchString(key) {
+				result.Errors = append(result.Errors, field.Invalid(
+					scPath.Child("config").Key(key), key,
+					"seedConfig key may contain only letters, digits, dots, underscores and dashes"))
+			}
+			if strings.ContainsAny(value, ",=") || cypherLiteralUnsafe(value) {
+				result.Errors = append(result.Errors, field.Invalid(
+					scPath.Child("config").Key(key), value,
+					"seedConfig value may not contain ',', '=', quote, backtick or newline characters"))
+			}
+		}
+	}
+
 	// replaceExisting is the destructive drop-and-recreate path. Two safety
 	// gates:
 	//   1. Must be paired with force=true so an accidental flip can't


### PR DESCRIPTION
## Summary

Closes #169 and #170. Migrates the Neo4j seed-from-URI Cypher to the **documented `OPTIONS {…}` form** and aligns every seed path on **CloudSeedProvider**, dropping the S3SeedProvider-era constructs. Stacked on #171 (base will retarget to `main` once #171 merges).

**Standard `Neo4jDatabase` seed path (#169)** — `internal/neo4j/client.go`, validator:
- Removed the non-grammar `FROM '<uri>'` (already done in #171) and the non-grammar `SEED CONFIG {…}` clause; deleted `buildSeedOptions`.
- `seedConfig` → the documented `OPTIONS { seedConfig: $p }` **string** (comma-separated `key=value`, e.g. `region=eu-west-1`), serialised deterministically and bound as a parameter.
- `restoreUntil` → the documented `seedRestoreUntil` key (integer txId as `$p`, RFC3339 as `datetime($p)`), **CalVer-gated** — the validator now rejects `restoreUntil` on a 5.x LTS target.
- Reworked seedConfig validation: dropped the fictional `compression`/`validation`/`bufferSize` keys (only real provider keys like `region` exist), constrained keys to an identifier set, and rejected values with `,`/`=`/quote/backtick/newline. Fixed the CRD field doc.

**Sharded `Neo4jShardedDatabase` seed path (#170)** — `neo4jshardeddatabase_controller.go`, validator:
- `buildShardedDatabaseOptions` raw-interpolated `seedURI`, the per-shard `seedURIs` map, `seedSourceDatabase`, `seedConfig`, `seedRestoreUntil` and ran them via the **string-only `ExecuteCypher`** — a Cypher injection. Added `ExecuteCypherWithParams`; all seed values are now driver parameters. Only per-shard `seedURIs` **keys** are interpolated — backtick-escaped (new `neo4j.EscapeBackticks`) and validator-constrained.
- Aligned the shapes with the standard path: `seedConfig` string via `neo4j.SerializeSeedConfig`, `seedRestoreUntil` integer/`datetime()`.
- Validator rejects unsafe `seedURIs` keys and `seedConfig` keys/values.

**Verified, no change needed (#170):** `dbms.databases.seed_from_uri_providers` already excludes the deprecated S3SeedProvider (rule 74, pinned by `seed_providers_test.go`); the restore/recreate path (`RecreateDatabaseWithSeedURI`) already runs `CALL <proc>($db, {seedURI: $uri})` — seedURI-only, parameterized (recreate supports no seedConfig/seedRestoreUntil per the docs).

## Docs basis

CalVer + 5.x `seed-from-uri` and `recreate-database` pages: seeding lives entirely in `OPTIONS` (no `FROM`/`SEED CONFIG` clause); `seedConfig` is a comma-separated string and an S3SeedProvider requirement (CloudSeedProvider uses env/SDK creds, rule 59); `seedRestoreUntil` is `datetime()`/integer and CalVer-only; `recreateDatabase` accepts only `seedURI`/`seedingServers`/topology.

## Type of change
- [x] Bug fix (correctness + security: closes the sharded seed Cypher injection)

## Testing
- [x] Full controller envtest suite (75 specs) + `internal/{neo4j,validation,resources}` pass; `make lint` + `check-drift` green (CRD doc regenerated into config/crd, helm, bundle).
- New unit tests: standard seedConfig→string param, `seedRestoreUntil` int/`datetime()`, CalVer gate, seedConfig key/value validation; sharded options fully parameterised (no value leaks), per-shard `seedURIs` keys backticked with param values, seedURI/seedURIs mutex; `SerializeSeedConfig`.
- Live seed (MinIO) runs in the extended lane; property-sharding seed is 2025.12+ so it is exercised there, not locally.
- [x] Labels `run-integration-tests` / `run-extended` — touches the database/sharded seed runtime paths.

## Checklist
- [x] Conventional Commits
- [x] CRD doc regenerated (manifests + helm + bundle); `check-drift` passes
- [x] Respects `CLAUDE.md` (CloudSeedProvider/rule 59, no S3SeedProvider; identifiers escaped, values parameterized)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes DDL/Cypher generation for database and sharded-database seeding (security fix for injection) and tightens validation that may reject previously accepted seedConfig values.
> 
> **Overview**
> Aligns seed-from-backup Cypher with Neo4j’s documented **`OPTIONS {…}`** form and closes **Cypher injection** on the sharded database path (#169, #170).
> 
> **Standard `Neo4jDatabase` path:** Drops the legacy **`SEED CONFIG {…}`** clause and **`buildSeedOptions`**. **`seedConfig`** is now a comma-separated **`key=value`** string (via **`SerializeSeedConfig`**) in **`OPTIONS`**, bound as a driver parameter; **`restoreUntil`** becomes **`seedRestoreUntil`** (int64 txId or **`datetime($p)`**). Validation drops fictional **`compression`/`validation`** keys, tightens **`seedConfig`** key/value rules, rejects **int64-overflowing `txId:`** values (so PITR isn’t silently dropped), and **forbids `restoreUntil` on 5.x LTS** targets. CRD field docs are updated and regenerated.
> 
> **Sharded `Neo4jShardedDatabase` path:** **`buildShardedDatabaseOptions`** no longer quotes user seed values into Cypher; it uses **`ExecuteCypherWithParams`** and the same **`seedConfig`/`seedRestoreUntil`** shapes. Per-shard **`seedURIs`** values are parameterized; only map **keys** are backtick-escaped (**`neo4j.EscapeBackticks`**). The sharded validator mirrors **`seedConfig`** / **`seedURIs`** constraints.
> 
> Tests cover parameterization, serialization, CalVer gating, and updated envtest expectations for invalid **`seedConfig`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ce948dabcf6d6c319c78010d6b9437d4345a35e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->