### PR TITLE
fix(chart): define metrics-auth-role; fix dangling roleRef + namespace-mode metrics RBAC

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -344,6 +344,7 @@ Several files are generated, not hand-written — each carries a `# This file is
 | `config/rbac/<crd>_{editor,viewer}_role.yaml` + kustomization | `spec.{group,names.plural,names.singular}` from each CRD base | `make sync-editor-viewer-roles` |
 | `charts/neo4j-operator/crds/*.yaml` | `config/crd/bases/*.yaml` | `make helm-sync-crds` |
 | `charts/neo4j-operator/templates/clusterrole.yaml` | `config/rbac/role.yaml` rules | `make helm-sync-rbac` |
+| `charts/neo4j-operator/templates/metrics-rbac.yaml` | `config/rbac/metrics_{auth,reader}_role.yaml` | `make helm-sync-rbac` |
 | `charts/neo4j-operator/Chart.yaml` (`artifacthub.io/crds`) | CRD bases + curated descriptions in `scripts/helm-sync-artifacthub-crds.sh` | `make helm-sync-artifacthub-crds` |
 | `bundle/manifests/*` and `bundle/metadata/*` (OperatorHub) | `config/manifests/bases/*.csv.yaml` + everything above | `make bundle` |
 

--- a/charts/neo4j-operator/templates/clusterrolebinding.yaml
+++ b/charts/neo4j-operator/templates/clusterrolebinding.yaml
@@ -13,19 +13,12 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "neo4j-operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ include "neo4j-operator.fullname" . }}-metrics-auth-rolebinding
-  labels:
-    {{- include "neo4j-operator.labels" . | nindent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ include "neo4j-operator.fullname" . }}-metrics-auth-role
-subjects:
-- kind: ServiceAccount
-  name: {{ include "neo4j-operator.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
 {{- end }}
+{{- /*
+  The metrics-auth ClusterRoleBinding used to live here, gated on
+  createClusterRole — which made it a dangling roleRef (the chart never defined
+  the metrics-auth-role ClusterRole) and skipped it entirely in namespace mode.
+  It now lives in the generated metrics-rbac.yaml, defined next to its
+  ClusterRole and gated on metrics.secure independent of operatorMode.
+  See scripts/helm-sync-rbac.sh.
+*/ -}}

