### PR TITLE
fix(restore): recover cluster availability on failed restore; use Job conditions

### DIFF
--- a/internal/controller/neo4jrestore_controller.go
+++ b/internal/controller/neo4jrestore_controller.go
@@ -367,6 +367,19 @@ func (r *Neo4jRestoreReconciler) checkRestoreProgress(ctx context.Context, resto
 		return r.pollClusterRestoreOnline(ctx, restore, cluster)
 	}
 
+	// Defense-in-depth: a true-cluster restore never creates a Job (rule 75) —
+	// it restores via Cypher. If we reach here in Running without the
+	// cypher-restore-issued annotation (e.g. an operator restart landed between
+	// persisting Running and stamping the annotation), the Job lookup below
+	// would NotFound and wrongly fail + tear down an active restore. Re-drive
+	// the cluster Cypher path instead — it is idempotent (guarded by the
+	// annotation) and re-issues the recreate / re-checks the database. The
+	// standalone path (which DOES use a Job) is unaffected: isRestoreTargetTrueCluster
+	// returns false for it, so a TTL-collected standalone Job still fails terminally.
+	if isCluster, _, terr := r.isRestoreTargetTrueCluster(ctx, restore); terr == nil && isCluster {
+		return r.startClusterCypherRestore(ctx, restore, cluster)
+	}
+
 	// Get restore job
 	jobName := restore.Name + "-restore"
 	job := &batchv1.Job{}
@@ -2201,7 +2214,16 @@ func (r *Neo4jRestoreReconciler) startClusterCypherRestore(
 		version = &neo4j.Version{Major: 5, Minor: 26, Patch: 0}
 	}
 
-	r.updateRestoreStatus(ctx, restore, StatusRunning, fmt.Sprintf("Cluster Cypher restore in progress (seedURI=%s, exists=%v)", seedURI, exists))
+	// Do NOT persist StatusRunning here. Setting Running BEFORE the recreate is
+	// issued + the cypher-restore-issued annotation is stamped (exists branch),
+	// or before CREATE…WAIT completes (absent branch), opens a window: an
+	// operator restart in between would route the Running CR to
+	// checkRestoreProgress, which — finding no annotation and no Job — would
+	// wrongly fail+tear-down an active cluster restore. The exists branch sets
+	// Running only AFTER the annotation; the absent branch goes straight to
+	// Completed. A crash before either leaves the CR in its prior phase, so
+	// re-entry flows through startRestore → startClusterCypherRestore (which is
+	// idempotent, guarded by the annotation).
 	r.Recorder.Event(restore, corev1.EventTypeNormal, EventReasonRestoreStarted,
 		fmt.Sprintf("Cluster Cypher restore: database %q (%s), seedURI=%s",
 			restore.Spec.DatabaseName, ternaryString(exists, "recreate", "create"), seedURI))

