### PR TITLE
fix(upgrade): retry+refetch upgrade status writes; make InProgress resumable (#174 follow-up)

### DIFF
--- a/internal/controller/neo4jenterprisecluster_controller.go
+++ b/internal/controller/neo4jenterprisecluster_controller.go
@@ -1609,11 +1609,15 @@ func (r *Neo4jEnterpriseClusterReconciler) isUpgradeRequired(ctx context.Context
 		return false
 	}
 
-	// Skip if upgrade is already in progress
-	if cluster.Status.UpgradeStatus != nil &&
-		(cluster.Status.UpgradeStatus.Phase == "InProgress" || cluster.Status.UpgradeStatus.Phase == "Paused") {
+	// "Paused" is an explicit manual hold (autoPauseOnFailure) — never auto-resume.
+	if cluster.Status.UpgradeStatus != nil && cluster.Status.UpgradeStatus.Phase == "Paused" {
 		return false
 	}
+	// A persisted "InProgress" no longer hard-blocks re-entry. If the operator
+	// restarted mid-upgrade, the image-drift check below is still true, so the
+	// upgrade resumes (ExecuteRollingUpgrade re-detects the current partition
+	// and continues) instead of wedging forever; once the upgrade has actually
+	// finished, the live image matches desired and the check returns false.
 
 	// Check the unified server StatefulSet for image drift
 	serverSts := &appsv1.StatefulSet{}

--- a/internal/controller/rolling_upgrade.go
+++ b/internal/controller/rolling_upgrade.go
@@ -469,23 +469,37 @@ func (r *RollingUpgradeOrchestrator) updateUpgradeStatus(
 		return
 	}
 
-	cluster.Status.UpgradeStatus.Phase = phase
-	cluster.Status.UpgradeStatus.CurrentStep = currentStep
-	cluster.Status.UpgradeStatus.Message = currentStep
-
-	if lastError != "" {
-		cluster.Status.UpgradeStatus.LastError = lastError
-	}
-
-	if phase == "Completed" {
-		now := metav1.Now()
-		cluster.Status.UpgradeStatus.CompletionTime = &now
-		cluster.Status.LastUpgradeTime = &now
-		cluster.Status.Version = cluster.Spec.Image.Tag
-	}
-
-	if err := r.Status().Update(ctx, cluster); err != nil {
-		// Log error but don't fail the upgrade status update
+	// Refetch + RetryOnConflict on every status write. The upgrade runs across
+	// minutes, so the reconcile-start `cluster` object's ResourceVersion goes
+	// stale; a bare Status().Update then conflicts and was silently swallowed —
+	// which could leave even a SUCCESSFUL upgrade stuck in "InProgress" (its
+	// final "Completed" write lost), permanently disabling further orchestrated
+	// upgrades for the CR. Mirrors updateClusterStatus.
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		latest := &neo4jv1beta1.Neo4jEnterpriseCluster{}
+		if getErr := r.Get(ctx, client.ObjectKeyFromObject(cluster), latest); getErr != nil {
+			return getErr
+		}
+		if latest.Status.UpgradeStatus == nil {
+			return nil
+		}
+		latest.Status.UpgradeStatus.Phase = phase
+		latest.Status.UpgradeStatus.CurrentStep = currentStep
+		latest.Status.UpgradeStatus.Message = currentStep
+		if lastError != "" {
+			latest.Status.UpgradeStatus.LastError = lastError
+		}
+		if phase == "Completed" {
+			now := metav1.Now()
+			latest.Status.UpgradeStatus.CompletionTime = &now
+			latest.Status.LastUpgradeTime = &now
+			latest.Status.Version = cluster.Spec.Image.Tag
+		}
+		// Keep the in-memory object consistent for callers that read it after.
+		cluster.Status.UpgradeStatus = latest.Status.UpgradeStatus
+		return r.Status().Update(ctx, latest)
+	})
+	if err != nil {
 		log.FromContext(ctx).Error(err, "Failed to update cluster status in updateUpgradeStatus")
 	}
 }

--- a/internal/controller/rolling_upgrade_orchestrator_test.go
+++ b/internal/controller/rolling_upgrade_orchestrator_test.go
@@ -265,3 +265,40 @@ func TestUpgradeServers_InitialStagingImage(t *testing.T) {
 		t.Error("expected upgrade-timestamp annotation to be set")
 	}
 }
