### PR TITLE
fix(status): refetch+retry on fleet and standalone failure-path status writes

### DIFF
--- a/internal/controller/neo4jenterprisecluster_controller.go
+++ b/internal/controller/neo4jenterprisecluster_controller.go
@@ -2648,15 +2648,26 @@ func (r *Neo4jEnterpriseClusterReconciler) mergeFleetManagementPlugin(ctx contex
 
 func (r *Neo4jEnterpriseClusterReconciler) setFleetManagementStatus(ctx context.Context, cluster *neo4jv1beta1.Neo4jEnterpriseCluster, registered bool, message string) error {
 	now := metav1.Now()
-	status := &neo4jv1beta1.AuraFleetManagementStatus{
-		Registered: registered,
-		Message:    message,
-	}
-	if registered {
-		status.LastRegistrationTime = &now
-	}
-	cluster.Status.AuraFleetManagement = status
-	return r.Status().Update(ctx, cluster)
+	// Refetch + RetryOnConflict: fleet registration runs after other status
+	// writes in the same reconcile, so the reconcile-start object is stale and a
+	// bare Status().Update conflicts (the standalone twin already refetches; the
+	// cluster path did not). Mirrors updateClusterStatus.
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest := &neo4jv1beta1.Neo4jEnterpriseCluster{}
+		if err := r.Get(ctx, client.ObjectKeyFromObject(cluster), latest); err != nil {
+			return err
+		}
+		status := &neo4jv1beta1.AuraFleetManagementStatus{
+			Registered: registered,
+			Message:    message,
+		}
+		if registered {
+			status.LastRegistrationTime = &now
+		}
+		latest.Status.AuraFleetManagement = status
+		cluster.Status.AuraFleetManagement = status // mirror for the in-memory caller
+		return r.Status().Update(ctx, latest)
+	})
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/neo4jenterprisestandalone_controller.go
+++ b/internal/controller/neo4jenterprisestandalone_controller.go
@@ -1582,8 +1582,17 @@ func (r *Neo4jEnterpriseStandaloneReconciler) createStatefulSet(standalone *neo4
 // object and retrying on conflict. The early-return failure paths previously
 // wrote the stale reconcile-start object directly (no refetch/retry), dropped
 // ObservedGeneration, and one used an event-reason constant as the phase.
+//
+// ObservedGeneration is stamped from the generation we actually reconciled
+// (the reconcile-start object), NOT the refetched latest.Generation. If the
+// spec changed mid-reconcile, latest.Generation is newer than what produced
+// this failure; claiming we observed it would suppress the re-reconcile the
+// new generation deserves. Stamping the older generation leaves
+// observedGeneration < generation, the correct "status is stale, reconcile
+// pending" signal — and the refetch is purely to win the resourceVersion race.
 func (r *Neo4jEnterpriseStandaloneReconciler) setFailedStatus(ctx context.Context, standalone *neo4jv1beta1.Neo4jEnterpriseStandalone, message string) {
 	logger := log.FromContext(ctx)
+	reconciledGen := standalone.Generation
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		latest := &neo4jv1beta1.Neo4jEnterpriseStandalone{}
 		if getErr := r.Get(ctx, types.NamespacedName{Name: standalone.Name, Namespace: standalone.Namespace}, latest); getErr != nil {
@@ -1592,9 +1601,9 @@ func (r *Neo4jEnterpriseStandaloneReconciler) setFailedStatus(ctx context.Contex
 		latest.Status.Phase = "Failed"
 		latest.Status.Message = message
 		latest.Status.Ready = false
-		latest.Status.ObservedGeneration = latest.Generation
+		latest.Status.ObservedGeneration = reconciledGen
 		condStatus, condReason := PhaseToConditionStatus("Failed")
-		SetReadyCondition(&latest.Status.Conditions, latest.Generation, condStatus, condReason, message)
+		SetReadyCondition(&latest.Status.Conditions, reconciledGen, condStatus, condReason, message)
 		// Mirror onto the in-memory object for the rest of the reconcile.
 		standalone.Status.Phase = "Failed"
 		standalone.Status.Message = message

--- a/internal/controller/neo4jenterprisestandalone_controller.go
+++ b/internal/controller/neo4jenterprisestandalone_controller.go
@@ -146,12 +146,7 @@ func (r *Neo4jEnterpriseStandaloneReconciler) Reconcile(ctx context.Context, req
 			fmt.Sprintf("Validation failed: %v", validationErrs))
 
 		// Update status to reflect validation failure
-		standalone.Status.Phase = EventReasonValidationFailed
-		standalone.Status.Message = fmt.Sprintf("Validation failed: %v", validationErrs)
-		standalone.Status.Ready = false
-		if err := r.Status().Update(ctx, standalone); err != nil {
-			logger.Error(err, "Failed to update status")
-		}
+		r.setFailedStatus(ctx, standalone, fmt.Sprintf("Validation failed: %v", validationErrs))
 		return ctrl.Result{RequeueAfter: r.RequeueAfter}, nil
 	}
 
@@ -166,12 +161,7 @@ func (r *Neo4jEnterpriseStandaloneReconciler) Reconcile(ctx context.Context, req
 		msg := fmt.Sprintf("StorageClass %q not found; create it or set spec.storage.className to an existing class (or leave it empty to use the cluster default)", standalone.Spec.Storage.ClassName)
 		logger.Error(fmt.Errorf("storage class not found"), msg)
 		r.Recorder.Event(standalone, corev1.EventTypeWarning, EventReasonStorageClassNotFound, msg)
-		standalone.Status.Phase = "Failed"
-		standalone.Status.Message = msg
-		standalone.Status.Ready = false
-		if statusErr := r.Status().Update(ctx, standalone); statusErr != nil {
-			logger.Error(statusErr, "Failed to update status")
-		}
+		r.setFailedStatus(ctx, standalone, msg)
 		return ctrl.Result{RequeueAfter: r.RequeueAfter}, nil
 	}
 
@@ -183,12 +173,7 @@ func (r *Neo4jEnterpriseStandaloneReconciler) Reconcile(ctx context.Context, req
 			fmt.Sprintf("Failed to reconcile: %v", err))
 
 		// Update status to reflect failure
-		standalone.Status.Phase = "Failed"
-		standalone.Status.Message = fmt.Sprintf("Reconciliation failed: %v", err)
-		standalone.Status.Ready = false
-		if statusErr := r.Status().Update(ctx, standalone); statusErr != nil {
-			logger.Error(statusErr, "Failed to update status")
-		}
+		r.setFailedStatus(ctx, standalone, fmt.Sprintf("Reconciliation failed: %v", err))
 		return ctrl.Result{RequeueAfter: r.RequeueAfter}, err
 	}
 
@@ -1593,6 +1578,34 @@ func (r *Neo4jEnterpriseStandaloneReconciler) createStatefulSet(standalone *neo4
 	}
 }
 
+// setFailedStatus records a terminal "Failed" phase, refetching the latest
+// object and retrying on conflict. The early-return failure paths previously
+// wrote the stale reconcile-start object directly (no refetch/retry), dropped
+// ObservedGeneration, and one used an event-reason constant as the phase.
+func (r *Neo4jEnterpriseStandaloneReconciler) setFailedStatus(ctx context.Context, standalone *neo4jv1beta1.Neo4jEnterpriseStandalone, message string) {
+	logger := log.FromContext(ctx)
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest := &neo4jv1beta1.Neo4jEnterpriseStandalone{}
+		if getErr := r.Get(ctx, types.NamespacedName{Name: standalone.Name, Namespace: standalone.Namespace}, latest); getErr != nil {
+			return getErr
+		}
+		latest.Status.Phase = "Failed"
+		latest.Status.Message = message
+		latest.Status.Ready = false
+		latest.Status.ObservedGeneration = latest.Generation
+		condStatus, condReason := PhaseToConditionStatus("Failed")
+		SetReadyCondition(&latest.Status.Conditions, latest.Generation, condStatus, condReason, message)
+		// Mirror onto the in-memory object for the rest of the reconcile.
+		standalone.Status.Phase = "Failed"
+		standalone.Status.Message = message
+		standalone.Status.Ready = false
+		return r.Status().Update(ctx, latest)
+	})
+	if err != nil {
+		logger.Error(err, "Failed to update standalone status to Failed")
+	}
+}
+
 // updateStatus updates the status of the standalone deployment
 func (r *Neo4jEnterpriseStandaloneReconciler) updateStatus(ctx context.Context, standalone *neo4jv1beta1.Neo4jEnterpriseStandalone) error {
 	logger := log.FromContext(ctx)
@@ -2384,10 +2397,13 @@ func (r *Neo4jEnterpriseStandaloneReconciler) setFleetManagementStatus(ctx conte
 		status.LastRegistrationTime = &now
 	}
 
-	latest := &neo4jv1beta1.Neo4jEnterpriseStandalone{}
-	if err := r.Get(ctx, types.NamespacedName{Namespace: standalone.Namespace, Name: standalone.Name}, latest); err != nil {
-		return err
-	}
-	latest.Status.AuraFleetManagement = status
-	return r.Status().Update(ctx, latest)
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest := &neo4jv1beta1.Neo4jEnterpriseStandalone{}
+		if err := r.Get(ctx, types.NamespacedName{Namespace: standalone.Namespace, Name: standalone.Name}, latest); err != nil {
+			return err
+		}
+		latest.Status.AuraFleetManagement = status
+		standalone.Status.AuraFleetManagement = status // mirror for the in-memory caller
+		return r.Status().Update(ctx, latest)
+	})
 }

