### PR TITLE
fix(restore): recover cluster availability on failed restore; use Job conditions

### DIFF
--- a/internal/controller/neo4jrestore_controller.go
+++ b/internal/controller/neo4jrestore_controller.go
@@ -373,25 +373,73 @@ func (r *Neo4jRestoreReconciler) checkRestoreProgress(ctx context.Context, resto
 	err := r.Get(ctx, types.NamespacedName{Name: jobName, Namespace: restore.Namespace}, job)
 
 	if err != nil {
+		if errors.IsNotFound(err) {
+			// The Job's TTLSecondsAfterFinished GC'd it before we observed a
+			// terminal state (e.g. the operator was down longer than the TTL).
+			// We can't tell success from failure, so fail safe: restore cluster
+			// availability and mark Failed rather than requeueing forever with
+			// the cluster scaled to 0.
+			logger.Info("Restore Job not found (likely TTL-collected before completion was observed); failing the restore", "job", jobName)
+			r.restoreClusterAfterFailure(ctx, restore, cluster)
+			r.updateRestoreStatus(ctx, restore, StatusFailed,
+				"restore Job disappeared before completion was observed (TTL-collected); re-create the Neo4jRestore to retry")
+			r.Recorder.Event(restore, corev1.EventTypeWarning, EventReasonRestoreFailed,
+				"restore Job disappeared before completion was observed")
+			return ctrl.Result{}, nil
+		}
 		logger.Error(err, "Failed to get restore job")
 		return ctrl.Result{RequeueAfter: r.RequeueAfter}, err
 	}
 
-	// Check job status
-	if job.Status.Succeeded > 0 {
-		// Restore completed successfully
+	// Decide on terminal Job CONDITIONS, not raw pod counts: with BackoffLimit>0
+	// `Status.Failed` counts failed pod attempts and can be >0 while Kubernetes
+	// is still retrying — which would flip the restore to a (pinned) terminal
+	// Failed before a retry that might succeed.
+	switch {
+	case jobConditionTrue(job, batchv1.JobComplete) || job.Status.Succeeded > 0:
 		return r.handleRestoreSuccess(ctx, restore, cluster, job)
-	}
-
-	if job.Status.Failed > 0 {
-		// Restore failed
+	case jobConditionTrue(job, batchv1.JobFailed):
+		// Terminal failure (BackoffLimit exhausted). Restore cluster
+		// availability BEFORE marking Failed — a StopCluster restore otherwise
+		// leaves the cluster scaled to 0 indefinitely (the cluster controller
+		// honours the restore-in-progress annotation until it is cleared).
+		r.restoreClusterAfterFailure(ctx, restore, cluster)
 		r.updateRestoreStatus(ctx, restore, StatusFailed, "Restore job failed")
 		r.Recorder.Event(restore, corev1.EventTypeWarning, EventReasonRestoreFailed, "Restore job failed")
 		return ctrl.Result{}, nil
+	default:
+		// Job still running, or retrying within BackoffLimit.
+		return ctrl.Result{RequeueAfter: r.RequeueAfter}, nil
 	}
+}
 
-	// Job is still running
-	return ctrl.Result{RequeueAfter: r.RequeueAfter}, nil
+// jobConditionTrue reports whether the Job has the given condition set to True.
+func jobConditionTrue(job *batchv1.Job, condType batchv1.JobConditionType) bool {
+	for _, c := range job.Status.Conditions {
+		if c.Type == condType && c.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+// restoreClusterAfterFailure scales the cluster back up and releases the
+// restore-in-progress hold after a terminal restore failure — mirroring the
+// teardown handleRestoreSuccess performs on success. Without it, a
+// StopCluster=true restore that fails leaves the cluster at 0 replicas until a
+// human deletes the CR. Both calls are idempotent and best-effort (logged, not
+// fatal) so the restore still reaches a terminal Failed state.
+func (r *Neo4jRestoreReconciler) restoreClusterAfterFailure(ctx context.Context, restore *neo4jv1beta1.Neo4jRestore, cluster *neo4jv1beta1.Neo4jEnterpriseCluster) {
+	if !restore.Spec.StopCluster || cluster == nil {
+		return
+	}
+	logger := log.FromContext(ctx)
+	if err := r.startCluster(ctx, cluster); err != nil {
+		logger.Error(err, "Failed to scale cluster back up after restore failure")
+	}
+	if err := r.clearRestoreInProgressAnnotation(ctx, restore, cluster.Name, cluster.Namespace); err != nil {
+		logger.Error(err, "Failed to clear restore-in-progress annotation after restore failure")
+	}
 }
 
 func (r *Neo4jRestoreReconciler) handleRestoreSuccess(ctx context.Context, restore *neo4jv1beta1.Neo4jRestore, cluster *neo4jv1beta1.Neo4jEnterpriseCluster, job *batchv1.Job) (ctrl.Result, error) {

--- a/internal/controller/neo4jrestore_progress_test.go
+++ b/internal/controller/neo4jrestore_progress_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
+)
+
+func TestJobConditionTrue(t *testing.T) {
+	j := &batchv1.Job{Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{
+		{Type: batchv1.JobFailed, Status: corev1.ConditionTrue},
+		{Type: batchv1.JobComplete, Status: corev1.ConditionFalse},
+	}}}
+	assert.True(t, jobConditionTrue(j, batchv1.JobFailed))
+	assert.False(t, jobConditionTrue(j, batchv1.JobComplete))
+	assert.False(t, jobConditionTrue(&batchv1.Job{}, batchv1.JobFailed))
+}
+
+// TestCheckRestoreProgress_TerminalDecisions pins the failed-restore recovery
+// fix: a failed POD attempt mid-retry (Status.Failed>0 without a JobFailed
+// condition) must NOT be terminal; only the JobFailed condition is; and a
+// TTL-collected (missing) Job is terminal rather than requeue-forever.
+func TestCheckRestoreProgress_TerminalDecisions(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, neo4jv1beta1.AddToScheme(scheme))
+	ctx := context.Background()
+
+	newRestore := func() *neo4jv1beta1.Neo4jRestore {
+		return &neo4jv1beta1.Neo4jRestore{
+			ObjectMeta: metav1.ObjectMeta{Name: "r1", Namespace: "default"},
+			Spec:       neo4jv1beta1.Neo4jRestoreSpec{StopCluster: false, DatabaseName: "db"},
+			Status:     neo4jv1beta1.Neo4jRestoreStatus{Phase: "Running"},
+		}
+	}
+	newJob := func(mut func(*batchv1.Job)) *batchv1.Job {
+		j := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "r1-restore", Namespace: "default"}}
+		if mut != nil {
+			mut(j)
+		}
+		return j
+	}
+	reconciler := func(objs ...client.Object) *Neo4jRestoreReconciler {
+		restore := newRestore()
+		all := append([]client.Object{restore}, objs...)
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(all...).WithStatusSubresource(restore).Build()
+		return &Neo4jRestoreReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(16), RequeueAfter: 5 * time.Second}
+	}
+
+	t.Run("failed pod attempt without JobFailed condition keeps running", func(t *testing.T) {
+		rec := reconciler(newJob(func(j *batchv1.Job) { j.Status.Failed = 1 }))
+		res, err := rec.checkRestoreProgress(ctx, newRestore(), nil)
+		require.NoError(t, err)
+		assert.Equal(t, 5*time.Second, res.RequeueAfter,
+			"a failed pod attempt within BackoffLimit must requeue, not flip to terminal Failed")
+	})
+
+	t.Run("JobFailed condition is terminal", func(t *testing.T) {
+		rec := reconciler(newJob(func(j *batchv1.Job) {
+			j.Status.Failed = 4
+			j.Status.Conditions = []batchv1.JobCondition{{Type: batchv1.JobFailed, Status: corev1.ConditionTrue}}
+		}))
+		res, err := rec.checkRestoreProgress(ctx, newRestore(), nil)
+		require.NoError(t, err)
+		assert.Zero(t, res.RequeueAfter, "JobFailed condition must be terminal (no requeue)")
+	})
+
+	t.Run("missing (TTL-collected) Job is terminal", func(t *testing.T) {
+		rec := reconciler() // no Job object
+		res, err := rec.checkRestoreProgress(ctx, newRestore(), nil)
+		require.NoError(t, err)
+		assert.Zero(t, res.RequeueAfter, "a TTL-collected Job must be terminal, not requeue forever")
+	})
+}


