### PR TITLE
docs: install discoverability (#177), strict_validation/db.format drift, NOTES quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ helm install neo4j-operator neo4j-operator/neo4j-operator \
   --namespace neo4j-operator-system --create-namespace
 ```
 
+Prefer plain `kubectl`? Each release attaches a single apply-able bundle
+(CRDs + RBAC + Deployment) as a **Release asset** — it's not a file in the repo,
+download it from the `releases/download/<tag>/` URL:
+
+```bash
+kubectl apply -f https://github.com/neo4j-partners/neo4j-kubernetes-operator/releases/download/v1.11.2/neo4j-kubernetes-operator-complete.yaml
+```
+
+See the [Installation guide](https://neo4j-partners.github.io/neo4j-kubernetes-operator/main/user_guide/installation/#method-3-quick-install-from-github-release) for CRDs-only and latest-version variants.
+
 Create admin credentials and deploy your first instance:
 
 ```bash

--- a/charts/neo4j-operator/templates/NOTES.txt
+++ b/charts/neo4j-operator/templates/NOTES.txt
@@ -49,7 +49,7 @@ Verify CRDs are installed:
        repo: {{ $repo | quote }}
        tag: {{ $tag | quote }}
      storage:
-       size: 10Gi
+       size: {{ .Values.neo4j.defaultStorageSize | quote }}
      auth:
        adminSecret: neo4j-admin-secret
    EOF
@@ -67,7 +67,7 @@ Verify CRDs are installed:
      topology:
        servers: 3
      storage:
-       size: 10Gi
+       size: {{ .Values.neo4j.defaultStorageSize | quote }}
      auth:
        adminSecret: neo4j-admin-secret
    EOF

--- a/charts/neo4j-operator/templates/NOTES.txt
+++ b/charts/neo4j-operator/templates/NOTES.txt
@@ -26,6 +26,13 @@ Verify CRDs are installed:
 
 ## Quick Start
 
+{{- /* spec.image is an object (repo/tag), not a string. Split the
+       repo:tag default image so the rendered manifests are schema-valid.
+       tag = segment after the last ':'; repo = everything before it (so a
+       registry:port prefix survives). */ -}}
+{{- $tag := .Values.neo4j.defaultImage | splitList ":" | last }}
+{{- $repo := trimSuffix (printf ":%s" $tag) .Values.neo4j.defaultImage }}
+
 1. Create a secret for Neo4j authentication:
    kubectl create secret generic neo4j-admin-secret \
      --from-literal=username=neo4j \
@@ -38,7 +45,11 @@ Verify CRDs are installed:
    metadata:
      name: my-neo4j
    spec:
-     image: {{ .Values.neo4j.defaultImage }}
+     image:
+       repo: {{ $repo | quote }}
+       tag: {{ $tag | quote }}
+     storage:
+       size: 10Gi
      auth:
        adminSecret: neo4j-admin-secret
    EOF
@@ -50,9 +61,13 @@ Verify CRDs are installed:
    metadata:
      name: my-cluster
    spec:
-     image: {{ .Values.neo4j.defaultImage }}
+     image:
+       repo: {{ $repo | quote }}
+       tag: {{ $tag | quote }}
      topology:
        servers: 3
+     storage:
+       size: 10Gi
      auth:
        adminSecret: neo4j-admin-secret
    EOF

--- a/docs/user_guide/configuration.md
+++ b/docs/user_guide/configuration.md
@@ -254,7 +254,7 @@ TLS is configured via `spec.tls`, not `spec.config`. Setting any of the followin
 - `dbms.ssl.policy.{bolt,https,cluster}.*` (full SSL policy block is operator-managed)
 - `server.directories.certificates`
 
-The pre-5.x `dbms.connector.{https,bolt}.*` keys are deprecated and superseded by the `server.*` namespace (`spec.tls` replaces the TLS-related ones). Reason for rejecting the keys above: Neo4j runs with `server.config.strict_validation.enabled=false`, so duplicate keys silently override each other; the validator blocks user values that would shadow operator-managed ones. See the [TLS certificates guide](tls_configuration.md) for the full TLS surface.
+The pre-5.x `dbms.connector.{https,bolt}.*` keys are deprecated and superseded by the `server.*` namespace (`spec.tls` replaces the TLS-related ones). Reason for rejecting the keys above: the operator runs Neo4j with `server.config.strict_validation.enabled=true`, so a duplicate or unknown key in the rendered `neo4j.conf` makes Neo4j **fail to start** rather than being silently dropped; the validator blocks user values that would shadow operator-managed ones before they can wedge startup. See the [TLS certificates guide](tls_configuration.md) for the full TLS surface.
 
 ### Cluster discovery — operator-managed, off-limits in `spec.config`
 
@@ -275,7 +275,7 @@ See the [Clustering guide](clustering.md) for what the operator writes for each 
 | `dbms.memory.*` | Deprecated | `server.memory.*` |
 | `dbms.connector.*` | Deprecated | `server.bolt.*` / `server.http.*` / `server.https.*` (or `spec.tls`) |
 | `causal_clustering.*` | Removed in 5.x | `dbms.cluster.*` |
-| `db.format=standard` / `db.format=high_limit` | Deprecated since 5.23 | `db.format=block` |
+| `db.format` (any value) | Operator-managed | Don't set in `spec.config` — the operator already emits `db.format=block` and the validator rejects a user-set `db.format` (a duplicate key fails startup under strict validation). `standard`/`high_limit` are also deprecated since 5.23. |
 | `server.groups` | Deprecated | `initial.server.tags` |
 | `dbms.logs.query.*` | Deprecated namespace | `db.logs.query.*` |
 | `dbms.cluster.role` | Removed in 5.0 | `SHOW DATABASES` / `SHOW SERVERS` |
@@ -355,7 +355,7 @@ If you're moving from Neo4j 4.x or an early 5.x release:
 2. `dbms.connector.*` → `server.bolt.*` / `server.http.*` / `server.https.*` (and TLS via `spec.tls`)
 3. Remove any `dbms.mode=SINGLE` — there is no replacement; use `Neo4jEnterpriseStandalone` instead
 4. `causal_clustering.*` → `dbms.cluster.*` (most discovery keys are now operator-managed anyway)
-5. `db.format=standard` / `db.format=high_limit` → `db.format=block` for new databases
+5. Remove any `db.format` from `spec.config` — the operator already emits `db.format=block` (the modern default) and the validator rejects a user-set `db.format`. To choose a non-default store format, set it per database via `Neo4jDatabase` `CREATE DATABASE` options, not cluster/standalone `spec.config`.
 6. `dbms.logs.query.*` → `db.logs.query.*`
 
 See the [Migration Guide](migration_guide.md) for operator-level migration steps (removed CRD fields, etc.).

--- a/docs/user_guide/installation.md
+++ b/docs/user_guide/installation.md
@@ -65,11 +65,26 @@ Use the chart version without the `v` prefix (for example, `1.10.2`).
 
 ### Method 3: Quick Install from GitHub Release
 
-For environments where running `helm` is inconvenient, every release also publishes a single kubectl-applyable YAML bundle:
+For environments where running `helm` is inconvenient, every release also publishes a single kubectl-applyable YAML bundle.
+
+> **These are GitHub *Release assets*, not files in the repository.** You won't
+> find `neo4j-kubernetes-operator-complete.yaml` by browsing the source tree on
+> the **Code** tab — it's attached to each tagged release under
+> [**Releases**](https://github.com/neo4j-partners/neo4j-kubernetes-operator/releases)
+> → *Assets*, and built fresh by the release pipeline. Download it from the
+> `releases/download/<tag>/` URL below (substitute a real `<tag>` for
+> `${RELEASE_VERSION}`).
 
 ```bash
 RELEASE_VERSION=v1.10.2  # Replace with desired version
 
+kubectl apply -f https://github.com/neo4j-partners/neo4j-kubernetes-operator/releases/download/${RELEASE_VERSION}/neo4j-kubernetes-operator-complete.yaml
+```
+
+To always pull the latest published release:
+
+```bash
+RELEASE_VERSION=$(gh release list --repo neo4j-partners/neo4j-kubernetes-operator --limit 1 --json tagName --jq '.[0].tagName')
 kubectl apply -f https://github.com/neo4j-partners/neo4j-kubernetes-operator/releases/download/${RELEASE_VERSION}/neo4j-kubernetes-operator-complete.yaml
 ```
 

--- a/docs/user_guide/security.md
+++ b/docs/user_guide/security.md
@@ -63,10 +63,10 @@ spec:
 > Do NOT set `dbms.ssl.policy.*`, `server.bolt.tls_level`, or
 > `server.directories.certificates` in `spec.config`. The cluster
 > validator rejects every key in that namespace with a `Forbidden`
-> error at apply time. The reason: `server.config.strict_validation.
-> enabled=false` lets Neo4j silently honour duplicate-key overrides,
-> so a user value would shadow operator-managed configuration without
-> any warning at startup.
+> error at apply time. The reason: the operator runs Neo4j with
+> `server.config.strict_validation.enabled=true`, so a duplicate key
+> from `spec.config` would make Neo4j **fail to start** — the validator
+> blocks it up front rather than letting it wedge the pod.
 >
 > When `spec.tls.mode: cert-manager` and `spec.tls.strictPeerValidation:
 > true` (the default), the operator emits Neo4j's canonical production

--- a/docs/user_guide/tls_configuration.md
+++ b/docs/user_guide/tls_configuration.md
@@ -89,7 +89,7 @@ The opt-out exists for installations whose external issuer (e.g. some custom `AW
 
 ### Hands off the SSL policy keys
 
-> **Do not set `dbms.ssl.policy.*` keys in `spec.config`.** The operator owns the SSL policy surface end-to-end. The cluster validator rejects any `dbms.ssl.policy.*` / `server.bolt.tls_level` / `server.directories.certificates` key in `spec.config` with a `Forbidden` error at apply time, because user values would silently override operator-managed configuration (`server.config.strict_validation.enabled=false` makes Neo4j accept duplicates without warning).
+> **Do not set `dbms.ssl.policy.*` keys in `spec.config`.** The operator owns the SSL policy surface end-to-end. The cluster validator rejects any `dbms.ssl.policy.*` / `server.bolt.tls_level` / `server.directories.certificates` key in `spec.config` with a `Forbidden` error at apply time, because the operator runs Neo4j with `server.config.strict_validation.enabled=true` — a duplicate key from `spec.config` would make Neo4j fail to start, so the validator blocks it before it can wedge the pod.
 
 ### Bolt client-certificate auth is not exposed today
 

--- a/internal/validation/config_validator.go
+++ b/internal/validation/config_validator.go
@@ -53,8 +53,7 @@ func (v *ConfigValidator) Validate(cluster *neo4jv1beta1.Neo4jEnterpriseCluster)
 
 	// Check for deprecated configuration settings
 	deprecatedSettings := map[string]string{
-		"dbms.default_database": "use dbms.setDefaultDatabase() procedure instead",
-		"db.format":             "standard and high_limit formats are deprecated, use block format",
+		"dbms.default_database":                     "use dbms.setDefaultDatabase() procedure instead",
 		"dbms.integrations.cloud_storage.s3.region": "replaced by new cloud storage integration settings",
 		"dbms.logs.query.enabled":                   "renamed to db.logs.query.enabled in Neo4j 5.x+",
 	}
@@ -174,15 +173,19 @@ func (v *ConfigValidator) Validate(cluster *neo4jv1beta1.Neo4jEnterpriseCluster)
 			))
 		}
 
-		// Validate database format settings
+		// db.format is operator-managed. The operator always emits
+		// db.format=block and runs Neo4j with strict_validation=true, so a
+		// user-set db.format — block included — is a duplicate key that makes
+		// Neo4j fail to start. Reject every value (the message says so plainly,
+		// rather than implying the user should "use block" as the old check
+		// did). The operator only ever uses block; when Neo4j ships additional
+		// store formats (e.g. MVCC) a format-switching surface will be designed
+		// then. Per-database format selection goes through Neo4jDatabase.
 		if configKey == "db.format" {
-			if configValue == "standard" || configValue == "high_limit" {
-				allErrs = append(allErrs, field.Invalid(
-					configPath.Child(configKey),
-					configValue,
-					"standard and high_limit database formats are deprecated, use block format",
-				))
-			}
+			allErrs = append(allErrs, field.Forbidden(
+				configPath.Child(configKey),
+				"db.format is managed by the operator (always 'block') and must not be set in spec.config; the operator emits it and runs with strict config validation, so a user value would fail Neo4j startup. To choose a non-default store format, set it per database via Neo4jDatabase CREATE DATABASE options.",
+			))
 		}
 
 		// Validate cloud storage integration settings

--- a/internal/validation/config_validator_test.go
+++ b/internal/validation/config_validator_test.go
@@ -298,6 +298,52 @@ func TestConfigValidator_DeprecatedKeys(t *testing.T) {
 	}
 }
 
+// TestConfigValidator_RejectsDbFormat pins that db.format is rejected for ANY
+// value — including "block" — because the operator emits db.format=block itself
+// and runs with strict_validation=true, so a user-set db.format is a duplicate
+// key that fails Neo4j startup. The rejection message must describe the key as
+// operator-managed, not tell the user to "use block" (which the old check did
+// even when the user had already passed block).
+func TestConfigValidator_RejectsDbFormat(t *testing.T) {
+	validator := NewConfigValidator()
+
+	for _, value := range []string{"block", "high_limit", "standard", "aligned"} {
+		t.Run("db.format="+value, func(t *testing.T) {
+			cluster := &neo4jv1beta1.Neo4jEnterpriseCluster{
+				Spec: neo4jv1beta1.Neo4jEnterpriseClusterSpec{
+					Config: map[string]string{"db.format": value},
+				},
+			}
+
+			errs := validator.Validate(cluster)
+
+			var dbFormatErr *field.Error
+			for _, e := range errs {
+				if e.Field == "spec.config.db.format" {
+					dbFormatErr = e
+					break
+				}
+			}
+			if dbFormatErr == nil {
+				t.Fatalf("expected db.format=%q to be rejected, got errors: %v", value, errs)
+			}
+			// Exactly one error for the key (the old code double-reported
+			// standard/high_limit via both the deprecated map and a dedicated
+			// check).
+			count := 0
+			for _, e := range errs {
+				if e.Field == "spec.config.db.format" {
+					count++
+				}
+			}
+			assert.Equal(t, 1, count, "expected exactly one db.format error, got %d: %v", count, errs)
+			assert.Equal(t, field.ErrorTypeForbidden, dbFormatErr.Type)
+			assert.Contains(t, dbFormatErr.Detail, "managed by the operator")
+			assert.NotContains(t, dbFormatErr.Detail, "use block", "message must not tell the user to set block")
+		})
+	}
+}
+
 func TestConfigValidator_ValidDiscoveryVersion(t *testing.T) {
 	validator := NewConfigValidator()
 

--- a/internal/validation/standalone_validator.go
+++ b/internal/validation/standalone_validator.go
@@ -276,6 +276,20 @@ func (v *StandaloneValidator) validateConfig(standalone *neo4jv1beta1.Neo4jEnter
 		))
 	}
 
+	// db.format is not configurable. The operator standardizes on the 'block'
+	// store format (Neo4j's default for 5.26+) and nothing else — unlike the
+	// cluster path, standalone relies on that default rather than emitting
+	// db.format, so a user value here would actually take effect and quietly
+	// switch the store format. Reject it. (When Neo4j ships additional store
+	// formats, e.g. MVCC, a format-switching surface will be designed then.)
+	// Per-database format selection goes through Neo4jDatabase.
+	if _, exists := standalone.Spec.Config["db.format"]; exists {
+		allErrs = append(allErrs, field.Forbidden(
+			configPath.Key("db.format"),
+			"db.format is managed by the operator (always 'block') and must not be set in spec.config. To choose a non-default store format, set it per database via Neo4jDatabase CREATE DATABASE options.",
+		))
+	}
+
 	// SSL policies are managed end-to-end by the operator via spec.tls.
 	// Reject user-set dbms.ssl.policy.* / server.bolt.tls_level /
 	// server.directories.certificates. Same rationale as the cluster

--- a/internal/validation/standalone_validator.go
+++ b/internal/validation/standalone_validator.go
@@ -279,9 +279,10 @@ func (v *StandaloneValidator) validateConfig(standalone *neo4jv1beta1.Neo4jEnter
 	// SSL policies are managed end-to-end by the operator via spec.tls.
 	// Reject user-set dbms.ssl.policy.* / server.bolt.tls_level /
 	// server.directories.certificates. Same rationale as the cluster
-	// ConfigValidator — server.config.strict_validation.enabled=false
-	// means Neo4j silently honours later duplicates, so without this
-	// rejection a user could silently downgrade TLS posture via spec.config.
+	// ConfigValidator — Neo4j runs with server.config.strict_validation.
+	// enabled=true, so a duplicate key from spec.config would make Neo4j
+	// fail to start; rejecting it up front keeps the user from wedging the
+	// pod (and from silently downgrading TLS posture via spec.config).
 	for key, value := range standalone.Spec.Config {
 		if strings.HasPrefix(key, "dbms.ssl.policy.") ||
 			key == "server.bolt.tls_level" ||

--- a/internal/validation/standalone_validator_test.go
+++ b/internal/validation/standalone_validator_test.go
@@ -130,6 +130,22 @@ func TestStandaloneValidator_ValidateCreate(t *testing.T) {
 			wantErrs: 1,
 		},
 		{
+			name: "db.format=block in spec.config is rejected (operator-managed)",
+			mutate: func(s *neo4jv1beta1.Neo4jEnterpriseStandalone) {
+				s.Spec.Config = map[string]string{"db.format": "block"}
+			},
+			wantErrs: 1,
+			errField: "spec.config[db.format]",
+		},
+		{
+			name: "db.format=high_limit in spec.config is rejected",
+			mutate: func(s *neo4jv1beta1.Neo4jEnterpriseStandalone) {
+				s.Spec.Config = map[string]string{"db.format": "high_limit"}
+			},
+			wantErrs: 1,
+			errField: "spec.config[db.format]",
+		},
+		{
 			name: "invalid auth provider",
 			mutate: func(s *neo4jv1beta1.Neo4jEnterpriseStandalone) {
 				s.Spec.Auth = &neo4jv1beta1.AuthSpec{AuthenticationProviders: []string{"bogus-auth"}}


### PR DESCRIPTION
Documentation-accuracy fixes, including **#177**.

## #177 — `complete.yaml` "doesn't exist"

The reporter looked for `complete.yaml` in the repo source tree. It's a GitHub **Release asset** (`neo4j-kubernetes-operator-complete.yaml`), built fresh by the release pipeline and attached under *Releases → Assets* — verified present and `200`-downloadable on every recent release (v1.11.2, v1.10.2, …). So this is a discoverability gap, not a missing artifact:

- `installation.md` Method 3 now has an explicit callout that these are Release **assets**, not repo files, plus a latest-tag one-liner (`gh release list … --json tagName`).
- `README.md` Quick Start now shows the `kubectl apply` bundle install — it previously documented **only** Helm, so a user avoiding Helm had no signpost and went hunting in the repo.

## `strict_validation` drift

The operator now emits `server.config.strict_validation.enabled=true` (`internal/resources/cluster.go`), but `configuration.md`, `tls_configuration.md`, `security.md`, and a `standalone_validator.go` comment still claimed `=false` / "Neo4j silently honours duplicates". Under strict validation a duplicate or unknown key makes Neo4j **fail to start** — corrected the rationale in all four places.

## `db.format` drift

The operator emits `db.format=block` itself and the validator rejects a user-set `db.format` (a duplicate key would fail startup). Docs that said "use `db.format=block`" in `spec.config` were misleading; reframed as operator-managed, with per-database format going through `Neo4jDatabase` `CREATE DATABASE` options.

## NOTES.txt quickstart was schema-invalid

`spec.image` is an `ImageSpec` object (`repo`/`tag`), but the post-install quickstart rendered `image: <repo:tag string>` (CRD-rejected) and omitted the required `storage`. Now splits the chart's `repo:tag` `defaultImage` into a valid `image` object and adds `storage.size`, so a copy-paste actually applies. Verified with `helm install --dry-run=client`.

> A separate PR will fix the chart's `-metrics-auth-rolebinding` dangling roleRef + namespace-mode metrics RBAC (a functional chart bug, kept out of this docs PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly documentation and admission validation messaging; behavior change is stricter rejection of `db.format` in `spec.config`, which prevents misconfiguration rather than altering runtime paths.
> 
> **Overview**
> Improves **install discoverability** and aligns docs/validation with how the operator actually runs Neo4j.
> 
> **Installation:** README and the installation guide now explain that `neo4j-kubernetes-operator-complete.yaml` is a **GitHub Release asset** (not in the repo), with `kubectl apply` and optional `gh release list` for the latest tag.
> 
> **Helm post-install:** `NOTES.txt` quick-start examples now use a valid `spec.image` object (`repo`/`tag` split from chart defaults) and required `storage.size`, so copy-paste applies cleanly.
> 
> **Docs accuracy:** Configuration, security, and TLS guides now state Neo4j runs with **`server.config.strict_validation.enabled=true`** (duplicate/unknown keys fail startup, not silent overrides). **`db.format`** is documented as operator-managed (`block` on clusters); users are pointed to per-database format via `Neo4jDatabase` instead of `spec.config`.
> 
> **Validation:** Cluster `spec.config` rejects **any** `db.format` value with `Forbidden` (including `block`), matching operator-emitted config under strict validation. Standalone validation adds the same `db.format` rejection; tests cover cluster and standalone cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d760de6e0672e475059bf9397193301840aa631f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->