--- a/internal/controller/status_write_test.go
+++ b/internal/controller/status_write_test.go
@@ -54,9 +54,8 @@ func TestSetFleetManagementStatus_Cluster_RefetchesAndPersists(t *testing.T) {
 }
 
 // TestSetFailedStatus_Standalone pins the failure-path fix: a refetched write
-// with phase=Failed, Ready=false, and ObservedGeneration set to the current
-// generation (it was previously dropped, and one path used an event-reason
-// constant as the phase).
+// with phase=Failed, Ready=false, and ObservedGeneration set (it was previously
+// dropped, and one path used an event-reason constant as the phase).
 func TestSetFailedStatus_Standalone(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, neo4jv1beta1.AddToScheme(scheme))
@@ -73,8 +72,40 @@ func TestSetFailedStatus_Standalone(t *testing.T) {
 	assert.Equal(t, "Failed", latest.Status.Phase)
 	assert.Equal(t, "boom", latest.Status.Message)
 	assert.False(t, latest.Status.Ready)
-	assert.Equal(t, latest.Generation, latest.Status.ObservedGeneration,
-		"ObservedGeneration must track the object's generation")
+	assert.Equal(t, int64(7), latest.Status.ObservedGeneration,
+		"ObservedGeneration must track the reconciled generation")
 	// In-memory mirror.
 	assert.Equal(t, "Failed", sa.Status.Phase)
+}
+
+// TestSetFailedStatus_Standalone_StaleGeneration pins that the failure is
+// stamped against the generation we actually reconciled, not the newer
+// generation a concurrent spec edit left in the store. Otherwise a failure
+// derived from generation N would mark generation N+1 as observed and suppress
+// the re-reconcile the new spec deserves.
+func TestSetFailedStatus_Standalone_StaleGeneration(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, neo4jv1beta1.AddToScheme(scheme))
+	// The object in the store has advanced to generation 8 (spec changed
+	// mid-reconcile).
+	stored := &neo4jv1beta1.Neo4jEnterpriseStandalone{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "default", Generation: 8},
+	}
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(stored).WithStatusSubresource(stored).Build()
+	r := &Neo4jEnterpriseStandaloneReconciler{Client: fc}
+
+	// We reconciled generation 7.
+	reconcileStart := &neo4jv1beta1.Neo4jEnterpriseStandalone{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "default", Generation: 7},
+	}
+	r.setFailedStatus(context.Background(), reconcileStart, "boom")
+
+	latest := &neo4jv1beta1.Neo4jEnterpriseStandalone{}
+	require.NoError(t, fc.Get(context.Background(), types.NamespacedName{Name: "s", Namespace: "default"}, latest))
+	assert.Equal(t, int64(8), latest.Generation, "store still holds the newer generation")
+	assert.Equal(t, int64(7), latest.Status.ObservedGeneration,
+		"must stamp the reconciled generation (7), not the stored latest (8)")
+	require.NotEmpty(t, latest.Status.Conditions)
+	assert.Equal(t, int64(7), latest.Status.Conditions[0].ObservedGeneration,
+		"the Ready condition's observedGeneration must also track the reconciled generation")
 }