### PR DESCRIPTION
## Summary

Closes the failed-restore recovery gaps (Tier-0/Tier-1 audit finding). `checkRestoreProgress` had three problems that could leave a cluster down or wedge a restore:

1. **Failed restore left the cluster scaled to 0 forever.** The failure branch set `phase=Failed` and returned — never scaling the cluster back up nor clearing the `restore-in-progress` annotation. A `StopCluster=true` restore that failed therefore left the StatefulSet at 0 replicas indefinitely (the cluster controller honours the annotation) — a permanent outage until a human deleted the CR. New `restoreClusterAfterFailure` mirrors the success-path teardown (`startCluster` + `clearRestoreInProgressAnnotation`; idempotent, best-effort) and runs before the terminal `Failed` on **every** failure path.

2. **Terminal-on-pod-count instead of Job condition.** Failure was decided on `job.Status.Failed > 0`, which counts failed *pod attempts* — with `BackoffLimit>0` that's >0 while Kubernetes is still retrying, flipping the restore to a pinned terminal `Failed` before a retry that might succeed. Now keys on the terminal Job **conditions** (`JobComplete` / `JobFailed`) via `jobConditionTrue`; the retry window is treated as "still running".

3. **TTL-collected Job wedged the restore.** A `NotFound` Job (the `TTLSecondsAfterFinished` GC fired before a terminal state was observed, e.g. operator downtime > TTL) returned an error and requeued forever with the cluster down. Now it fails safe: restore cluster availability + mark `Failed` with an actionable message.

