### PR TITLE
fix(restore): standalone-target restore (#196,#187) + auto-inherit rollout wait (#190)

### DIFF
--- a/internal/controller/neo4jenterprisestandalone_controller.go
+++ b/internal/controller/neo4jenterprisestandalone_controller.go
@@ -767,8 +767,13 @@ func (r *Neo4jEnterpriseStandaloneReconciler) reconcileStatefulSet(ctx context.C
 			// Spec-level fields are cheap to set unconditionally — they don't roll
 			// pods on their own and CreateOrUpdate skips the Update when nothing
 			// changed. UpdateStrategy must apply so a Rolling↔Recreate switch takes
-			// effect; Replicas is always 1 for a standalone.
-			statefulSet.Spec.Replicas = desiredSpec.Replicas
+			// effect; Replicas is normally 1 for a standalone — but leave it alone
+			// while a restore is quiescing the instance (it scales the STS to 0).
+			// Otherwise we race the restore controller and the scale-to-0 never
+			// sticks — the standalone analog of the cluster gate (#117 / #196).
+			if !replicasReconciliationPaused(standalone) {
+				statefulSet.Spec.Replicas = desiredSpec.Replicas
+			}
 			statefulSet.Spec.UpdateStrategy = desiredSpec.UpdateStrategy
 
 			// Apply the desired template only when our desired hash differs from the

--- a/internal/controller/neo4jrestore_controller.go
+++ b/internal/controller/neo4jrestore_controller.go
@@ -483,9 +483,9 @@ func (r *Neo4jRestoreReconciler) handleRestoreSuccess(ctx context.Context, resto
 			// Non-fatal — the finalizer path will clean it up if needed.
 		}
 
-		// Wait for cluster to be ready
-		if err := r.waitForClusterReady(ctx, cluster); err != nil {
-			logger.Error(err, "Cluster not ready after restore")
+		// Wait for the standalone to be ready
+		if err := r.waitForClusterReady(ctx, restore, cluster); err != nil {
+			logger.Error(err, "Standalone not ready after restore")
 			r.updateRestoreStatus(ctx, restore, StatusFailed, fmt.Sprintf("Cluster not ready after restore: %v", err))
 			return ctrl.Result{RequeueAfter: r.RequeueAfter}, err
 		}
@@ -1847,9 +1847,9 @@ func (r *Neo4jRestoreReconciler) startCluster(ctx context.Context, cluster *neo4
 	return nil
 }
 
-func (r *Neo4jRestoreReconciler) waitForClusterReady(ctx context.Context, cluster *neo4jv1beta1.Neo4jEnterpriseCluster) error {
+func (r *Neo4jRestoreReconciler) waitForClusterReady(ctx context.Context, restore *neo4jv1beta1.Neo4jRestore, cluster *neo4jv1beta1.Neo4jEnterpriseCluster) error {
 	logger := log.FromContext(ctx)
-	logger.Info("Waiting for cluster to be ready", "cluster", cluster.Name)
+	logger.Info("Waiting for standalone to be ready", "standalone", cluster.Name)
 
 	timeout := time.After(10 * time.Minute)
 	ticker := time.NewTicker(30 * time.Second)
@@ -1883,8 +1883,11 @@ func (r *Neo4jRestoreReconciler) waitForClusterReady(ctx context.Context, cluste
 			}
 
 			if allReady {
-				// Verify Neo4j connectivity
-				neo4jClient, err := r.createNeo4jClient(ctx, cluster)
+				// Verify Neo4j connectivity over the standalone's `<name>-service`
+				// (this readiness wait is on the standalone Job path); the cluster
+				// `<name>-client` routing service doesn't exist for a standalone
+				// (#187), so the cluster client would never connect.
+				neo4jClient, err := r.newStandaloneRestoreClient(ctx, restore)
 				if err != nil {
 					logger.Info("Failed to create Neo4j client, retrying...")
 					continue

--- a/internal/controller/neo4jrestore_controller.go
+++ b/internal/controller/neo4jrestore_controller.go
@@ -2183,6 +2183,27 @@ func (r *Neo4jRestoreReconciler) startClusterCypherRestore(
 					fmt.Sprintf("Auto-inherited seed credentials Secret %q onto cluster %q; waiting for rolling restart", storage.Cloud.CredentialsSecretRef, cluster.Name))
 				return ctrl.Result{RequeueAfter: r.RequeueAfter}, nil
 			}
+			// The creds are in spec.extraEnvFrom, but the cluster controller
+			// rolls the StatefulSet asynchronously to apply them. Issuing the
+			// seedURI restore before that rollout finishes seeds against pods
+			// that still lack the creds — the JVM's AWS/GCP/Azure SDK then
+			// fails ("Unable to load region …"), and the restore terminal-fails
+			// with no retry (#190). Gate on the rollout: stay Pending+requeue
+			// until the STS pod template carries the creds Secret AND every pod
+			// is updated to that template and Ready.
+			rolledOut, rolloutErr := r.seedCredsRolledOut(ctx, cluster, storage.Cloud.CredentialsSecretRef)
+			if rolloutErr != nil {
+				logger.Error(rolloutErr, "Failed to check seed-creds rollout status")
+				r.updateRestoreStatus(ctx, restore, StatusPending,
+					fmt.Sprintf("Waiting to verify seed-credentials rollout on cluster %q: %v", cluster.Name, rolloutErr))
+				return ctrl.Result{RequeueAfter: r.RequeueAfter}, nil
+			}
+			if !rolledOut {
+				logger.Info("Waiting for StatefulSet to roll out seed credentials before restoring", "cluster", cluster.Name)
+				r.updateRestoreStatus(ctx, restore, StatusPending,
+					fmt.Sprintf("Waiting for cluster %q server pods to roll out seed credentials Secret %q", cluster.Name, storage.Cloud.CredentialsSecretRef))
+				return ctrl.Result{RequeueAfter: r.RequeueAfter}, nil
+			}
 		}
 	case "pvc":
 		// Cluster + PVC restore: spawn the in-cluster HTTP proxy in front
@@ -2602,6 +2623,47 @@ func (r *Neo4jRestoreReconciler) newStandaloneRestoreClient(ctx context.Context,
 		return nil, fmt.Errorf("failed to get standalone %q for restore: %w", restore.Spec.ClusterRef, err)
 	}
 	return neo4j.NewClientForEnterpriseStandalone(standalone, r.Client, getStandaloneAdminSecretName(standalone))
+}
+
+// seedCredsRolledOut reports whether the cluster's StatefulSet has fully rolled
+// out the seed-credentials Secret (projected via spec.extraEnvFrom) onto its
+// server pods — i.e. the pod template's container references the Secret in
+// envFrom AND every replica is updated to that template and Ready. Until then a
+// seedURI restore runs against pods that still lack the creds, so the seed
+// fetch fails (#190). The template-has-Secret check is essential: a fully
+// rolled-out OLD template (without the creds) is also "ready", so readiness
+// alone is not enough.
+func (r *Neo4jRestoreReconciler) seedCredsRolledOut(ctx context.Context, cluster *neo4jv1beta1.Neo4jEnterpriseCluster, secretName string) (bool, error) {
+	sts := &appsv1.StatefulSet{}
+	if err := r.Get(ctx, types.NamespacedName{Name: cluster.Name + "-server", Namespace: cluster.Namespace}, sts); err != nil {
+		return false, err
+	}
+	if !podTemplateReferencesSecretEnvFrom(&sts.Spec.Template, secretName) {
+		return false, nil // cluster controller hasn't applied extraEnvFrom to the template yet
+	}
+	desired := int32(1)
+	if sts.Spec.Replicas != nil {
+		desired = *sts.Spec.Replicas
+	}
+	// Rollout complete: status reflects the current template, and every pod is
+	// on the updated revision and Ready.
+	return sts.Status.ObservedGeneration == sts.Generation &&
+		sts.Status.UpdatedReplicas == desired &&
+		sts.Status.ReadyReplicas == desired, nil
+}
+
+// podTemplateReferencesSecretEnvFrom reports whether any container in the pod
+// template projects the named Secret via envFrom (how spec.extraEnvFrom is
+// wired onto the neo4j container).
+func podTemplateReferencesSecretEnvFrom(tmpl *corev1.PodTemplateSpec, secretName string) bool {
+	for _, c := range tmpl.Spec.Containers {
+		for _, ef := range c.EnvFrom {
+			if ef.SecretRef != nil && ef.SecretRef.Name == secretName {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (r *Neo4jRestoreReconciler) cleanupRestoreJobs(ctx context.Context, restore *neo4jv1beta1.Neo4jRestore) error {

--- a/internal/controller/neo4jrestore_controller.go
+++ b/internal/controller/neo4jrestore_controller.go
@@ -533,8 +533,11 @@ func (r *Neo4jRestoreReconciler) handleRestoreSuccess(ctx context.Context, resto
 
 // createOrStartDatabase registers the restored database with Neo4j.
 // If the database already exists (overwrite restore) it starts it; otherwise it creates it.
-func (r *Neo4jRestoreReconciler) createOrStartDatabase(ctx context.Context, restore *neo4jv1beta1.Neo4jRestore, cluster *neo4jv1beta1.Neo4jEnterpriseCluster) error {
-	neo4jClient, err := r.createNeo4jClient(ctx, cluster)
+func (r *Neo4jRestoreReconciler) createOrStartDatabase(ctx context.Context, restore *neo4jv1beta1.Neo4jRestore, _ *neo4jv1beta1.Neo4jEnterpriseCluster) error {
+	// Job-path restore is standalone-only (clusters use the Cypher seed/recreate
+	// path, rule 75), so connect via the standalone's `<name>-service`, not the
+	// cluster `<name>-client` routing service a standalone doesn't have (#187).
+	neo4jClient, err := r.newStandaloneRestoreClient(ctx, restore)
 	if err != nil {
 		return fmt.Errorf("failed to create Neo4j client: %w", err)
 	}
@@ -729,9 +732,10 @@ func (r *Neo4jRestoreReconciler) validateRestore(ctx context.Context, restore *n
 	return nil
 }
 
-func (r *Neo4jRestoreReconciler) checkDatabaseExists(ctx context.Context, restore *neo4jv1beta1.Neo4jRestore, cluster *neo4jv1beta1.Neo4jEnterpriseCluster) error {
-	// Create Neo4j client
-	neo4jClient, err := r.createNeo4jClient(ctx, cluster)
+func (r *Neo4jRestoreReconciler) checkDatabaseExists(ctx context.Context, restore *neo4jv1beta1.Neo4jRestore, _ *neo4jv1beta1.Neo4jEnterpriseCluster) error {
+	// Job-path restore is standalone-only (rule 75); connect via the
+	// standalone's `<name>-service` (#187).
+	neo4jClient, err := r.newStandaloneRestoreClient(ctx, restore)
 	if err != nil {
 		return fmt.Errorf("failed to create Neo4j client: %w", err)
 	}
@@ -1655,7 +1659,7 @@ func (r *Neo4jRestoreReconciler) refuseRestoreIfPodsRunning(ctx context.Context,
 	pods := &corev1.PodList{}
 	if err := r.List(ctx, pods,
 		client.InNamespace(cluster.Namespace),
-		client.MatchingLabels(resources.ServerPodSelector(cluster.Name))); err != nil {
+		client.MatchingLabels(resources.StandalonePodSelector(cluster.Name))); err != nil {
 		return fmt.Errorf("failed to list server pods for restore preflight: %w", err)
 	}
 	if len(pods.Items) > 0 {
@@ -1672,12 +1676,18 @@ func (r *Neo4jRestoreReconciler) refuseRestoreIfPodsRunning(ctx context.Context,
 // cannot run concurrently.
 func (r *Neo4jRestoreReconciler) setRestoreInProgressAnnotation(ctx context.Context, restore *neo4jv1beta1.Neo4jRestore, cluster *neo4jv1beta1.Neo4jEnterpriseCluster) error {
 	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		latest := &neo4jv1beta1.Neo4jEnterpriseCluster{}
+		// The Job restore path is standalone-only (clusters use the Cypher
+		// path, rule 75), so the in-progress marker lives on the
+		// Neo4jEnterpriseStandalone — NOT a Neo4jEnterpriseCluster, which
+		// doesn't exist for a standalone target (#196). `cluster` is the
+		// standaloneAsCluster wrapper, so its name/namespace resolve the
+		// standalone.
+		latest := &neo4jv1beta1.Neo4jEnterpriseStandalone{}
 		if err := r.Get(ctx, client.ObjectKeyFromObject(cluster), latest); err != nil {
 			return err
 		}
 		if existing, ok := latest.Annotations[RestoreInProgressAnnotation]; ok && existing != restore.Name {
-			return fmt.Errorf("cluster %q already has a restore in progress by Neo4jRestore %q; cannot start %q", cluster.Name, existing, restore.Name)
+			return fmt.Errorf("standalone %q already has a restore in progress by Neo4jRestore %q; cannot start %q", cluster.Name, existing, restore.Name)
 		}
 		if latest.Annotations == nil {
 			latest.Annotations = map[string]string{}
@@ -1696,10 +1706,14 @@ func (r *Neo4jRestoreReconciler) setRestoreInProgressAnnotation(ctx context.Cont
 // never set or was already cleared.
 func (r *Neo4jRestoreReconciler) clearRestoreInProgressAnnotation(ctx context.Context, restore *neo4jv1beta1.Neo4jRestore, clusterName, clusterNamespace string) error {
 	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		latest := &neo4jv1beta1.Neo4jEnterpriseCluster{}
+		// Mirror of setRestoreInProgressAnnotation: the marker lives on the
+		// Neo4jEnterpriseStandalone. A NotFound here means the target was a
+		// true cluster (which never sets this marker — Cypher path) or the
+		// standalone is already gone, so there's nothing to clear.
+		latest := &neo4jv1beta1.Neo4jEnterpriseStandalone{}
 		if err := r.Get(ctx, types.NamespacedName{Name: clusterName, Namespace: clusterNamespace}, latest); err != nil {
 			if errors.IsNotFound(err) {
-				return nil // cluster gone — nothing to clean
+				return nil // standalone gone / not a standalone target — nothing to clean
 			}
 			return err
 		}
@@ -1757,7 +1771,7 @@ func (r *Neo4jRestoreReconciler) stopCluster(ctx context.Context, cluster *neo4j
 		case <-ticker.C:
 			pods := &corev1.PodList{}
 			if err := r.List(ctx, pods, client.InNamespace(cluster.Namespace),
-				client.MatchingLabels(resources.ServerPodSelector(cluster.Name))); err != nil {
+				client.MatchingLabels(resources.StandalonePodSelector(cluster.Name))); err != nil {
 				logger.Error(err, "Failed to list pods")
 				continue
 			}
@@ -1849,7 +1863,7 @@ func (r *Neo4jRestoreReconciler) waitForClusterReady(ctx context.Context, cluste
 			// Check if all pods are ready
 			pods := &corev1.PodList{}
 			if err := r.List(ctx, pods, client.InNamespace(cluster.Namespace),
-				client.MatchingLabels(resources.ServerPodSelector(cluster.Name))); err != nil {
+				client.MatchingLabels(resources.StandalonePodSelector(cluster.Name))); err != nil {
 				logger.Error(err, "Failed to list pods")
 				continue
 			}
@@ -2573,6 +2587,21 @@ func (r *Neo4jRestoreReconciler) isRestoreTargetTrueCluster(ctx context.Context,
 
 func (r *Neo4jRestoreReconciler) createNeo4jClient(_ context.Context, cluster *neo4jv1beta1.Neo4jEnterpriseCluster) (*neo4j.Client, error) {
 	return neo4j.NewClientForEnterprise(cluster, r.Client, cluster.Spec.Auth.AdminSecret)
+}
+
+// newStandaloneRestoreClient builds a Bolt client for the Neo4jEnterpriseStandalone
+// the restore targets. The Job-based restore path runs only for standalones
+// (clusters use the Cypher seed/recreate path, rule 75). A standalone's Bolt
+// service is `<name>-service` (NewClientForEnterpriseStandalone), whereas
+// createNeo4jClient / NewClientForEnterprise target the cluster `<name>-client`
+// routing service a standalone doesn't have — using that connected to a
+// nonexistent service (#187).
+func (r *Neo4jRestoreReconciler) newStandaloneRestoreClient(ctx context.Context, restore *neo4jv1beta1.Neo4jRestore) (*neo4j.Client, error) {
+	standalone := &neo4jv1beta1.Neo4jEnterpriseStandalone{}
+	if err := r.Get(ctx, types.NamespacedName{Name: restore.Spec.ClusterRef, Namespace: restore.Namespace}, standalone); err != nil {
+		return nil, fmt.Errorf("failed to get standalone %q for restore: %w", restore.Spec.ClusterRef, err)
+	}
+	return neo4j.NewClientForEnterpriseStandalone(standalone, r.Client, getStandaloneAdminSecretName(standalone))
 }
 
 func (r *Neo4jRestoreReconciler) cleanupRestoreJobs(ctx context.Context, restore *neo4jv1beta1.Neo4jRestore) error {

--- a/internal/controller/neo4jrestore_coordination_test.go
+++ b/internal/controller/neo4jrestore_coordination_test.go
@@ -357,6 +357,19 @@ func TestReplicasReconciliationPaused(t *testing.T) {
 			assert.Equal(t, tc.expected, replicasReconciliationPaused(tc.owner))
 		})
 	}
+
+	// The gate must also pause a Neo4jEnterpriseStandalone owner — the standalone
+	// controller honours it so a stopCluster=true standalone restore can quiesce
+	// (it scales the STS to 0) without the controller racing it back to 1.
+	t.Run("standalone with restore-in-progress annotation pauses", func(t *testing.T) {
+		sa := &neo4jv1beta1.Neo4jEnterpriseStandalone{
+			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{RestoreInProgressAnnotation: "r1"}},
+		}
+		assert.True(t, replicasReconciliationPaused(sa))
+	})
+	t.Run("standalone without the annotation is not paused", func(t *testing.T) {
+		assert.False(t, replicasReconciliationPaused(&neo4jv1beta1.Neo4jEnterpriseStandalone{}))
+	})
 }
 
 func TestBuildRestoreVolumesAlwaysMountsDataPVC(t *testing.T) {

--- a/internal/controller/neo4jrestore_coordination_test.go
+++ b/internal/controller/neo4jrestore_coordination_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -190,6 +191,66 @@ func TestClearRestoreInProgressAnnotation(t *testing.T) {
 // The Job restore path is standalone-only, so the preflight lists standalone
 // pods via the `app=<name>` selector (StandalonePodSelector) — not the cluster
 // ServerPodSelector. This pins that swap (part of #196/#187).
+// TestSeedCredsRolledOut pins the #190 gate: a cluster Cypher restore must not
+// issue the seedURI recreate until the StatefulSet has rolled out the
+// seed-credentials Secret. The decisive check is "the pod template references
+// the Secret AND every pod is updated+ready" — a fully-ready OLD template
+// (without the creds) must NOT count as rolled out.
+func TestSeedCredsRolledOut(t *testing.T) {
+	ctx := context.Background()
+	ns := "default"
+	const secret = "s3-creds"
+
+	mkSTS := func(mut func(*appsv1.StatefulSet)) *appsv1.StatefulSet {
+		replicas := int32(2)
+		sts := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "c-server", Namespace: ns, Generation: 3},
+			Spec: appsv1.StatefulSetSpec{
+				Replicas: &replicas,
+				Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "neo4j"}}}},
+			},
+			Status: appsv1.StatefulSetStatus{ObservedGeneration: 3, UpdatedReplicas: 2, ReadyReplicas: 2},
+		}
+		if mut != nil {
+			mut(sts)
+		}
+		return sts
+	}
+	withCreds := func(sts *appsv1.StatefulSet) {
+		sts.Spec.Template.Spec.Containers[0].EnvFrom = []corev1.EnvFromSource{
+			{SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: secret}}},
+		}
+	}
+
+	cases := []struct {
+		name string
+		sts  *appsv1.StatefulSet
+		want bool
+	}{
+		{"creds rolled out + all pods ready", mkSTS(withCreds), true},
+		{"creds in spec but template not yet updated (the #190 window)", mkSTS(nil), false},
+		{"creds in template but mid-roll", mkSTS(func(s *appsv1.StatefulSet) { withCreds(s); s.Status.UpdatedReplicas = 1 }), false},
+		{"creds in template, ready, but observedGeneration stale", mkSTS(func(s *appsv1.StatefulSet) { withCreds(s); s.Status.ObservedGeneration = 2 }), false},
+		{"creds in template but not all ready", mkSTS(func(s *appsv1.StatefulSet) { withCreds(s); s.Status.ReadyReplicas = 1 }), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cluster := minimalClusterForRestore("c", ns)
+			r := newRestoreTestReconciler(t, cluster, tc.sts)
+			got, err := r.seedCredsRolledOut(ctx, cluster, secret)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+
+	t.Run("StatefulSet missing returns error", func(t *testing.T) {
+		cluster := minimalClusterForRestore("c", ns)
+		r := newRestoreTestReconciler(t, cluster)
+		_, err := r.seedCredsRolledOut(ctx, cluster, secret)
+		require.Error(t, err)
+	})
+}
+
 func TestRefuseRestoreIfPodsRunning(t *testing.T) {
 	ctx := context.Background()
 	ns := "default"

--- a/internal/controller/neo4jrestore_coordination_test.go
+++ b/internal/controller/neo4jrestore_coordination_test.go
@@ -69,49 +69,69 @@ func minimalRestore(name, namespace, clusterRef string) *neo4jv1beta1.Neo4jResto
 	}
 }
 
+// minimalStandaloneForRestore builds a Neo4jEnterpriseStandalone for the
+// Job-based restore path. That path is standalone-only (clusters use the
+// Cypher seed/recreate path, rule 75), so the coordination helpers
+// (setRestoreInProgressAnnotation, stopCluster pod-wait, refuse preflight)
+// operate on a Neo4jEnterpriseStandalone + the `app=<name>` pod selector.
+func minimalStandaloneForRestore(name, namespace string) *neo4jv1beta1.Neo4jEnterpriseStandalone {
+	return &neo4jv1beta1.Neo4jEnterpriseStandalone{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: neo4jv1beta1.Neo4jEnterpriseStandaloneSpec{
+			Image: neo4jv1beta1.ImageSpec{Repo: "neo4j", Tag: "5.26-enterprise"},
+		},
+	}
+}
+
+// The Job-based restore path (and thus the restore-in-progress marker) is
+// standalone-only — clusters use the Cypher path (rule 75). #196: the marker
+// must be written on the Neo4jEnterpriseStandalone; the pre-fix code Got/Updated
+// a Neo4jEnterpriseCluster that doesn't exist for a standalone target and failed
+// with "Neo4jEnterpriseCluster ... not found". `cluster` here is the
+// standaloneAsCluster wrapper, exactly as the controller passes it.
 func TestSetRestoreInProgressAnnotation(t *testing.T) {
 	ctx := context.Background()
 	ns := "default"
 
-	t.Run("sets annotation on a clean cluster", func(t *testing.T) {
-		cluster := minimalClusterForRestore("c", ns)
-		restore := minimalRestore("r1", ns, "c")
-		r := newRestoreTestReconciler(t, cluster, restore)
+	t.Run("sets annotation on a clean standalone (#196)", func(t *testing.T) {
+		sa := minimalStandaloneForRestore("s", ns)
+		restore := minimalRestore("r1", ns, "s")
+		r := newRestoreTestReconciler(t, sa, restore)
 
-		require.NoError(t, r.setRestoreInProgressAnnotation(ctx, restore, cluster))
+		require.NoError(t, r.setRestoreInProgressAnnotation(ctx, restore, standaloneAsCluster(sa)))
 
-		got := &neo4jv1beta1.Neo4jEnterpriseCluster{}
-		require.NoError(t, r.Get(ctx, types.NamespacedName{Name: "c", Namespace: ns}, got))
+		got := &neo4jv1beta1.Neo4jEnterpriseStandalone{}
+		require.NoError(t, r.Get(ctx, types.NamespacedName{Name: "s", Namespace: ns}, got))
 		assert.Equal(t, "r1", got.Annotations[RestoreInProgressAnnotation])
 	})
 
 	t.Run("idempotent when annotation already names this restore", func(t *testing.T) {
-		cluster := minimalClusterForRestore("c", ns)
-		cluster.Annotations = map[string]string{RestoreInProgressAnnotation: "r1"}
-		restore := minimalRestore("r1", ns, "c")
-		r := newRestoreTestReconciler(t, cluster, restore)
+		sa := minimalStandaloneForRestore("s", ns)
+		sa.Annotations = map[string]string{RestoreInProgressAnnotation: "r1"}
+		restore := minimalRestore("r1", ns, "s")
+		r := newRestoreTestReconciler(t, sa, restore)
 
-		require.NoError(t, r.setRestoreInProgressAnnotation(ctx, restore, cluster))
+		require.NoError(t, r.setRestoreInProgressAnnotation(ctx, restore, standaloneAsCluster(sa)))
 
-		got := &neo4jv1beta1.Neo4jEnterpriseCluster{}
-		require.NoError(t, r.Get(ctx, types.NamespacedName{Name: "c", Namespace: ns}, got))
+		got := &neo4jv1beta1.Neo4jEnterpriseStandalone{}
+		require.NoError(t, r.Get(ctx, types.NamespacedName{Name: "s", Namespace: ns}, got))
 		assert.Equal(t, "r1", got.Annotations[RestoreInProgressAnnotation])
 	})
 
 	t.Run("refuses when a different restore is already in progress", func(t *testing.T) {
-		cluster := minimalClusterForRestore("c", ns)
-		cluster.Annotations = map[string]string{RestoreInProgressAnnotation: "older-restore"}
-		restore := minimalRestore("r1", ns, "c")
-		r := newRestoreTestReconciler(t, cluster, restore)
+		sa := minimalStandaloneForRestore("s", ns)
+		sa.Annotations = map[string]string{RestoreInProgressAnnotation: "older-restore"}
+		restore := minimalRestore("r1", ns, "s")
+		r := newRestoreTestReconciler(t, sa, restore)
 
-		err := r.setRestoreInProgressAnnotation(ctx, restore, cluster)
+		err := r.setRestoreInProgressAnnotation(ctx, restore, standaloneAsCluster(sa))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "older-restore")
 		assert.Contains(t, err.Error(), "r1")
 
 		// Annotation must NOT have been overwritten.
-		got := &neo4jv1beta1.Neo4jEnterpriseCluster{}
-		require.NoError(t, r.Get(ctx, types.NamespacedName{Name: "c", Namespace: ns}, got))
+		got := &neo4jv1beta1.Neo4jEnterpriseStandalone{}
+		require.NoError(t, r.Get(ctx, types.NamespacedName{Name: "s", Namespace: ns}, got))
 		assert.Equal(t, "older-restore", got.Annotations[RestoreInProgressAnnotation])
 	})
 }
@@ -121,107 +141,97 @@ func TestClearRestoreInProgressAnnotation(t *testing.T) {
 	ns := "default"
 
 	t.Run("clears annotation set by this restore", func(t *testing.T) {
-		cluster := minimalClusterForRestore("c", ns)
-		cluster.Annotations = map[string]string{RestoreInProgressAnnotation: "r1"}
-		restore := minimalRestore("r1", ns, "c")
-		r := newRestoreTestReconciler(t, cluster, restore)
+		sa := minimalStandaloneForRestore("s", ns)
+		sa.Annotations = map[string]string{RestoreInProgressAnnotation: "r1"}
+		restore := minimalRestore("r1", ns, "s")
+		r := newRestoreTestReconciler(t, sa, restore)
 
-		require.NoError(t, r.clearRestoreInProgressAnnotation(ctx, restore, "c", ns))
+		require.NoError(t, r.clearRestoreInProgressAnnotation(ctx, restore, "s", ns))
 
-		got := &neo4jv1beta1.Neo4jEnterpriseCluster{}
-		require.NoError(t, r.Get(ctx, types.NamespacedName{Name: "c", Namespace: ns}, got))
+		got := &neo4jv1beta1.Neo4jEnterpriseStandalone{}
+		require.NoError(t, r.Get(ctx, types.NamespacedName{Name: "s", Namespace: ns}, got))
 		_, present := got.Annotations[RestoreInProgressAnnotation]
 		assert.False(t, present, "annotation should be cleared")
 	})
 
 	t.Run("leaves annotation set by a DIFFERENT restore alone", func(t *testing.T) {
-		cluster := minimalClusterForRestore("c", ns)
-		cluster.Annotations = map[string]string{RestoreInProgressAnnotation: "other-restore"}
-		restore := minimalRestore("r1", ns, "c")
-		r := newRestoreTestReconciler(t, cluster, restore)
+		sa := minimalStandaloneForRestore("s", ns)
+		sa.Annotations = map[string]string{RestoreInProgressAnnotation: "other-restore"}
+		restore := minimalRestore("r1", ns, "s")
+		r := newRestoreTestReconciler(t, sa, restore)
 
-		require.NoError(t, r.clearRestoreInProgressAnnotation(ctx, restore, "c", ns))
+		require.NoError(t, r.clearRestoreInProgressAnnotation(ctx, restore, "s", ns))
 
-		got := &neo4jv1beta1.Neo4jEnterpriseCluster{}
-		require.NoError(t, r.Get(ctx, types.NamespacedName{Name: "c", Namespace: ns}, got))
+		got := &neo4jv1beta1.Neo4jEnterpriseStandalone{}
+		require.NoError(t, r.Get(ctx, types.NamespacedName{Name: "s", Namespace: ns}, got))
 		assert.Equal(t, "other-restore", got.Annotations[RestoreInProgressAnnotation],
 			"clear must be a no-op when the annotation belongs to a different restore")
 	})
 
 	t.Run("no-op when annotation is absent", func(t *testing.T) {
-		cluster := minimalClusterForRestore("c", ns)
-		restore := minimalRestore("r1", ns, "c")
-		r := newRestoreTestReconciler(t, cluster, restore)
+		sa := minimalStandaloneForRestore("s", ns)
+		restore := minimalRestore("r1", ns, "s")
+		r := newRestoreTestReconciler(t, sa, restore)
 
-		require.NoError(t, r.clearRestoreInProgressAnnotation(ctx, restore, "c", ns))
+		require.NoError(t, r.clearRestoreInProgressAnnotation(ctx, restore, "s", ns))
 	})
 
-	t.Run("no-op when cluster CR is gone", func(t *testing.T) {
+	t.Run("no-op when target CR is gone (or was a cluster, which never sets it)", func(t *testing.T) {
 		restore := minimalRestore("r1", ns, "gone")
 		r := newRestoreTestReconciler(t, restore)
 
-		// Cleanly handles a missing cluster — the restore finalizer must be
-		// able to release even after the cluster has already been deleted.
+		// Cleanly handles a missing standalone — the restore finalizer must be
+		// able to release even after the standalone is deleted, and a true
+		// cluster (which never sets this marker) is a no-op too.
 		require.NoError(t, r.clearRestoreInProgressAnnotation(ctx, restore, "gone", ns))
 	})
 }
 
+// The Job restore path is standalone-only, so the preflight lists standalone
+// pods via the `app=<name>` selector (StandalonePodSelector) — not the cluster
+// ServerPodSelector. This pins that swap (part of #196/#187).
 func TestRefuseRestoreIfPodsRunning(t *testing.T) {
 	ctx := context.Background()
 	ns := "default"
 
-	serverPod := func(podName string) *corev1.Pod {
+	standalonePod := func(podName, app string) *corev1.Pod {
 		return &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      podName,
 				Namespace: ns,
-				Labels: map[string]string{
-					"app.kubernetes.io/instance":  "c",
-					"app.kubernetes.io/component": "database",
-				},
+				Labels:    map[string]string{"app": app},
 			},
 			Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "neo4j", Image: "neo4j:5.26-enterprise"}}},
 		}
 	}
 
 	t.Run("no pods → allowed", func(t *testing.T) {
-		cluster := minimalClusterForRestore("c", ns)
-		restore := minimalRestore("r1", ns, "c")
-		r := newRestoreTestReconciler(t, cluster, restore)
+		sa := minimalStandaloneForRestore("s", ns)
+		restore := minimalRestore("r1", ns, "s")
+		r := newRestoreTestReconciler(t, sa, restore)
 
-		require.NoError(t, r.refuseRestoreIfPodsRunning(ctx, restore, cluster))
+		require.NoError(t, r.refuseRestoreIfPodsRunning(ctx, restore, standaloneAsCluster(sa)))
 	})
 
-	t.Run("server pods exist → refused with actionable error", func(t *testing.T) {
-		cluster := minimalClusterForRestore("c", ns)
-		restore := minimalRestore("r1", ns, "c")
-		r := newRestoreTestReconciler(t, cluster, restore, serverPod("c-server-0"), serverPod("c-server-1"))
+	t.Run("standalone pod exists → refused with actionable error", func(t *testing.T) {
+		sa := minimalStandaloneForRestore("s", ns)
+		restore := minimalRestore("r1", ns, "s")
+		r := newRestoreTestReconciler(t, sa, restore, standalonePod("s-0", "s"))
 
-		err := r.refuseRestoreIfPodsRunning(ctx, restore, cluster)
+		err := r.refuseRestoreIfPodsRunning(ctx, restore, standaloneAsCluster(sa))
 		require.Error(t, err)
 		msg := err.Error()
-		assert.Contains(t, msg, "2 server pod(s)")
+		assert.Contains(t, msg, "server pod(s)")
 		assert.Contains(t, msg, "stopCluster=true")
 		assert.Contains(t, msg, "\"r1\"")
 	})
 
-	t.Run("pods of an unrelated cluster don't trigger refusal", func(t *testing.T) {
-		cluster := minimalClusterForRestore("c", ns)
-		restore := minimalRestore("r1", ns, "c")
-		other := &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "other-server-0",
-				Namespace: ns,
-				Labels: map[string]string{
-					"app.kubernetes.io/instance":  "other",
-					"app.kubernetes.io/component": "database",
-				},
-			},
-			Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "neo4j", Image: "neo4j:5.26-enterprise"}}},
-		}
-		r := newRestoreTestReconciler(t, cluster, restore, other)
+	t.Run("pods of an unrelated instance don't trigger refusal", func(t *testing.T) {
+		sa := minimalStandaloneForRestore("s", ns)
+		restore := minimalRestore("r1", ns, "s")
+		r := newRestoreTestReconciler(t, sa, restore, standalonePod("other-0", "other"))
 
-		require.NoError(t, r.refuseRestoreIfPodsRunning(ctx, restore, cluster))
+		require.NoError(t, r.refuseRestoreIfPodsRunning(ctx, restore, standaloneAsCluster(sa)))
 	})
 }
 


### PR DESCRIPTION
**Stacked on #192** (base `fix/failed-restore-recovery`) — all edit `neo4jrestore_controller.go`. Will rebase/retarget to main after #192 merges. Theme-A restore bugs from PS validation against v1.11.2; restore *methods* verified against the [CalVer](https://neo4j.com/docs/operations-manual/current/backup-restore/restore-backup/) + [5.x](https://neo4j.com/docs/operations-manual/5/backup-restore/restore-backup/) docs.

## #196 / #187 — restore against a standalone
The Job restore path ran through the `standaloneAsCluster` synthetic wrapper, so its orchestration assumed a `Neo4jEnterpriseCluster`. Since clusters use the Cypher path (rule 75 + #192), the Job path is **standalone-only**, so the helpers are now standalone-shaped:
- **#196** — `set/clearRestoreInProgressAnnotation` mark the **`Neo4jEnterpriseStandalone`** (the "Neo4jEnterpriseCluster … not found / coordinate cluster scale-down" failure); `stopCluster`/`refuse`/`waitReady` use **`StandalonePodSelector`**.
- **#187** — DB-existence check + post-restore `CREATE/START` connect via **`NewClientForEnterpriseStandalone`** (`<name>-service`), not the cluster `<name>-client`.
- `neo4j-admin database restore` command unchanged.

## #190 — cluster restore + auto-inherit-seed-creds
With `auto-inherit-seed-creds`, the operator patched the creds Secret into `extraEnvFrom` then issued `dbms.recreateDatabase` before the StatefulSet rolled the pods onto the new env → JVM SDK "Unable to load region", restore terminal-failed with no retry. Now gated on `seedCredsRolledOut`: stay **Pending+requeue** until the STS pod template references the creds Secret **and** every replica is updated+Ready. The template-has-Secret check is decisive (a fully-ready OLD template must not pass). Routing through Pending also fixes the no-retry half.

## Tests (closing the gap)
Every restore test previously targeted a cluster — restore-to-standalone had **zero** coverage. The coordination tests are now standalone-based (regression-locking #196 + the selector swap), plus `TestSeedCredsRolledOut` for #190. All run in the existing controller envtest suite — **no new integration-lane runtime**.

Addresses #196, #187, #190 (kept OPEN until the next release ships + the PS team re-pins, per the team workflow — these fixes are on `main`, not in v1.11.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes restore orchestration and StatefulSet replica coordination on live data paths; incorrect gating could delay restores or leave scale-down races, but scope is bounded to restore flows with added unit tests.
> 
> **Overview**
> Fixes **Job-based restore when the target is a standalone** by treating that path as standalone-only: restore-in-progress annotations are written on **`Neo4jEnterpriseStandalone`**, pod checks use **`StandalonePodSelector`**, and post-restore Cypher/Bolt work uses **`newStandaloneRestoreClient`** (`<name>-service`) instead of the cluster client service. The **standalone controller** now skips re-asserting **`StatefulSet` replicas** while restore is in progress, matching the cluster gate so scale-to-0 can stick.
> 
> For **cluster Cypher restores with auto-inherited seed credentials**, the reconciler **waits in Pending** until **`seedCredsRolledOut`** reports the server STS pod template projects the creds Secret via `envFrom` and every replica is updated and Ready—avoiding seedURI against pods that still lack cloud SDK env.
> 
> Tests shift coordination coverage to standalones and add **`TestSeedCredsRolledOut`** plus standalone **`replicasReconciliationPaused`** cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c673dd77c878c4f194b43e1d0fe678a947a666f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->