### PR TITLE
fix(finalizer): don't wedge CR deletion when Neo4j drop/revoke fails

### DIFF
--- a/internal/controller/finalizer_deletion.go
+++ b/internal/controller/finalizer_deletion.go
@@ -77,6 +77,16 @@ func classifyFinalizerCleanup(obj metav1.Object, err error) finalizerCleanupDisp
 	return retryCleanup
 }
 
+// isAlreadyGoneCleanup reports whether err means the specific target of a
+// drop/revoke is already gone — i.e. that one operation is idempotently
+// satisfied. Multi-step cleanup (e.g. revoking several role grants in a loop)
+// uses this to skip a satisfied item and keep going with the rest, instead of
+// routing it through classifyFinalizerCleanup, which would release the
+// finalizer and abandon the remaining items on the first not-found.
+func isAlreadyGoneCleanup(err error) bool {
+	return neo4j.IsNotFoundError(err)
+}
+
 // deletionGracePeriodExceeded reports whether finalizerDeletionGracePeriod has
 // elapsed since the object's deletion was requested.
 func deletionGracePeriodExceeded(obj metav1.Object) bool {

--- a/internal/controller/finalizer_deletion.go
+++ b/internal/controller/finalizer_deletion.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/neo4j-partners/neo4j-kubernetes-operator/internal/neo4j"
+)
+
+// finalizerDeletionGracePeriod bounds how long the operator keeps retrying a
+// failed Neo4j drop/revoke during finalizer cleanup before it releases the
+// finalizer anyway. A CR wedged undeletable forever is worse than an orphaned
+// Neo4j object an admin can drop by hand, so transient and unknown failures get
+// a bounded retry window — not an infinite one.
+const finalizerDeletionGracePeriod = 5 * time.Minute
+
+// finalizerCleanupDisposition is the decision for a Neo4j drop/revoke that ran
+// (or failed) during finalizer cleanup.
+type finalizerCleanupDisposition int
+
+const (
+	// releaseFinalizer means the finalizer may be removed now: the cleanup
+	// succeeded, the target was already gone, the host's DNS no longer resolves
+	// (cluster deleted), or the bounded retry window has elapsed.
+	releaseFinalizer finalizerCleanupDisposition = iota
+	// retryCleanup means the failure looks transient and the grace period has
+	// not yet elapsed; the caller should requeue and keep the finalizer.
+	retryCleanup
+)
+
+// classifyFinalizerCleanup decides whether a Neo4j drop/revoke performed during
+// deletion lets the finalizer be released. It is the single shared policy used
+// by every CR whose deletion runs Cypher against Neo4j (user, role,
+// rolebinding, authrule, database):
+//
+//   - err == nil ...................... release (cleanup succeeded)
+//   - target already gone ............. release (idempotent — desired end state)
+//   - host DNS no longer resolves ..... release (Service/cluster deleted; the
+//     object went with it and the name will not come back)
+//   - transient / unknown ............. retry until finalizerDeletionGracePeriod
+//     has elapsed since deletion was requested, then release rather than wedge
+//
+// obj is the object being deleted; its DeletionTimestamp bounds the retry
+// window. A nil DeletionTimestamp (object not actually being deleted) is
+// treated conservatively as "just started", so transient errors retry.
+func classifyFinalizerCleanup(obj metav1.Object, err error) finalizerCleanupDisposition {
+	if err == nil {
+		return releaseFinalizer
+	}
+	if neo4j.IsNotFoundError(err) || neo4j.IsHostUnresolvableError(err) {
+		return releaseFinalizer
+	}
+	// Transient connect failures, conflicting-transaction retries, and any
+	// unclassified error all get the same bounded-retry treatment: keep trying
+	// while the grace window is open, then release so the CR can finish
+	// deleting instead of wedging forever.
+	if deletionGracePeriodExceeded(obj) {
+		return releaseFinalizer
+	}
+	return retryCleanup
+}
+
+// deletionGracePeriodExceeded reports whether finalizerDeletionGracePeriod has
+// elapsed since the object's deletion was requested.
+func deletionGracePeriodExceeded(obj metav1.Object) bool {
+	ts := obj.GetDeletionTimestamp()
+	if ts == nil {
+		return false
+	}
+	return time.Since(ts.Time) > finalizerDeletionGracePeriod
+}

