### PR TITLE
fix(standalone): widen startup probe budget to ~10m (matches cluster) — fixes LTS standalone timeouts

### DIFF
--- a/internal/controller/neo4jenterprisestandalone_controller.go
+++ b/internal/controller/neo4jenterprisestandalone_controller.go
@@ -1338,11 +1338,19 @@ func buildStandaloneStartupProbe() *corev1.Probe {
 				Command: []string{"/bin/bash", "-c", "/conf/health.sh"},
 			},
 		},
-		InitialDelaySeconds: 10,
+		InitialDelaySeconds: 30,
 		PeriodSeconds:       10,
 		TimeoutSeconds:      5,
-		FailureThreshold:    30, // Allow up to 5 minutes for startup (30 * 10s)
-		SuccessThreshold:    1,
+		// ~10 minutes (30s initial + 60 * 10s). Matches the cluster startup
+		// probe's budget (buildStartupProbe). The previous 5-minute budget was
+		// too tight for a 5.26 Enterprise boot (JVM + APOC copy + store
+		// recovery) under the CI CPU limit (100m) on a slow/contended runner:
+		// the startup probe would exhaust before Neo4j bound :7474, the kubelet
+		// would kill and restart the pod, and it CrashLooped instead of ever
+		// reaching Ready. The cluster pods survived the same runner because
+		// they had the larger budget.
+		FailureThreshold: 60,
+		SuccessThreshold: 1,
 	}
 }
 

--- a/internal/controller/neo4jenterprisestandalone_controller_test.go
+++ b/internal/controller/neo4jenterprisestandalone_controller_test.go
@@ -573,6 +573,19 @@ var _ = Describe("Neo4jEnterpriseStandalone Controller", func() {
 			Expect(neo4jContainer.ReadinessProbe.Exec.Command).To(ContainElement("/conf/health.sh"))
 			Expect(neo4jContainer.LivenessProbe.Exec.Command).To(ContainElement("/conf/health.sh"))
 			Expect(neo4jContainer.StartupProbe.Exec.Command).To(ContainElement("/conf/health.sh"))
+
+			By("Verifying the startup probe budget tolerates a slow 5.26 boot under CI CPU throttling")
+			// The startup probe is the only gate during initial Neo4j boot;
+			// readiness/liveness are suspended until it passes. A 5.26
+			// Enterprise boot (JVM + APOC copy + recovery) under the CI 100m CPU
+			// limit on a slow runner can exceed 5 minutes, so the budget must
+			// match the cluster's (~10 min) or the pod CrashLoops and never
+			// reaches Ready. Guard against a regression back to the old 5-min
+			// budget.
+			sp := neo4jContainer.StartupProbe
+			startupBudget := time.Duration(sp.InitialDelaySeconds+sp.PeriodSeconds*sp.FailureThreshold) * time.Second
+			Expect(startupBudget).To(BeNumerically(">=", 10*time.Minute),
+				"standalone startup probe budget (%s) must be >= 10m to tolerate a throttled 5.26 boot", startupBudget)
 		})
 
 		It("Should include health.sh in the ConfigMap", func() {


### PR DESCRIPTION
## Why

The 5.26 (LTS) core integration suite timed out (15/60 specs in 1h) with all three standalone specs failing — each waited the full 1200s for a standalone that never reached `Ready`. The same code passed on the CalVer runner and on main's prior LTS run. Investigation (asked: is this a plugin/standalone *convergence bug*?) found:

- **No code-level convergence bug.** The standalone conf path — `DedupeNeo4jConf`, `UpsertNeo4jConfSettings` (sorts keys), the owned-keys annotation (`joinSortedKeys`), and the SHA-256 config hash — is fully deterministic and idempotent, so the operator is **not** rolling the pod every reconcile.
- **A startup-probe budget asymmetry that fully explains the symptom:**

  | Probe | InitialDelay | Period | FailureThreshold | Startup budget |
  |---|---|---|---|---|
  | Cluster (`buildStartupProbe`) | 30s | 10s | 60 | **~10.5 min** |
  | Standalone (`buildStandaloneStartupProbe`) | 10s | 10s | 30 | **~5.2 min** |

Standalone `Ready` is gated solely on `StatefulSet.Status.ReadyReplicas == 1`. Under the CI CPU limit (**100m**) on a slow/contended runner, a 5.26 Enterprise boot (JVM + APOC core-jar copy + store recovery) can exceed 5 minutes to bind `:7474`. When it does, the startup probe exhausts → kubelet kills & restarts the pod → CrashLoop → `ReadyReplicas` never reaches 1 → never `Ready`. The **cluster** pods survived the same runner because they had the ~10-min budget; the faster **CalVer** runner booted within 5 min and passed. That's the exact cluster-passes / standalone-fails split we saw.

## Fix

Align the standalone startup budget with the cluster's proven one: `InitialDelaySeconds 30`, `FailureThreshold 60` → **~10 min**. The startup probe only gates initial boot — readiness/liveness still run unchanged once Neo4j is up, so this widens the boot window without masking runtime-health regressions.

Adds an assertion that the rendered standalone startup-probe budget is `>= 10m`, guarding against a regression to the old 5-min window.

> Context: this surfaced while diagnosing the LTS integration failure on the rolling-upgrade PR (#175). That PR's diff is upgrade-path-only (gated on `UpgradeStatus != nil`) and unrelated — its LTS failure was this same standalone-startup flake. This fix is independent and off main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Probe timing-only change during initial boot; readiness/liveness unchanged, so runtime health behavior is unaffected.
> 
> **Overview**
> **Widens the standalone Neo4j startup probe window** so slow initial boots (especially 5.26 Enterprise under CI CPU limits) can finish before the kubelet restarts the pod.
> 
> `buildStandaloneStartupProbe` now uses **`InitialDelaySeconds: 30`** and **`FailureThreshold: 60`** (with `PeriodSeconds: 10`), giving roughly **~10 minutes** of startup tolerance—aligned with cluster `buildStartupProbe`. Readiness and liveness probes are unchanged; only the boot gate is relaxed.
> 
> A controller test now asserts the rendered standalone startup probe budget is **≥ 10 minutes**, to prevent regressing to the previous ~5 minute budget that could cause CrashLoop / never-Ready standalones in LTS integration runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e95fcb9c729e63e27d6d6b155ce0b87358cc6a9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->