--- a/internal/controller/neo4jrestore_controller.go
+++ b/internal/controller/neo4jrestore_controller.go
@@ -373,25 +373,73 @@ func (r *Neo4jRestoreReconciler) checkRestoreProgress(ctx context.Context, resto
 	err := r.Get(ctx, types.NamespacedName{Name: jobName, Namespace: restore.Namespace}, job)
 
 	if err != nil {
+		if errors.IsNotFound(err) {
+			// The Job's TTLSecondsAfterFinished GC'd it before we observed a
+			// terminal state (e.g. the operator was down longer than the TTL).
+			// We can't tell success from failure, so fail safe: restore cluster
+			// availability and mark Failed rather than requeueing forever with
+			// the cluster scaled to 0.
+			logger.Info("Restore Job not found (likely TTL-collected before completion was observed); failing the restore", "job", jobName)
+			r.restoreClusterAfterFailure(ctx, restore, cluster)
+			r.updateRestoreStatus(ctx, restore, StatusFailed,
+				"restore Job disappeared before completion was observed (TTL-collected); re-create the Neo4jRestore to retry")
+			r.Recorder.Event(restore, corev1.EventTypeWarning, EventReasonRestoreFailed,
+				"restore Job disappeared before completion was observed")
+			return ctrl.Result{}, nil
+		}
 		logger.Error(err, "Failed to get restore job")
 		return ctrl.Result{RequeueAfter: r.RequeueAfter}, err
 	}
 
-	// Check job status
-	if job.Status.Succeeded > 0 {
-		// Restore completed successfully
+	// Decide on terminal Job CONDITIONS, not raw pod counts: with BackoffLimit>0
+	// `Status.Failed` counts failed pod attempts and can be >0 while Kubernetes
+	// is still retrying — which would flip the restore to a (pinned) terminal
+	// Failed before a retry that might succeed.
+	switch {
+	case jobConditionTrue(job, batchv1.JobComplete) || job.Status.Succeeded > 0:
 		return r.handleRestoreSuccess(ctx, restore, cluster, job)
-	}
-
-	if job.Status.Failed > 0 {
-		// Restore failed
+	case jobConditionTrue(job, batchv1.JobFailed):
+		// Terminal failure (BackoffLimit exhausted). Restore cluster
+		// availability BEFORE marking Failed — a StopCluster restore otherwise
+		// leaves the cluster scaled to 0 indefinitely (the cluster controller
+		// honours the restore-in-progress annotation until it is cleared).
+		r.restoreClusterAfterFailure(ctx, restore, cluster)
 		r.updateRestoreStatus(ctx, restore, StatusFailed, "Restore job failed")
 		r.Recorder.Event(restore, corev1.EventTypeWarning, EventReasonRestoreFailed, "Restore job failed")
 		return ctrl.Result{}, nil
+	default:
+		// Job still running, or retrying within BackoffLimit.
+		return ctrl.Result{RequeueAfter: r.RequeueAfter}, nil
 	}
+}
 
-	// Job is still running
-	return ctrl.Result{RequeueAfter: r.RequeueAfter}, nil
+// jobConditionTrue reports whether the Job has the given condition set to True.
+func jobConditionTrue(job *batchv1.Job, condType batchv1.JobConditionType) bool {
+	for _, c := range job.Status.Conditions {
+		if c.Type == condType && c.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+// restoreClusterAfterFailure scales the cluster back up and releases the
+// restore-in-progress hold after a terminal restore failure — mirroring the
+// teardown handleRestoreSuccess performs on success. Without it, a
+// StopCluster=true restore that fails leaves the cluster at 0 replicas until a
+// human deletes the CR. Both calls are idempotent and best-effort (logged, not
+// fatal) so the restore still reaches a terminal Failed state.
+func (r *Neo4jRestoreReconciler) restoreClusterAfterFailure(ctx context.Context, restore *neo4jv1beta1.Neo4jRestore, cluster *neo4jv1beta1.Neo4jEnterpriseCluster) {
+	if !restore.Spec.StopCluster || cluster == nil {
+		return
+	}
+	logger := log.FromContext(ctx)
+	if err := r.startCluster(ctx, cluster); err != nil {
+		logger.Error(err, "Failed to scale cluster back up after restore failure")
+	}
+	if err := r.clearRestoreInProgressAnnotation(ctx, restore, cluster.Name, cluster.Namespace); err != nil {
+		logger.Error(err, "Failed to clear restore-in-progress annotation after restore failure")
+	}
 }
 
 func (r *Neo4jRestoreReconciler) handleRestoreSuccess(ctx context.Context, restore *neo4jv1beta1.Neo4jRestore, cluster *neo4jv1beta1.Neo4jEnterpriseCluster, job *batchv1.Job) (ctrl.Result, error) {

--- a/internal/controller/neo4jrestore_progress_test.go
+++ b/internal/controller/neo4jrestore_progress_test.go
@@ -100,4 +100,30 @@ func TestCheckRestoreProgress_TerminalDecisions(t *testing.T) {
 		require.NoError(t, err)
 		assert.Zero(t, res.RequeueAfter, "a TTL-collected Job must be terminal, not requeue forever")
 	})
+
+	// A true-cluster restore has NO Job (rule 75 — it restores via Cypher). If
+	// it reaches checkRestoreProgress in Running without the
+	// cypher-restore-issued annotation, the missing Job must NOT be treated as
+	// a TTL-collected failure (which would tear down an active restore). It
+	// re-drives the cluster Cypher path instead.
+	t.Run("true-cluster restore with no Job is not failed as TTL-collected", func(t *testing.T) {
+		clusterRestore := &neo4jv1beta1.Neo4jRestore{
+			ObjectMeta: metav1.ObjectMeta{Name: "r1", Namespace: "default"},
+			Spec:       neo4jv1beta1.Neo4jRestoreSpec{ClusterRef: "c1", DatabaseName: "db"},
+			Status:     neo4jv1beta1.Neo4jRestoreStatus{Phase: "Running"},
+		}
+		cluster := &neo4jv1beta1.Neo4jEnterpriseCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "c1", Namespace: "default"},
+		}
+		c := fake.NewClientBuilder().WithScheme(scheme).
+			WithObjects(clusterRestore, cluster).WithStatusSubresource(clusterRestore).Build()
+		rec := &Neo4jRestoreReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(16), RequeueAfter: 5 * time.Second}
+
+		_, _ = rec.checkRestoreProgress(ctx, clusterRestore, cluster)
+
+		got := &neo4jv1beta1.Neo4jRestore{}
+		require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(clusterRestore), got))
+		assert.NotContains(t, got.Status.Message, "Job disappeared",
+			"a true-cluster restore must not be failed via the Job-NotFound (TTL-collected) path")
+	})
 }