--- a/internal/controller/status_write_test.go
+++ b/internal/controller/status_write_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
+)
+
+// TestSetFleetManagementStatus_Cluster_RefetchesAndPersists pins the cluster
+// fleet status fix: the write goes to the refetched object (not the stale
+// reconcile-start one) and is mirrored back in memory.
+func TestSetFleetManagementStatus_Cluster_RefetchesAndPersists(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, neo4jv1beta1.AddToScheme(scheme))
+	cluster := &neo4jv1beta1.Neo4jEnterpriseCluster{ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: "default"}}
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster).WithStatusSubresource(cluster).Build()
+	r := &Neo4jEnterpriseClusterReconciler{Client: fc}
+
+	require.NoError(t, r.setFleetManagementStatus(context.Background(), cluster, true, "registered"))
+
+	latest := &neo4jv1beta1.Neo4jEnterpriseCluster{}
+	require.NoError(t, fc.Get(context.Background(), types.NamespacedName{Name: "c", Namespace: "default"}, latest))
+	require.NotNil(t, latest.Status.AuraFleetManagement)
+	assert.True(t, latest.Status.AuraFleetManagement.Registered)
+	assert.Equal(t, "registered", latest.Status.AuraFleetManagement.Message)
+	assert.NotNil(t, latest.Status.AuraFleetManagement.LastRegistrationTime)
+	// In-memory object mirrored.
+	require.NotNil(t, cluster.Status.AuraFleetManagement)
+	assert.True(t, cluster.Status.AuraFleetManagement.Registered)
+}
+
+// TestSetFailedStatus_Standalone pins the failure-path fix: a refetched write
+// with phase=Failed, Ready=false, and ObservedGeneration set to the current
+// generation (it was previously dropped, and one path used an event-reason
+// constant as the phase).
+func TestSetFailedStatus_Standalone(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, neo4jv1beta1.AddToScheme(scheme))
+	sa := &neo4jv1beta1.Neo4jEnterpriseStandalone{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "default", Generation: 7},
+	}
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(sa).WithStatusSubresource(sa).Build()
+	r := &Neo4jEnterpriseStandaloneReconciler{Client: fc}
+
+	r.setFailedStatus(context.Background(), sa, "boom")
+
+	latest := &neo4jv1beta1.Neo4jEnterpriseStandalone{}
+	require.NoError(t, fc.Get(context.Background(), types.NamespacedName{Name: "s", Namespace: "default"}, latest))
+	assert.Equal(t, "Failed", latest.Status.Phase)
+	assert.Equal(t, "boom", latest.Status.Message)
+	assert.False(t, latest.Status.Ready)
+	assert.Equal(t, latest.Generation, latest.Status.ObservedGeneration,
+		"ObservedGeneration must track the object's generation")
+	// In-memory mirror.
+	assert.Equal(t, "Failed", sa.Status.Phase)
+}