+
+// TestUpdateUpgradeStatus_PersistsCompleted pins the status-write fix: the
+// "Completed" transition is persisted via a refetch (so a stale reconcile-start
+// object can't lose it), stamps CompletionTime and the new Version, and mirrors
+// back onto the in-memory object.
+func TestUpdateUpgradeStatus_PersistsCompleted(t *testing.T) {
+	scheme := makeUpgradeScheme()
+	cluster := clusterForUpgrade("mycluster", "default", "5.26.0-enterprise", "2025.01.0-enterprise", 3)
+	cluster.Status.UpgradeStatus = &neo4jv1beta1.UpgradeStatus{Phase: "InProgress"}
+
+	fc := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cluster).
+		WithStatusSubresource(cluster).
+		Build()
+	orch := &RollingUpgradeOrchestrator{Client: fc}
+
+	orch.updateUpgradeStatus(context.Background(), cluster, "Completed", "done", "")
+
+	latest := &neo4jv1beta1.Neo4jEnterpriseCluster{}
+	if err := fc.Get(context.Background(), types.NamespacedName{Name: "mycluster", Namespace: "default"}, latest); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if latest.Status.UpgradeStatus == nil || latest.Status.UpgradeStatus.Phase != "Completed" {
+		t.Fatalf("Completed phase not persisted: %+v", latest.Status.UpgradeStatus)
+	}
+	if latest.Status.UpgradeStatus.CompletionTime == nil {
+		t.Error("CompletionTime must be set on Completed")
+	}
+	if latest.Status.Version != "2025.01.0-enterprise" {
+		t.Errorf("Version = %q, want the target tag", latest.Status.Version)
+	}
+	// In-memory object is mirrored for callers that read it afterwards.
+	if cluster.Status.UpgradeStatus.Phase != "Completed" {
+		t.Errorf("in-memory mirror not updated: %q", cluster.Status.UpgradeStatus.Phase)
+	}
+}

--- a/internal/controller/upgrade_detection_test.go
+++ b/internal/controller/upgrade_detection_test.go
@@ -196,3 +196,66 @@ func TestIsUpgradeRequiredSingleStatefulSet(t *testing.T) {
 		t.Fatalf("expected upgrade not to be required when images match")
 	}
 }
