### PR TITLE
docs(backup): clarify target.kind + standalone backups; fix PVC example (#182,#185,#186,#188)

### DIFF
--- a/docs/user_guide/guides/backup_restore.md
+++ b/docs/user_guide/guides/backup_restore.md
@@ -30,6 +30,16 @@ The operator spawns a Kubernetes Job that runs `neo4j-admin database backup` fro
 
 Backup Jobs run as the auto-created `neo4j-backup-sa` ServiceAccount in the same namespace. For Workload Identity (IRSA / GKE WI / Azure WI), annotate the SA via `cloud.identity.autoCreate.annotations` — see [Cloud Storage Authentication](#cloud-storage-authentication).
 
+### Backup targets (`target.kind`)
+
+| `target.kind` | `target.name` | `target.clusterRef` | Backs up |
+|---|---|---|---|
+| `Cluster` | the **instance** name — a `Neo4jEnterpriseCluster` **or** `Neo4jEnterpriseStandalone` (auto-detected) | *(unused — leave unset)* | every database on the instance |
+| `Database` | the **database** name (e.g. `neo4j`) | the owning instance name | a single database |
+| `ShardedDatabase` | the logical sharded-DB name (e.g. `products`) | the owning cluster | all shards in one `neo4j-admin` run |
+
+There is **no `kind: Standalone`** — a standalone is just an instance. To back one up, use `kind: Cluster` with `name: <standalone-name>` (whole instance), or `kind: Database` with `name: <database>` + `clusterRef: <standalone-name>` (one database). Key gotcha: for `kind: Cluster`, `name` is the **instance** name and `clusterRef` is unused; for `kind: Database`/`ShardedDatabase`, `name` is the **database** and `clusterRef` is the instance that owns it.
+
 ### Storage Layout
 
 All runs of a single `Neo4jBackup` CR write to the **same directory**: `<storage.path>/<cr-name>/`. This is what `neo4j-admin` requires for differential backup chaining — every diff run reads the prior full from the same directory to compute the delta. Per-run identity is preserved by the timestamp `neo4j-admin` embeds in each artifact filename (`<dbname>-YYYY-MM-DDThh-mm-ss.backup`).
@@ -846,6 +856,10 @@ spec:
 ```
 
 **Best for:** Cross-cluster recovery, disaster recovery from a known directory in storage (no `Neo4jBackup` CR available in this namespace).
+
+> **Restoring after the `Neo4jBackup` CR is deleted.** `source.type: backup` resolves the storage location *from the Backup CR*, so it fails with `backup "<name>" not found` once you delete that CR — the artifacts in object storage / the PVC are untouched, but the operator no longer knows where they are. Restore directly from the artifacts with **`source.type: storage`** (above): point `backupPath` at the exact `.backup` file (cluster) or the directory (standalone). You do **not** need to re-create the Backup CR.
+>
+> ⚠️ **Restore is destructive and overwrites in place.** With `replaceExisting`/`force` the target database's current data is replaced by the backup. Re-running a restore — including after re-creating a deleted Backup CR — re-seeds and overwrites again. Treat every restore as a destructive operation against the named database.
 
 > **Which run a restore picks**: a cluster restore seeds from the **latest successful artifact of the referenced `Neo4jBackup` CR** (standalone uses `tail -1` of the timestamped glob in that CR's directory). In a FULL+DIFF chain, reference the **DIFF CR** for the latest state or the **FULL CR** to roll back to the last full snapshot — restoring via the FULL CR does *not* apply the newer diffs (and emits a `RestoreFromChainParent` warning). To pin to an arbitrary earlier run, set `source.type: storage` with `backupPath` pointing at the exact `.backup` file, or keep a point-in-time snapshot of the directory (cloud lifecycle rules / versioning).
 

--- a/examples/backup-restore/backup-pvc-simple.yaml
+++ b/examples/backup-restore/backup-pvc-simple.yaml
@@ -6,32 +6,32 @@ metadata:
     environment: development
     backup-type: one-time
 spec:
-  # target.kind=Cluster backs up all databases on the cluster
   target:
+    # kind=Cluster backs up EVERY database on the instance. `name` is the
+    # Neo4jEnterpriseCluster *or* Neo4jEnterpriseStandalone name (the operator
+    # auto-detects which) — there is no `kind: Standalone`. Do NOT set
+    # `clusterRef` for kind=Cluster.
+    #
+    # To back up a SINGLE database instead, use:
+    #   kind: Database
+    #   name: <database-name>        # e.g. "neo4j"
+    #   clusterRef: <instance-name>  # the cluster/standalone that owns it
     kind: Cluster
-    name: single-node-cluster  # References your Neo4jEnterpriseCluster name
+    name: my-neo4j        # your Neo4jEnterpriseCluster or Neo4jEnterpriseStandalone name
   storage:
     type: pvc
     pvc:
       name: backup-storage
-      storageClassName: standard  # Must match an available StorageClass
       size: 50Gi
+      # storageClassName is intentionally omitted: the operator creates the PVC
+      # WITHOUT a class so it inherits the cluster's DEFAULT StorageClass —
+      # portable across Kind, EKS, GKE, AKS. Set it ONLY to pin a class that
+      # EXISTS on your cluster (Kind: standard · EKS: gp3 · AKS: managed-csi ·
+      # GKE: standard-rwo). To bind to a PVC you created yourself, set only
+      # `name` (size/storageClassName are then ignored).
+      # storageClassName: gp3
   options:
     compress: true
     backupType: FULL  # FULL | DIFF | AUTO
   retention:
     maxCount: 5
-
----
-# Pre-create the PVC (or let the operator create it via spec.storage.pvc)
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: backup-storage
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 50Gi
-  storageClassName: standard

--- a/examples/backup-restore/backup-s3-basic.yaml
+++ b/examples/backup-restore/backup-s3-basic.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   target:
     kind: Cluster
-    name: single-node-cluster  # References your Neo4jEnterpriseCluster name
+    name: my-neo4j  # kind=Cluster: the Neo4jEnterpriseCluster OR Neo4jEnterpriseStandalone instance name (clusterRef unused; backs up all databases)
   storage:
     type: s3
     bucket: my-neo4j-backups           # S3 bucket name

--- a/examples/backup-restore/backup-scheduled-daily.yaml
+++ b/examples/backup-restore/backup-scheduled-daily.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   target:
     kind: Cluster
-    name: single-node-cluster  # References your Neo4jEnterpriseCluster name
+    name: my-neo4j  # kind=Cluster: the Neo4jEnterpriseCluster OR Neo4jEnterpriseStandalone instance name (clusterRef unused; backs up all databases)
   # schedule is a flat cron string — no nesting
   schedule: "0 2 * * *"  # Daily at 2 AM UTC
   storage:


### PR DESCRIPTION
Backup/restore ergonomics surfaced during PS validation (against v1.11.2). Docs + examples only — no controller changes.

- **#185 / #186** — the backup target model confused users (there's no `kind: Standalone`, and `name` means different things per kind). Added a **Backup targets** table to `backup_restore.md` and rewrote `backup-pvc-simple.yaml`'s comments: `kind: Cluster` → `name` is the **instance** (cluster *or* standalone), `clusterRef` unused; `kind: Database` → `name` is the **database** + `clusterRef` is the owning instance. Same misleading comment fixed in `backup-s3-basic.yaml` / `backup-scheduled-daily.yaml`.
- **#182** — `backup-pvc-simple.yaml` set `storage.pvc.storageClassName` **and** pre-created the PVC with the same class (redundant). Dropped the manual PVC block; the operator creates the PVC from `spec.storage.pvc`, and **`storageClassName` is now omitted so the PVC inherits the cluster's DEFAULT class** (portable across Kind/EKS/GKE/AKS) — with a comment on how to pin one or bind to a pre-existing PVC. (Confirmed the backup PVC builder only sets the class when non-empty, so omitting → default.)
- **#188** — documented restoring after the `Neo4jBackup` CR is deleted (use `source.type: storage` — artifacts are untouched) and added an explicit warning that restore overwrites the target database in place and re-running re-seeds/overwrites.

`backup-with-type.yaml`'s `fast-ssd` is intentionally left as a "pin a specific class" demonstration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example YAML only; no runtime or API behavior changes.
> 
> **Overview**
> **Docs-only** clarification from PS validation — no controller changes.
> 
> Adds a **Backup targets (`target.kind`)** table and narrative in `backup_restore.md`: there is no `kind: Standalone`; `kind: Cluster` uses `name` as the cluster/standalone **instance** (no `clusterRef`); `Database` / `ShardedDatabase` use `name` for the DB and `clusterRef` for the owning instance.
> 
> Updates `backup-pvc-simple.yaml`, `backup-s3-basic.yaml`, and `backup-scheduled-daily.yaml` with matching target comments. The PVC example drops the manual PVC manifest and omits `storageClassName` so operator-provisioned PVCs use the cluster default StorageClass, with comments on when to pin a class or bind an existing PVC.
> 
> Documents **restore after deleting the `Neo4jBackup` CR** (`source.type: storage` with `backupPath`) and warns that restore is **destructive** and re-runs overwrite the target database.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 200e31526e2040ea20faeaeee40cb972f5a1797d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->