### PR TITLE
fix(rbac): generate namespace-mode Role from kubebuilder markers (#199)

### DIFF
--- a/charts/neo4j-operator/templates/role.yaml
+++ b/charts/neo4j-operator/templates/role.yaml
@@ -1,4 +1,13 @@
-{{- if and .Values.rbac.create (eq .Values.operatorMode "namespace") -}}
+# This file is GENERATED. DO NOT EDIT.
+#
+# Source of truth: +kubebuilder:rbac:* markers in internal/controller/*.go.
+# To change the operator's permissions:
+#   1. Edit the relevant +kubebuilder:rbac:groups=...,resources=...,verbs=... marker
+#   2. Run 'make manifests' (regenerates config/rbac/role.yaml)
+#   3. Run 'make helm-sync-rbac' (regenerates this file)
+#
+# CI's 'make check-drift' fails if these are out of sync.
+{{- if and .Values.rbac.create (eq .Values.operatorMode "namespace") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -8,105 +17,235 @@ metadata:
     {{- include "neo4j-operator.labels" . | nindent 4 }}
 rules:
 - apiGroups:
-  - ""
+    - ""
   resources:
-  - configmaps
-  - endpoints
-  - persistentvolumeclaims
-  - secrets
-  - serviceaccounts
-  - services
-  - events
-  - pods
-  - pods/exec
-  - pods/log
+    - configmaps
+    - endpoints
+    - persistentvolumeclaims
+    - secrets
+    - serviceaccounts
+    - services
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
 - apiGroups:
-  - apps
+    - ""
   resources:
-  - statefulsets
+    - events
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+    - create
+    - patch
 - apiGroups:
-  - batch
+    - ""
   resources:
-  - cronjobs
-  - jobs
+    - nodes
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+    - get
+    - list
+    - watch
 - apiGroups:
-  - neo4j.neo4j.com
+    - ""
   resources:
-  - neo4jbackups
-  - neo4jdatabases
-  - neo4jenterpriseclusters
-  - neo4jenterprisestandalones
-  - neo4jplugins
-  - neo4jrestores
-  - neo4jshardeddatabases
+    - pods
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+    - delete
+    - get
+    - list
+    - watch
 - apiGroups:
-  - neo4j.neo4j.com
+    - ""
   resources:
-  - neo4jbackups/finalizers
-  - neo4jdatabases/finalizers
-  - neo4jenterpriseclusters/finalizers
-  - neo4jenterprisestandalones/finalizers
-  - neo4jplugins/finalizers
-  - neo4jrestores/finalizers
-  - neo4jshardeddatabases/finalizers
+    - pods/log
   verbs:
-  - update
+    - get
 - apiGroups:
-  - neo4j.neo4j.com
+    - apps
   resources:
-  - neo4jbackups/status
-  - neo4jdatabases/status
-  - neo4jenterpriseclusters/status
-  - neo4jenterprisestandalones/status
-  - neo4jplugins/status
-  - neo4jrestores/status
-  - neo4jshardeddatabases/status
+    - deployments
+    - statefulsets
   verbs:
-  - get
-  - patch
-  - update
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
 - apiGroups:
-  - networking.k8s.io
+    - batch
   resources:
-  - ingresses
+    - cronjobs
+    - jobs
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - cert-manager.io
+  resources:
+    - certificates
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - cert-manager.io
+  resources:
+    - clusterissuers
+    - issuers
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - monitoring.coreos.com
+  resources:
+    - prometheusrules
+    - servicemonitors
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - neo4j.neo4j.com
+  resources:
+    - neo4jauthrules
+    - neo4jbackups
+    - neo4jdatabases
+    - neo4jenterpriseclusters
+    - neo4jenterprisestandalones
+    - neo4jplugins
+    - neo4jrestores
+    - neo4jrolebindings
+    - neo4jroles
+    - neo4jshardeddatabases
+    - neo4jusers
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - neo4j.neo4j.com
+  resources:
+    - neo4jauthrules/finalizers
+    - neo4jbackups/finalizers
+    - neo4jdatabases/finalizers
+    - neo4jenterpriseclusters/finalizers
+    - neo4jenterprisestandalones/finalizers
+    - neo4jplugins/finalizers
+    - neo4jrestores/finalizers
+    - neo4jrolebindings/finalizers
+    - neo4jroles/finalizers
+    - neo4jshardeddatabases/finalizers
+    - neo4jusers/finalizers
+  verbs:
+    - update
+- apiGroups:
+    - neo4j.neo4j.com
+  resources:
+    - neo4jauthrules/status
+    - neo4jbackups/status
+    - neo4jdatabases/status
+    - neo4jenterpriseclusters/status
+    - neo4jenterprisestandalones/status
+    - neo4jplugins/status
+    - neo4jrestores/status
+    - neo4jrolebindings/status
+    - neo4jroles/status
+    - neo4jshardeddatabases/status
+    - neo4jusers/status
+  verbs:
+    - get
+    - patch
+    - update
+- apiGroups:
+    - networking.k8s.io
+  resources:
+    - ingresses
+    - networkpolicies
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - rbac.authorization.k8s.io
+  resources:
+    - rolebindings
+    - roles
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - route.openshift.io
+  resources:
+    - routes
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - storage.k8s.io
+  resources:
+    - storageclasses
+  verbs:
+    - get
+    - list
+    - watch
+{{- if .Values.rbac.externalSecretsIntegration }}
+- apiGroups:
+    - external-secrets.io
+  resources:
+    - clustersecretstores
+    - secretstores
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - external-secrets.io
+  resources:
+    - externalsecrets
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+{{- end }}
 {{- end }}

--- a/scripts/helm-sync-rbac.sh
+++ b/scripts/helm-sync-rbac.sh
@@ -86,6 +86,51 @@ EOF
 
 echo "Wrote $DST from $SRC"
 
+# --- Namespaced manager Role ------------------------------------------------
+# operatorMode: namespace watches only .Release.Namespace, so the manager
+# permissions are granted via a namespaced Role + RoleBinding instead of a
+# ClusterRole. This Role MUST carry the SAME rules as the ClusterRole above —
+# the manager's cache builds informers (LIST/WATCH) for every reconciled CRD
+# AND the label-filtered Job/CronJob/Certificate caches; if any of those is
+# missing from the Role, WaitForCacheSync times out and the operator exits at
+# startup (issue #199). Generating it from the same CORE_RULES keeps it
+# complete and drift-proof — check-drift fails if it falls behind.
+#
+# Note: a handful of CORE_RULES entries name cluster-scoped resources (nodes,
+# cert-manager clusterissuers/issuers, external-secrets cluster*stores). In a
+# namespaced Role these are inert — they neither error nor grant anything — so
+# features that read them directly (zone-aware scheduling, ClusterIssuer TLS)
+# remain a documented namespace-mode limitation (#197), distinct from the
+# startup crash this Role fixes.
+ROLE_DST="${ROOT}/charts/neo4j-operator/templates/role.yaml"
+cat > "$ROLE_DST" <<EOF
+# This file is GENERATED. DO NOT EDIT.
+#
+# Source of truth: +kubebuilder:rbac:* markers in internal/controller/*.go.
+# To change the operator's permissions:
+#   1. Edit the relevant +kubebuilder:rbac:groups=...,resources=...,verbs=... marker
+#   2. Run 'make manifests' (regenerates config/rbac/role.yaml)
+#   3. Run 'make helm-sync-rbac' (regenerates this file)
+#
+# CI's 'make check-drift' fails if these are out of sync.
+{{- if and .Values.rbac.create (eq .Values.operatorMode "namespace") }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "neo4j-operator.fullname" . }}-manager-role
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "neo4j-operator.labels" . | nindent 4 }}
+rules:
+${CORE_RULES}
+{{- if .Values.rbac.externalSecretsIntegration }}
+${EXT_SECRETS_RULES}
+{{- end }}
+{{- end }}
+EOF
+
+echo "Wrote $ROLE_DST from $SRC"
+
 # --- Metrics RBAC -----------------------------------------------------------
 # controller-runtime's secure metrics endpoint authenticates scrapers via
 # TokenReview and authorizes them via SubjectAccessReview. That requires the