--- a/internal/controller/finalizer_deletion_test.go
+++ b/internal/controller/finalizer_deletion_test.go
@@ -70,3 +70,27 @@ func TestClassifyFinalizerCleanup(t *testing.T) {
 		})
 	}
 }
+
+// TestIsAlreadyGoneCleanup pins the per-item "already gone" check used by the
+// role-binding revoke loop to skip a satisfied grant (rather than abandon the
+// remaining ones) without releasing the finalizer on a host-level failure.
+func TestIsAlreadyGoneCleanup(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"not found is already gone", errors.New("role `auditor` does not exist"), true},
+		{"user not found is already gone", errors.New("user not found"), true},
+		{"connection refused is NOT already gone", errors.New("connection refused"), false},
+		{"no such host is NOT already gone", errors.New("no such host"), false},
+		{"nil is not", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isAlreadyGoneCleanup(tc.err); got != tc.want {
+				t.Fatalf("isAlreadyGoneCleanup(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/controller/finalizer_deletion_test.go
+++ b/internal/controller/finalizer_deletion_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	driver "github.com/neo4j/neo4j-go-driver/v5/neo4j"
+)
+
+// objBeingDeleted returns a minimal metav1.Object whose deletion was requested
+// `age` ago (age <= 0 means "no deletion timestamp set").
+func objBeingDeleted(age time.Duration) metav1.Object {
+	om := &metav1.ObjectMeta{}
+	if age > 0 {
+		ts := metav1.NewTime(time.Now().Add(-age))
+		om.DeletionTimestamp = &ts
+	}
+	return om
+}
+
+func TestClassifyFinalizerCleanup(t *testing.T) {
+	justDeleted := time.Second                              // well inside grace window
+	pastGrace := finalizerDeletionGracePeriod + time.Minute // grace window elapsed
+
+	cases := []struct {
+		name string
+		obj  metav1.Object
+		err  error
+		want finalizerCleanupDisposition
+	}{
+		{"nil error releases", objBeingDeleted(justDeleted), nil, releaseFinalizer},
+		{"not found releases", objBeingDeleted(justDeleted), errors.New("user not found"), releaseFinalizer},
+		{"database not found releases", objBeingDeleted(justDeleted), errors.New("database does not exist"), releaseFinalizer},
+		{"host gone releases immediately", objBeingDeleted(justDeleted), errors.New("dial tcp: lookup x: no such host"), releaseFinalizer},
+		{"transient connect retries within grace", objBeingDeleted(justDeleted), errors.New("connection refused"), retryCleanup},
+		{"transient connect releases after grace", objBeingDeleted(pastGrace), errors.New("connection refused"), releaseFinalizer},
+		{"driver connectivity wrapped retries within grace", objBeingDeleted(justDeleted), fmt.Errorf("drop: %w", &driver.ConnectivityError{Inner: errors.New("boom")}), retryCleanup},
+		{"unknown error retries within grace", objBeingDeleted(justDeleted), errors.New("some weird neo4j error"), retryCleanup},
+		{"unknown error releases after grace", objBeingDeleted(pastGrace), errors.New("some weird neo4j error"), releaseFinalizer},
+		// Defensive: no deletion timestamp is treated as "just started" so a
+		// transient error retries rather than releasing prematurely.
+		{"no deletion timestamp retries on transient", objBeingDeleted(0), errors.New("connection refused"), retryCleanup},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyFinalizerCleanup(tc.obj, tc.err); got != tc.want {
+				t.Fatalf("classifyFinalizerCleanup(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/controller/neo4jauthrule_controller.go
+++ b/internal/controller/neo4jauthrule_controller.go
@@ -313,9 +313,15 @@ func (r *Neo4jAuthRuleReconciler) handleDeletion(ctx context.Context, rule *neo4
 		ruleName = rule.Name
 	}
 	if err := nc.DropAuthRuleIfExists(ctx, ruleName); err != nil {
+		if classifyFinalizerCleanup(rule, err) == retryCleanup {
+			r.Recorder.Eventf(rule, corev1.EventTypeWarning, EventReasonAuthRuleFailed,
+				"DROP AUTH RULE %q failed, will retry: %v", ruleName, err)
+			return ctrl.Result{RequeueAfter: requeue}, nil
+		}
 		r.Recorder.Eventf(rule, corev1.EventTypeWarning, EventReasonAuthRuleFailed,
-			"DROP AUTH RULE %q failed: %v", ruleName, err)
-		return ctrl.Result{RequeueAfter: requeue}, err
+			"DROP AUTH RULE %q failed; releasing finalizer to avoid wedging deletion: %v", ruleName, err)
+		controllerutil.RemoveFinalizer(rule, Neo4jAuthRuleFinalizer)
+		return ctrl.Result{}, r.Update(ctx, rule)
 	}
 	r.Recorder.Eventf(rule, corev1.EventTypeNormal, EventReasonAuthRuleDeleted, "auth rule %q dropped", ruleName)
 

--- a/internal/controller/neo4jdatabase_controller.go
+++ b/internal/controller/neo4jdatabase_controller.go
@@ -319,9 +319,15 @@ func (r *Neo4jDatabaseReconciler) handleDeletion(ctx context.Context, database *
 	// Drop database
 	if err := neo4jClient.DropDatabase(ctx, database.Spec.Name); err != nil {
 		logger.Error(err, "Failed to drop database")
+		if classifyFinalizerCleanup(database, err) == retryCleanup {
+			r.Recorder.Eventf(database, corev1.EventTypeWarning, EventReasonDeletionFailed,
+				"Failed to drop database, will retry: %v", err)
+			return ctrl.Result{RequeueAfter: r.RequeueAfter}, nil
+		}
 		r.Recorder.Eventf(database, corev1.EventTypeWarning, EventReasonDeletionFailed,
-			"Failed to drop database: %v", err)
-		return ctrl.Result{RequeueAfter: r.RequeueAfter}, err
+			"Failed to drop database; releasing finalizer to avoid wedging deletion: %v", err)
+		controllerutil.RemoveFinalizer(database, DatabaseFinalizer)
+		return ctrl.Result{}, r.Update(ctx, database)
 	}
 
 	r.Recorder.Event(database, corev1.EventTypeNormal, EventReasonDatabaseDeleted, "Database dropped successfully")

--- a/internal/controller/neo4jrole_controller.go
+++ b/internal/controller/neo4jrole_controller.go
@@ -287,9 +287,15 @@ func (r *Neo4jRoleReconciler) handleDeletion(ctx context.Context, role *neo4jv1b
 	defer func() { _ = nc.Close() }()
 
 	if err := nc.DropRoleIfExists(ctx, roleName); err != nil {
+		if classifyFinalizerCleanup(role, err) == retryCleanup {
+			r.Recorder.Eventf(role, corev1.EventTypeWarning, EventReasonRoleDeletionFailed,
+				"DROP ROLE %q failed, will retry: %v", roleName, err)
+			return ctrl.Result{RequeueAfter: requeue}, nil
+		}
 		r.Recorder.Eventf(role, corev1.EventTypeWarning, EventReasonRoleDeletionFailed,
-			"DROP ROLE %q failed: %v", roleName, err)
-		return ctrl.Result{RequeueAfter: requeue}, err
+			"DROP ROLE %q failed; releasing finalizer to avoid wedging deletion: %v", roleName, err)
+		controllerutil.RemoveFinalizer(role, Neo4jRoleFinalizer)
+		return ctrl.Result{}, r.Update(ctx, role)
 	}
 
 	r.Recorder.Eventf(role, corev1.EventTypeNormal, EventReasonRoleDeleted, "Role %q dropped", roleName)

--- a/internal/controller/neo4jrolebinding_controller.go
+++ b/internal/controller/neo4jrolebinding_controller.go
@@ -277,17 +277,28 @@ func (r *Neo4jRoleBindingReconciler) handleDeletion(ctx context.Context, rb *neo
 	// We never touch roles we did not add — that's the whole point of
 	// non-exclusive bindings.
 	for _, role := range rb.Status.GrantedRoles {
-		if err := nc.RevokeRoleFromUser(ctx, role, rb.Spec.Username); err != nil {
-			if classifyFinalizerCleanup(rb, err) == retryCleanup {
-				r.Recorder.Eventf(rb, corev1.EventTypeWarning, EventReasonBindingFailed,
-					"revoke %q from %q failed, will retry: %v", role, rb.Spec.Username, err)
-				return ctrl.Result{RequeueAfter: requeue}, nil
-			}
-			r.Recorder.Eventf(rb, corev1.EventTypeWarning, EventReasonBindingFailed,
-				"revoke %q from %q failed; releasing finalizer to avoid wedging deletion: %v", role, rb.Spec.Username, err)
-			controllerutil.RemoveFinalizer(rb, Neo4jRoleBindingFinalizer)
-			return ctrl.Result{}, r.Update(ctx, rb)
+		err := nc.RevokeRoleFromUser(ctx, role, rb.Spec.Username)
+		if err == nil {
+			continue
 		}
+		// A "not found" for this grant (the user lacks the role, or the
+		// role/user is already gone) means THIS revoke is satisfied. Skip it
+		// and keep revoking the rest — don't abandon the remaining grants the
+		// way a host-level failure would.
+		if isAlreadyGoneCleanup(err) {
+			continue
+		}
+		if classifyFinalizerCleanup(rb, err) == retryCleanup {
+			r.Recorder.Eventf(rb, corev1.EventTypeWarning, EventReasonBindingFailed,
+				"revoke %q from %q failed, will retry: %v", role, rb.Spec.Username, err)
+			return ctrl.Result{RequeueAfter: requeue}, nil
+		}
+		// Host gone or grace period exceeded: the remaining revokes would fail
+		// the same way, so release the finalizer rather than wedge deletion.
+		r.Recorder.Eventf(rb, corev1.EventTypeWarning, EventReasonBindingFailed,
+			"revoke %q from %q failed; releasing finalizer to avoid wedging deletion: %v", role, rb.Spec.Username, err)
+		controllerutil.RemoveFinalizer(rb, Neo4jRoleBindingFinalizer)
+		return ctrl.Result{}, r.Update(ctx, rb)
 	}
 	r.Recorder.Eventf(rb, corev1.EventTypeNormal, EventReasonBindingDeleted,
 		"revoked %d role(s) from user %q", len(rb.Status.GrantedRoles), rb.Spec.Username)

--- a/internal/controller/neo4jrolebinding_controller.go
+++ b/internal/controller/neo4jrolebinding_controller.go
@@ -278,9 +278,15 @@ func (r *Neo4jRoleBindingReconciler) handleDeletion(ctx context.Context, rb *neo
 	// non-exclusive bindings.
 	for _, role := range rb.Status.GrantedRoles {
 		if err := nc.RevokeRoleFromUser(ctx, role, rb.Spec.Username); err != nil {
+			if classifyFinalizerCleanup(rb, err) == retryCleanup {
+				r.Recorder.Eventf(rb, corev1.EventTypeWarning, EventReasonBindingFailed,
+					"revoke %q from %q failed, will retry: %v", role, rb.Spec.Username, err)
+				return ctrl.Result{RequeueAfter: requeue}, nil
+			}
 			r.Recorder.Eventf(rb, corev1.EventTypeWarning, EventReasonBindingFailed,
-				"revoke %q from %q failed: %v", role, rb.Spec.Username, err)
-			return ctrl.Result{RequeueAfter: requeue}, err
+				"revoke %q from %q failed; releasing finalizer to avoid wedging deletion: %v", role, rb.Spec.Username, err)
+			controllerutil.RemoveFinalizer(rb, Neo4jRoleBindingFinalizer)
+			return ctrl.Result{}, r.Update(ctx, rb)
 		}
 	}
 	r.Recorder.Eventf(rb, corev1.EventTypeNormal, EventReasonBindingDeleted,

--- a/internal/controller/neo4juser_controller.go
+++ b/internal/controller/neo4juser_controller.go
@@ -325,9 +325,15 @@ func (r *Neo4jUserReconciler) handleDeletion(ctx context.Context, user *neo4jv1b
 	defer func() { _ = nc.Close() }()
 
 	if err := nc.DropUserIfExists(ctx, username); err != nil {
+		if classifyFinalizerCleanup(user, err) == retryCleanup {
+			r.Recorder.Eventf(user, corev1.EventTypeWarning, EventReasonUserDeletionFailed,
+				"DROP USER %q failed, will retry: %v", username, err)
+			return ctrl.Result{RequeueAfter: requeue}, nil
+		}
 		r.Recorder.Eventf(user, corev1.EventTypeWarning, EventReasonUserDeletionFailed,
-			"DROP USER %q failed: %v", username, err)
-		return ctrl.Result{RequeueAfter: requeue}, err
+			"DROP USER %q failed; releasing finalizer to avoid wedging deletion: %v", username, err)
+		controllerutil.RemoveFinalizer(user, Neo4jUserFinalizer)
+		return ctrl.Result{}, r.Update(ctx, user)
 	}
 	r.Recorder.Eventf(user, corev1.EventTypeNormal, EventReasonUserDeleted, "User %q dropped", username)
 	controllerutil.RemoveFinalizer(user, Neo4jUserFinalizer)

--- a/internal/neo4j/error_classify.go
+++ b/internal/neo4j/error_classify.go
@@ -32,26 +32,22 @@ func IsTransientError(err error) bool {
 }
 
 // IsHostUnresolvableError reports whether err indicates the Neo4j host's DNS
-// name no longer resolves — the signal that the Service (and almost always the
-// whole cluster/standalone) has been deleted. Distinct from a transient
-// connect failure (IsConnectivityError): a vanished DNS name will not come
-// back on its own, so finalizer cleanup against it is a permanent no-op and the
-// finalizer can be released immediately.
+// name authoritatively does not exist — the signal that the Service (and almost
+// always the whole cluster/standalone) has been deleted. Distinct from a
+// transient connect failure (IsConnectivityError): a vanished DNS name will not
+// come back on its own, so finalizer cleanup against it is a permanent no-op and
+// the finalizer can be released immediately.
+//
+// Matches ONLY "no such host" — Go's rendering of an NXDOMAIN (the name does not
+// exist). It deliberately excludes "temporary failure in name resolution"
+// (SERVFAIL) and "server misbehaving", which are transient resolver hiccups
+// while the cluster is still up; those fall through to the bounded-retry bucket
+// rather than releasing the finalizer prematurely.
 func IsHostUnresolvableError(err error) bool {
 	if err == nil {
 		return false
 	}
-	msg := strings.ToLower(err.Error())
-	for _, marker := range []string{
-		"no such host",
-		"name resolution",
-		"server misbehaving",
-	} {
-		if strings.Contains(msg, marker) {
-			return true
-		}
-	}
-	return false
+	return strings.Contains(strings.ToLower(err.Error()), "no such host")
 }
 
 // IsConnectivityError reports whether err indicates the operator could not

--- a/internal/neo4j/error_classify.go
+++ b/internal/neo4j/error_classify.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package neo4j
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+)
+
+// IsTransientError reports whether err is a transient Neo4j error worth
+// retrying (driver-classified retryable, or a conflicting-transaction-state
+// marker). Exported wrapper around the package-internal classifier so callers
+// outside this package (e.g. controller finalizer cleanup) can reuse it.
+func IsTransientError(err error) bool {
+	return isTransientNeo4jError(err)
+}
+
+// IsHostUnresolvableError reports whether err indicates the Neo4j host's DNS
+// name no longer resolves — the signal that the Service (and almost always the
+// whole cluster/standalone) has been deleted. Distinct from a transient
+// connect failure (IsConnectivityError): a vanished DNS name will not come
+// back on its own, so finalizer cleanup against it is a permanent no-op and the
+// finalizer can be released immediately.
+func IsHostUnresolvableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, marker := range []string{
+		"no such host",
+		"name resolution",
+		"server misbehaving",
+	} {
+		if strings.Contains(msg, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsConnectivityError reports whether err indicates the operator could not
+// reach the Neo4j server even though its host still resolves: connection
+// refused (pod down/restarting), connect timeout, reset, or a routing-table
+// fetch failure. These are typically transient (a rolling restart, a
+// not-yet-ready pod), so callers should retry rather than give up immediately.
+//
+// The driver's own neo4j.IsConnectivityError uses a bare type assertion, so it
+// returns false once the error has been wrapped with %w (as every drop/revoke
+// helper in this package does). We unwrap with errors.As so wrapped driver
+// errors are still recognised, then fall back to matching the common
+// network-failure substrings the driver surfaces as plain strings.
+//
+// DNS-resolution failures are deliberately excluded here — see
+// IsHostUnresolvableError, which callers should check first.
+func IsConnectivityError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var ce *neo4j.ConnectivityError
+	if errors.As(err, &ce) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	for _, marker := range []string{
+		"connection refused",
+		"i/o timeout",
+		"connection reset",
+		"broken pipe",
+		"unable to retrieve routing table",
+		"could not perform discovery",
+		"server is shutting down",
+		"dial tcp",
+	} {
+		if strings.Contains(msg, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsNotFoundError reports whether err indicates the target object (database,
+// user, or role) does not exist — i.e. a drop/revoke is already satisfied and
+// can be treated as idempotent success.
+func IsNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if isDatabaseNotFoundError(err) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "not found") ||
+		strings.Contains(msg, "does not exist")
+}

--- a/internal/neo4j/error_classify_test.go
+++ b/internal/neo4j/error_classify_test.go
@@ -33,10 +33,12 @@ func TestIsHostUnresolvableError(t *testing.T) {
 		want bool
 	}{
 		{"nil", nil, false},
-		{"no such host", errors.New("dial tcp: lookup my-cluster-server.ns.svc.cluster.local: no such host"), true},
-		{"name resolution", errors.New("temporary failure in name resolution"), true},
-		{"server misbehaving", errors.New("lookup foo: server misbehaving"), true},
+		{"no such host (NXDOMAIN)", errors.New("dial tcp: lookup my-cluster-server.ns.svc.cluster.local: no such host"), true},
 		{"wrapped no such host", fmt.Errorf("failed to drop user bob: %w", errors.New("no such host")), true},
+		// Transient resolver failures must NOT be treated as host-gone — they
+		// take the bounded-retry path so a DNS blip doesn't skip cleanup.
+		{"temporary name-resolution failure is transient", errors.New("temporary failure in name resolution"), false},
+		{"server misbehaving is transient", errors.New("lookup foo: server misbehaving"), false},
 		{"connection refused is not host-gone", errors.New("dial tcp 10.0.0.1:7687: connect: connection refused"), false},
 		{"not found is not host-gone", errors.New("user not found"), false},
 	}

--- a/internal/neo4j/error_classify_test.go
+++ b/internal/neo4j/error_classify_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package neo4j_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	driver "github.com/neo4j/neo4j-go-driver/v5/neo4j"
+
+	"github.com/neo4j-partners/neo4j-kubernetes-operator/internal/neo4j"
+)
+
+func TestIsHostUnresolvableError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"no such host", errors.New("dial tcp: lookup my-cluster-server.ns.svc.cluster.local: no such host"), true},
+		{"name resolution", errors.New("temporary failure in name resolution"), true},
+		{"server misbehaving", errors.New("lookup foo: server misbehaving"), true},
+		{"wrapped no such host", fmt.Errorf("failed to drop user bob: %w", errors.New("no such host")), true},
+		{"connection refused is not host-gone", errors.New("dial tcp 10.0.0.1:7687: connect: connection refused"), false},
+		{"not found is not host-gone", errors.New("user not found"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := neo4j.IsHostUnresolvableError(tc.err); got != tc.want {
+				t.Fatalf("IsHostUnresolvableError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsConnectivityError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"connection refused", errors.New("dial tcp 10.0.0.1:7687: connect: connection refused"), true},
+		{"i/o timeout", errors.New("read tcp: i/o timeout"), true},
+		{"connection reset", errors.New("connection reset by peer"), true},
+		{"routing table", errors.New("unable to retrieve routing table from any of the servers"), true},
+		// The driver's own helper uses a bare type assertion; ours must still
+		// see through a %w wrap via errors.As.
+		{"driver ConnectivityError direct", &driver.ConnectivityError{Inner: errors.New("boom")}, true},
+		{"driver ConnectivityError wrapped", fmt.Errorf("drop failed: %w", &driver.ConnectivityError{Inner: errors.New("boom")}), true},
+		{"host gone is not transient connectivity", errors.New("no such host"), false},
+		{"not found is not connectivity", errors.New("database not found"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := neo4j.IsConnectivityError(tc.err); got != tc.want {
+				t.Fatalf("IsConnectivityError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsNotFoundError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"database not found", errors.New("Neo.ClientError.Database.DatabaseNotFound: database not found"), true},
+		{"does not exist", errors.New("role `auditor` does not exist"), true},
+		{"user not found", errors.New("user not found"), true},
+		{"wrapped", fmt.Errorf("failed to drop database mydb: %w", errors.New("database does not exist")), true},
+		{"connection refused is not not-found", errors.New("connection refused"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := neo4j.IsNotFoundError(tc.err); got != tc.want {
+				t.Fatalf("IsNotFoundError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

The five CRs whose deletion runs Cypher against Neo4j — `Neo4jUser`, `Neo4jRole`, `Neo4jRoleBinding`, `Neo4jAuthRule`, `Neo4jDatabase` — all returned the drop/revoke error **unclassified**, keeping the finalizer and requeuing forever:

```go
if err := nc.DropUserIfExists(ctx, username); err != nil {
    r.Recorder.Eventf(...)
    return ctrl.Result{RequeueAfter: requeue}, err   // finalizer never released
}
```

The Go driver connects **lazily**, so a host-gone failure surfaces at *drop* time, not at client construction. Deleting the Neo4j cluster/standalone first therefore left every dependent CR **permanently undeletable** (stuck on its finalizer) — a real wedge that required manual `kubectl patch` finalizer removal.

## Fix

One shared deletion-cleanup policy used by all five handlers:

| Condition | Disposition |
|---|---|
| cleanup succeeded / target already gone (not found) | **release** |
| host DNS no longer resolves (Service/cluster deleted) | **release** |
| transient connect / conflicting-txn / unknown | **retry** until a 5m grace window since deletion was requested elapses, then **release** rather than wedge |

- Error classification → `internal/neo4j/error_classify.go`: `IsTransientError`, `IsHostUnresolvableError`, `IsConnectivityError`, `IsNotFoundError`.
- Grace-bounded disposition → `internal/controller/finalizer_deletion.go`: `classifyFinalizerCleanup`.
- `IsConnectivityError` uses `errors.As` so the driver's `ConnectivityError` is recognised through `%w` wrapping — the driver's own `IsConnectivityError` uses a bare type assertion and would silently miss wrapped errors.
- The host-gone vs transient split is deliberate: a vanished DNS name (cluster deleted) won't return, so we release immediately; a "connection refused" (pod restarting) might, so we retry within the window.
- Retry now returns `(RequeueAfter, nil)` instead of `(RequeueAfter, err)` so the requeue interval is honoured instead of controller-runtime's exponential backoff.

## Tests

- `internal/neo4j`: `TestIsHostUnresolvableError`, `TestIsConnectivityError` (incl. `%w`-wrapped driver error), `TestIsNotFoundError`.
- `internal/controller`: `TestClassifyFinalizerCleanup` (10 cases incl. grace-window boundary).
- Full controller envtest + neo4j unit suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deletion/finalizer behavior across five controllers: CRs may delete while Neo4j objects remain after grace-period failures, which is intentional but operators should understand orphaned-resource risk.
> 
> **Overview**
> Fixes **Neo4j-backed CRs stuck in deletion** when drop/revoke fails (especially after the cluster is gone): finalizers no longer requeue forever on every error.
> 
> Introduces shared **`classifyFinalizerCleanup`** policy (5-minute grace from `DeletionTimestamp`): release on success, not-found, or NXDOMAIN (`no such host`); retry transient/unknown errors until grace expires, then **release the finalizer** with a warning instead of wedging. Retries return **`RequeueAfter` with `nil` error** so the configured interval is used, not exponential backoff from returning `err`.
> 
> Adds **`internal/neo4j/error_classify.go`** helpers (`IsNotFoundError`, `IsHostUnresolvableError`, `IsConnectivityError`, etc.) and wires them into deletion handlers for **Neo4jUser**, **Neo4jRole**, **Neo4jRoleBinding** (per-grant `isAlreadyGoneCleanup` so not-found skips one revoke without abandoning the loop), **Neo4jAuthRule**, and **Neo4jDatabase**. Unit tests cover classification and disposition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a623f81d5cbbc7264fff55b7cfabd63621b546a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->