## Type of change
- [x] Bug fix

## Testing
- [x] Full controller envtest suite (75 specs); `make lint` + `check-drift` green.
- New unit tests: `jobConditionTrue`; a failed pod attempt without `JobFailed` keeps running; `JobFailed` is terminal; a missing Job is terminal. (The success path needs a live Neo4j client, so it stays covered by the extended lane.)

## Scope
- Stacked on #171 (both touch `neo4jrestore_controller.go`, different functions — `checkRestoreProgress`/`handleRestoreSuccess` vs #171's `buildRestoreCommand`/`validateRestore`). Base retargets to `main` when #171 merges.

## Checklist
- [x] Conventional Commit
- [x] No API/CRD change
- [x] Respects `CLAUDE.md` (restore/cluster coordination via the restore-in-progress annotation, rule 46)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes restore failure handling and cluster scale/annotation coordination—directly affects availability after failed `StopCluster` restores; logic is localized to `checkRestoreProgress` with new unit tests.
> 
> **Overview**
> Fixes **failed-restore recovery** in `checkRestoreProgress` so `StopCluster` restores do not leave the cluster at zero replicas or wedge the CR in a requeue loop.
> 
> **Terminal Job detection** now uses Kubernetes Job **conditions** (`JobComplete` / `JobFailed`) via `jobConditionTrue`, instead of treating `job.Status.Failed > 0` as failure while retries are still in flight.
> 
> On **terminal failure** (including a **TTL-GC’d missing Job**), the reconciler calls new **`restoreClusterAfterFailure`** to scale the cluster back up and clear `neo4j.com/restore-in-progress` before marking the restore **Failed**—matching success-path teardown.
> 
> Adds unit tests for `jobConditionTrue` and the three terminal vs in-progress Job outcomes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f79da662bd9218642673226d2cf19faf59bdb7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->