### PR DESCRIPTION
## Summary

`operatorMode: namespace` installs grant the manager its permissions via a namespaced **Role**, but `charts/neo4j-operator/templates/role.yaml` was **hand-maintained and had drifted** far behind the kubebuilder-generated source (`config/rbac/role.yaml`). It was missing:

- `cert-manager.io/certificates`
- `neo4jusers` / `neo4jroles` / `neo4jrolebindings` / `neo4jauthrules` (+ their `/finalizers` and `/status`)
- `apps/deployments`, `networking.k8s.io/networkpolicies`, `monitoring.coreos.com`, `rbac.../roles+rolebindings`, `route.openshift.io/routes`, `storage.k8s.io/storageclasses`

## Why it crashed (#199)

In namespace mode the manager builds informers (LIST/WATCH) for **every reconciled CRD** (the user/role/rolebinding/authrule controllers register in every mode) and the **label-filtered `Certificate` cache**. With those verbs denied by RBAC, `WaitForCacheSync` times out and the operator **exits at startup** — exactly the failure reported in #199.

## Fix

Stop hand-maintaining the Role. `scripts/helm-sync-rbac.sh` now generates `templates/role.yaml` (kind: `Role`, namespaced, gated on `operatorMode == namespace`) from the **same `CORE_RULES` / `EXT_SECRETS_RULES`** it already uses for `clusterrole.yaml`. The two can never diverge again, and `make check-drift` enforces it in CI.