+
+// TestIsUpgradeRequired_InProgressResumable pins the resumability fix: a
+// persisted "InProgress" upgrade no longer hard-blocks re-entry (so an operator
+// restart mid-upgrade resumes instead of wedging), while "Paused" stays an
+// explicit manual hold.
+func TestIsUpgradeRequired_InProgressResumable(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = neo4jv1beta1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	newCluster := func(phase string) *neo4jv1beta1.Neo4jEnterpriseCluster {
+		return &neo4jv1beta1.Neo4jEnterpriseCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "default"},
+			Spec: neo4jv1beta1.Neo4jEnterpriseClusterSpec{
+				Image:    neo4jv1beta1.ImageSpec{Repo: "neo4j", Tag: "2025.01.0-enterprise"},
+				Topology: neo4jv1beta1.TopologyConfiguration{Servers: 3},
+			},
+			Status: neo4jv1beta1.Neo4jEnterpriseClusterStatus{
+				Phase:         "Ready",
+				UpgradeStatus: &neo4jv1beta1.UpgradeStatus{Phase: phase},
+			},
+		}
+	}
+	newSTS := func(image string) *appsv1.StatefulSet {
+		return &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "demo-server", Namespace: "default"},
+			Spec: appsv1.StatefulSetSpec{
+				Replicas: ptr.To(int32(3)),
+				Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "neo4j", Image: image}},
+				}},
+			},
+		}
+	}
+
+	t.Run("InProgress + image drift resumes", func(t *testing.T) {
+		c := newCluster("InProgress")
+		fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(c, newSTS("neo4j:5.26.0-enterprise")).Build()
+		r := &Neo4jEnterpriseClusterReconciler{Client: fc}
+		if !r.isUpgradeRequired(context.Background(), c) {
+			t.Fatal("InProgress with image drift must re-enter (resume), not wedge")
+		}
+	})
+
+	t.Run("InProgress + images match is done", func(t *testing.T) {
+		c := newCluster("InProgress")
+		fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(c, newSTS("neo4j:2025.01.0-enterprise")).Build()
+		r := &Neo4jEnterpriseClusterReconciler{Client: fc}
+		if r.isUpgradeRequired(context.Background(), c) {
+			t.Fatal("InProgress with matching image must report no upgrade required")
+		}
+	})
+
+	t.Run("Paused is an explicit hold", func(t *testing.T) {
+		c := newCluster("Paused")
+		fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(c, newSTS("neo4j:5.26.0-enterprise")).Build()
+		r := &Neo4jEnterpriseClusterReconciler{Client: fc}
+		if r.isUpgradeRequired(context.Background(), c) {
+			t.Fatal("Paused must never auto-resume even with image drift")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Two contained correctness fixes for the orchestrated rolling upgrade (Tier-0 audit blocker #6). The larger requeue-driven state-machine rework (to remove single-worker starvation) is tracked separately in **#174**.

**1. Upgrade status writes were stale + conflict-swallowing.** `updateUpgradeStatus` mutated the reconcile-start `cluster` object and called `Status().Update` once, logging-and-ignoring conflicts. An upgrade runs for minutes, so that object's `ResourceVersion` goes stale and the **final `Completed` write could be lost** — leaving even a *successful* upgrade stuck in `InProgress`, which (with the old guard below) permanently disabled further orchestrated upgrades for the CR. Now refetches `latest` + wraps the write in `RetryOnConflict` (mirroring `updateClusterStatus`), and mirrors the result back onto the in-memory object.

**2. `InProgress` wedged the cluster after an operator restart.** `isUpgradeRequired` returned `false` whenever `Phase == "InProgress"`, with nothing to reset it — so a restart mid-upgrade left the cluster permanently un-upgradeable. Now only `"Paused"` (the explicit `autoPauseOnFailure` hold) blocks; `"InProgress"` falls through to the image-drift check, so a restart **resumes** the upgrade (`ExecuteRollingUpgrade` re-detects the current partition) and a finished upgrade (image matches) reports nothing to do.

## Type of change
- [x] Bug fix

## Testing
- [x] Full controller envtest suite (75 specs) + `go vet`; `make lint` + `check-drift` green.
- New unit tests: `Completed` persists with `CompletionTime`+`Version` and mirrors back; `InProgress`+drift resumes, `InProgress`+match is done, `Paused` never auto-resumes.

## Scope / follow-ups
- Independent of #171/#172 (touches only `rolling_upgrade.go` + `isUpgradeRequired`).
- #174 tracks the architectural fix (one partition step per reconcile so an upgrading cluster doesn't stall others under `MaxConcurrentReconciles: 1`).

## Checklist
- [x] Conventional Commit
- [x] No API/CRD change
- [x] Respects `CLAUDE.md` (status writes via refetch+RetryOnConflict; observedGeneration/condition patterns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches orchestrated rolling upgrade gating and long-running status writes; wrong behavior could re-trigger or wedge upgrades, but scope is limited and covered by new unit tests.
> 
> **Overview**
> Fixes two rolling-upgrade correctness bugs that could leave clusters stuck and block future orchestrated upgrades.
> 
> **`updateUpgradeStatus`** now refetches the CR and writes status inside **`RetryOnConflict`** (same pattern as **`updateClusterStatus`**), instead of updating a reconcile-start object whose **`ResourceVersion`** goes stale during multi-minute upgrades. Conflicts were logged and dropped, so a successful run could fail to persist **`Completed`** and stay **`InProgress`**. The in-memory **`UpgradeStatus`** is mirrored after a successful write.
> 
> **`isUpgradeRequired`** no longer treats **`UpgradeStatus.Phase == "InProgress"`** as a hard stop. Only **`Paused`** (manual **`autoPauseOnFailure`** hold) blocks re-entry. With **`InProgress`**, image drift still triggers upgrade (operator restart mid-upgrade can resume); matching live and desired images means no upgrade is needed.
> 
> Unit tests cover **`Completed`** persistence (**`CompletionTime`**, **`Version`**, in-memory mirror) and **`InProgress`** vs **`Paused`** behavior with image drift.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18e0af75c640924e20dd069e63272a6ece0bbcc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->