--- a/internal/controller/neo4jrestore_progress_test.go
+++ b/internal/controller/neo4jrestore_progress_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
+)
+
+func TestJobConditionTrue(t *testing.T) {
+	j := &batchv1.Job{Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{
+		{Type: batchv1.JobFailed, Status: corev1.ConditionTrue},
+		{Type: batchv1.JobComplete, Status: corev1.ConditionFalse},
+	}}}
+	assert.True(t, jobConditionTrue(j, batchv1.JobFailed))
+	assert.False(t, jobConditionTrue(j, batchv1.JobComplete))
+	assert.False(t, jobConditionTrue(&batchv1.Job{}, batchv1.JobFailed))
+}
+
+// TestCheckRestoreProgress_TerminalDecisions pins the failed-restore recovery
+// fix: a failed POD attempt mid-retry (Status.Failed>0 without a JobFailed
+// condition) must NOT be terminal; only the JobFailed condition is; and a
+// TTL-collected (missing) Job is terminal rather than requeue-forever.
+func TestCheckRestoreProgress_TerminalDecisions(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, neo4jv1beta1.AddToScheme(scheme))
+	ctx := context.Background()
+
+	newRestore := func() *neo4jv1beta1.Neo4jRestore {
+		return &neo4jv1beta1.Neo4jRestore{
+			ObjectMeta: metav1.ObjectMeta{Name: "r1", Namespace: "default"},
+			Spec:       neo4jv1beta1.Neo4jRestoreSpec{StopCluster: false, DatabaseName: "db"},
+			Status:     neo4jv1beta1.Neo4jRestoreStatus{Phase: "Running"},
+		}
+	}
+	newJob := func(mut func(*batchv1.Job)) *batchv1.Job {
+		j := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "r1-restore", Namespace: "default"}}
+		if mut != nil {
+			mut(j)
+		}
+		return j
+	}
+	reconciler := func(objs ...client.Object) *Neo4jRestoreReconciler {
+		restore := newRestore()
+		all := append([]client.Object{restore}, objs...)
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(all...).WithStatusSubresource(restore).Build()
+		return &Neo4jRestoreReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(16), RequeueAfter: 5 * time.Second}
+	}
+
+	t.Run("failed pod attempt without JobFailed condition keeps running", func(t *testing.T) {
+		rec := reconciler(newJob(func(j *batchv1.Job) { j.Status.Failed = 1 }))
+		res, err := rec.checkRestoreProgress(ctx, newRestore(), nil)
+		require.NoError(t, err)
+		assert.Equal(t, 5*time.Second, res.RequeueAfter,
+			"a failed pod attempt within BackoffLimit must requeue, not flip to terminal Failed")
+	})
+
+	t.Run("JobFailed condition is terminal", func(t *testing.T) {
+		rec := reconciler(newJob(func(j *batchv1.Job) {
+			j.Status.Failed = 4
+			j.Status.Conditions = []batchv1.JobCondition{{Type: batchv1.JobFailed, Status: corev1.ConditionTrue}}
+		}))
+		res, err := rec.checkRestoreProgress(ctx, newRestore(), nil)
+		require.NoError(t, err)
+		assert.Zero(t, res.RequeueAfter, "JobFailed condition must be terminal (no requeue)")
+	})
+
+	t.Run("missing (TTL-collected) Job is terminal", func(t *testing.T) {
+		rec := reconciler() // no Job object
+		res, err := rec.checkRestoreProgress(ctx, newRestore(), nil)
+		require.NoError(t, err)
+		assert.Zero(t, res.RequeueAfter, "a TTL-collected Job must be terminal, not requeue forever")
+	})
+}


### PR DESCRIPTION
Reopened after #171 merged (original #176 auto-closed on base-branch deletion). Rebased onto main — single commit.

On a failed restore, tears down fail-safe and routes to Failed via `JobComplete`/`JobFailed` conditions instead of `job.Status.Failed > 0`. Supersedes the closed #176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes restore lifecycle and cluster scale-down coordination on failure paths; mistakes could scale clusters incorrectly or mark restores failed/succeeded at the wrong time, but behavior is covered by new tests and targets known production footguns.
> 
> **Overview**
> Hardens **Neo4jRestore** progress handling so failed or ambiguous restores don’t leave clusters scaled down and stuck on the restore-in-progress annotation.
> 
> **Job-based (standalone) restores:** Terminal outcome now follows **`JobComplete` / `JobFailed` conditions**, not `Status.Failed > 0`, so in-retry pod failures aren’t marked Failed early. A **missing restore Job** (e.g. TTL GC before the operator observed completion) is treated as **terminal Failed**, with **`restoreClusterAfterFailure`** scaling the cluster back up and clearing the annotation when `stopCluster` was used. The same teardown runs on **confirmed Job failure**.
> 
> **Cluster Cypher restores:** If progress runs in **Running** without the **`cypher-restore-issued`** annotation, the controller **re-enters the cluster Cypher path** instead of treating “no Job” as TTL failure. **`startClusterCypherRestore`** no longer sets **Running** before the recreate is issued / annotated, closing a restart window that could wrongly fail an active cluster restore.
> 
> New unit tests cover **`jobConditionTrue`** and these terminal-progress behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5104558ea72aff12ba73ff0a63643b55400b6ac8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->