### PR DESCRIPTION
## Summary

Finishes the Tier-1 stale-status-write cleanup. Two status-write sites still wrote a **stale in-memory object** via `r.Status().Update(...)` without refetching, so a concurrent reconcile's resourceVersion bump silently dropped the write:

1. **Cluster `setFleetManagementStatus`** — fleet-management condition/status mirror.
2. **Standalone failure path** — three blocks (validation, storage-class, reconcile) each hand-rolled a status update.

The standalone failure path also had two correctness bugs:
- `Status.Phase` was set to the **event-reason string** (`"ValidationFailed"`) instead of `"Failed"`.
- `ObservedGeneration` was not stamped, so a failed reconcile left a stale generation.

## Changes

- Rewrote `setFleetManagementStatus` on **both** controllers to refetch `latest`, apply status under `retry.RetryOnConflict`, and mirror persisted fields back onto the caller's object.
- Added a shared standalone **`setFailedStatus(ctx, standalone, message)`** helper (refetch + retry + `Phase="Failed"` + `Ready=false` + message + `ObservedGeneration=latest.Generation` + `SetReadyCondition` + mirror-back) and routed the three failure blocks through it.

Same refetch + `RetryOnConflict` pattern as #175 (upgrade-status fix), which this is stacked on.

## Tests

- `TestSetFleetManagementStatus_Cluster_RefetchesAndPersists`
- `TestSetFailedStatus_Standalone` (asserts `Phase=Failed`, `ObservedGeneration==Generation`, `Ready=false`, mirror)
- Full controller envtest suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches controller status persistence and generation/condition semantics; incorrect behavior would misreport failures or delay re-reconcile, but does not change Neo4j runtime or auth.
> 
> **Overview**
> Fixes **stale status writes** that could be lost when another reconcile or an earlier step in the same loop bumped `resourceVersion`.
> 
> **Cluster:** `setFleetManagementStatus` now **refetches** the CR, updates under **`retry.RetryOnConflict`**, and **mirrors** `AuraFleetManagement` back onto the in-memory object (aligned with `updateClusterStatus` and the standalone path).
> 
> **Standalone:** Validation, missing StorageClass, and reconcile errors go through a new **`setFailedStatus`** helper instead of updating the reconcile-start object directly. That sets **`Phase="Failed"`** (replacing the validation path that used the event reason as phase), **`Ready=false`**, **`SetReadyCondition`**, and **`ObservedGeneration`** from the **generation being reconciled** (not the refetched latest), so a mid-reconcile spec bump still triggers another reconcile. Fleet status writes gain the same **retry-on-conflict** wrapper as the cluster.
> 
> Adds **`status_write_test.go`** unit tests for fleet persistence and failed-status / generation stamping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfc05ce0faface2d29132ec97601333e18bad9a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->