--- a/charts/neo4j-operator/templates/metrics-rbac.yaml
+++ b/charts/neo4j-operator/templates/metrics-rbac.yaml
@@ -1,0 +1,62 @@
+# This file is GENERATED. DO NOT EDIT.
+#
+# Source of truth: config/rbac/metrics_auth_role.yaml + metrics_reader_role.yaml.
+# To change the metrics RBAC:
+#   1. Edit the relevant config/rbac/metrics_*_role.yaml base
+#   2. Run 'make helm-sync-rbac' (regenerates this file)
+#
+# CI's 'make check-drift' fails if this is out of sync.
+#
+# controller-runtime's secure metrics endpoint (metrics.secure=true) needs the
+# operator SA bound to the metrics-auth role so it can run TokenReview /
+# SubjectAccessReview on incoming scrapes; scrapers need the metrics-reader
+# role. Both ClusterRoles are cluster-scoped (the authn/authz APIs are
+# non-namespaced), so they are emitted in every operatorMode.
+{{- if and .Values.rbac.create .Values.metrics.enabled .Values.metrics.secure }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "neo4j-operator.fullname" . }}-metrics-auth-role
+  labels:
+    {{- include "neo4j-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+    - authentication.k8s.io
+  resources:
+    - tokenreviews
+  verbs:
+    - create
+- apiGroups:
+    - authorization.k8s.io
+  resources:
+    - subjectaccessreviews
+  verbs:
+    - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "neo4j-operator.fullname" . }}-metrics-auth-rolebinding
+  labels:
+    {{- include "neo4j-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "neo4j-operator.fullname" . }}-metrics-auth-role
+subjects:
+- kind: ServiceAccount
+  name: {{ include "neo4j-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "neo4j-operator.fullname" . }}-metrics-reader
+  labels:
+    {{- include "neo4j-operator.labels" . | nindent 4 }}
+rules:
+- nonResourceURLs:
+    - "/metrics"
+  verbs:
+    - get
+{{- end }}

--- a/scripts/helm-sync-rbac.sh
+++ b/scripts/helm-sync-rbac.sh
@@ -85,3 +85,84 @@ ${EXT_SECRETS_RULES}
 EOF
 
 echo "Wrote $DST from $SRC"
+
+# --- Metrics RBAC -----------------------------------------------------------
+# controller-runtime's secure metrics endpoint authenticates scrapers via
+# TokenReview and authorizes them via SubjectAccessReview. That requires the
+# operator's ServiceAccount to hold the metrics-auth role (create
+# tokenreviews + subjectaccessreviews); scrapers in turn must be bound to the
+# metrics-reader role (GET /metrics). Both are cluster-scoped — the
+# authentication.k8s.io / authorization.k8s.io APIs are non-namespaced — so
+# they are emitted regardless of operatorMode (unlike the manager role above,
+# which is a Role in namespace mode), gated only on secure metrics being on.
+#
+# Source of truth: config/rbac/metrics_auth_role.yaml + metrics_reader_role.yaml
+# (static kustomize bases). The kustomize binding hard-codes the
+# controller-manager SA + neo4j-operator-system namespace; the Helm template
+# substitutes the chart's serviceAccountName / Release.Namespace instead.
+METRICS_DST="${ROOT}/charts/neo4j-operator/templates/metrics-rbac.yaml"
+AUTH_SRC="${ROOT}/config/rbac/metrics_auth_role.yaml"
+READER_SRC="${ROOT}/config/rbac/metrics_reader_role.yaml"
+
+for f in "$AUTH_SRC" "$READER_SRC"; do
+    if [[ ! -f "$f" ]]; then
+        echo "error: $f not found." >&2
+        exit 1
+    fi
+done
+
+AUTH_RULES=$("$YQ" '.rules' "$AUTH_SRC")
+READER_RULES=$("$YQ" '.rules' "$READER_SRC")
+
+cat > "$METRICS_DST" <<EOF
+# This file is GENERATED. DO NOT EDIT.
+#
+# Source of truth: config/rbac/metrics_auth_role.yaml + metrics_reader_role.yaml.
+# To change the metrics RBAC:
+#   1. Edit the relevant config/rbac/metrics_*_role.yaml base
+#   2. Run 'make helm-sync-rbac' (regenerates this file)
+#
+# CI's 'make check-drift' fails if this is out of sync.
+#
+# controller-runtime's secure metrics endpoint (metrics.secure=true) needs the
+# operator SA bound to the metrics-auth role so it can run TokenReview /
+# SubjectAccessReview on incoming scrapes; scrapers need the metrics-reader
+# role. Both ClusterRoles are cluster-scoped (the authn/authz APIs are
+# non-namespaced), so they are emitted in every operatorMode.
+{{- if and .Values.rbac.create .Values.metrics.enabled .Values.metrics.secure }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "neo4j-operator.fullname" . }}-metrics-auth-role
+  labels:
+    {{- include "neo4j-operator.labels" . | nindent 4 }}
+rules:
+${AUTH_RULES}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "neo4j-operator.fullname" . }}-metrics-auth-rolebinding
+  labels:
+    {{- include "neo4j-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "neo4j-operator.fullname" . }}-metrics-auth-role
+subjects:
+- kind: ServiceAccount
+  name: {{ include "neo4j-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "neo4j-operator.fullname" . }}-metrics-reader
+  labels:
+    {{- include "neo4j-operator.labels" . | nindent 4 }}
+rules:
+${READER_RULES}
+{{- end }}
+EOF
+
+echo "Wrote $METRICS_DST from $AUTH_SRC + $READER_SRC"


### PR DESCRIPTION
## Problem

`charts/.../templates/clusterrolebinding.yaml` created a `<fullname>-metrics-auth-rolebinding` whose `roleRef` pointed at a `<fullname>-metrics-auth-role` ClusterRole **that the chart never defined** — a dangling roleRef. controller-runtime's secure metrics endpoint (`metrics.secure=true`, the chart default) authenticates scrapers via `TokenReview` and authorizes via `SubjectAccessReview`, so without that role bound to the operator SA every scrape gets 401/403.

Two compounding bugs:
1. **Dangling roleRef** — the `metrics-auth-role` ClusterRole exists in `config/rbac/` (kustomize distribution) but was never ported to the Helm chart.
2. **Namespace-mode gap** — the binding was gated on `createClusterRole`, so `operatorMode=namespace` got **no** metrics-auth RBAC, even though `tokenreviews`/`subjectaccessreviews` are cluster-scoped and required in every mode.

## Fix — and the chart-sync now owns this path

Per the request to make chart-syncing cover this path so it can't drift again, I extended the generator rather than hand-adding a template:

- **`scripts/helm-sync-rbac.sh`** now also generates `templates/metrics-rbac.yaml` from `config/rbac/metrics_{auth,reader}_role.yaml` — the same source of truth the kustomize distribution uses. It emits the metrics-auth ClusterRole + its ClusterRoleBinding (wired to the chart's `serviceAccountName` / `Release.Namespace`) and the metrics-reader ClusterRole, gated on `rbac.create AND metrics.enabled AND metrics.secure`, **independent of `operatorMode`**.
- Removed the duplicate/dangling metrics-auth binding from `clusterrolebinding.yaml`.
- Recorded the new generated file in CLAUDE.md's generated-artifacts table.

## Automations don't break (verified)

- `make helm-sync-rbac` and `make sync-all` regenerate `metrics-rbac.yaml` **idempotently** — committed output is byte-identical, so **`make check-drift`** stays green (pre-commit's "generated artifacts in sync" hook passed on commit).
- `helm lint` → 0 failures.
- `helm template` renders the roles in both `cluster` and `namespace` modes, and omits all of them when `metrics.secure=false` (only the generated YAML comment header remains, same harmless pattern as the existing `clusterrole.yaml`).
- The kustomize / `complete.yaml` distribution is unaffected (it already ships these via `config/rbac`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster-scoped RBAC for metrics authentication/authorization; low blast radius because it aligns Helm with existing kustomize rules and only applies when secure metrics is enabled.
> 
> **Overview**
> Fixes broken Helm metrics RBAC for **secure metrics** (`metrics.secure=true`): the chart previously created a `metrics-auth-rolebinding` pointing at a **ClusterRole that was never rendered**, and skipped that binding in some **namespace** installs because it was tied to `createClusterRole`.
> 
> **`make helm-sync-rbac`** now also emits generated **`metrics-rbac.yaml`** from `config/rbac/metrics_{auth,reader}_role.yaml` (same source as kustomize), defining the metrics-auth ClusterRole + binding (chart SA/namespace) and metrics-reader ClusterRole. Rendering is gated on **`rbac.create` + `metrics.enabled` + `metrics.secure`**, not `operatorMode`. The duplicate binding is removed from **`clusterrolebinding.yaml`**; **`CLAUDE.md`** documents the new generated artifact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 802ff5a1fed449775934b51b595964c43c827062. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->