## Verification

- `helm template` — namespace mode emits the manager **Role** (no manager ClusterRole); cluster mode emits the **ClusterRole** (no manager Role); metrics ClusterRoles present in both; `rbac.externalSecretsIntegration=true` adds the external-secrets rules under the same `{{- if }}` gate.
- `make helm-sync-rbac` is idempotent; `make check-drift` (pre-commit) passes; `helm lint` clean.

## Known limitation (out of scope — tracked under #197)

A few `CORE_RULES` entries name **cluster-scoped** resources (`nodes`, cert-manager `clusterissuers`/`issuers`, external-secrets `cluster*stores`). In a namespaced Role these are **inert** — they don't error and don't grant anything. They are *direct reads*, not cached informers, so they don't block cache sync (no crash). Features that read them at reconcile time — zone-aware scheduling (`topology_scheduler.discoverAvailabilityZones`) and `ClusterIssuer`-based TLS — remain a documented namespace-mode limitation, distinct from this startup-crash fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands operator RBAC in namespace Helm installs to match cluster mode; incorrect rules could over-grant in-namespace or still leave edge cases for cluster-scoped reads documented under #197.
> 
> **Overview**
> **Namespace-mode Helm installs** no longer rely on a hand-maintained manager **Role** that had fallen behind kubebuilder RBAC. `make helm-sync-rbac` now writes `charts/neo4j-operator/templates/role.yaml` from the same **`CORE_RULES` / external-secrets split** as `clusterrole.yaml`, with a generated-file header and the existing `operatorMode: namespace` + `rbac.create` gates.
> 
> The regenerated Role adds the permissions that were missing (e.g. cert-manager **certificates**, Neo4j **users/roles/rolebindings/authrules**, **deployments**, **networkpolicies**, monitoring, OpenShift **routes**, **storageclasses**, and related finalizers/status). That aligns RBAC with what the manager’s informers need so **`WaitForCacheSync` no longer fails at startup** ([#199](https://github.com/...)). **`make check-drift`** keeps the Role and ClusterRole in sync going forward.
> 
> The script documents that a few cluster-scoped rule entries in a namespaced Role stay **inert** (nodes, ClusterIssuer-style reads)—a known namespace-mode limitation ([#197](https://github.com/...)), separate from this crash fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14d212451755ac3a23c35858f75ccad513ab58d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->