### PR TITLE
fix(standalone): expose bolt/http on headless service for parity (#184)

### DIFF
--- a/docs/user_guide/external_access.md
+++ b/docs/user_guide/external_access.md
@@ -11,6 +11,31 @@ The Neo4j Kubernetes Operator supports multiple methods for external access:
 - **NodePort** - Direct node access (on-premise/development)
 - **Ingress** - HTTP/HTTPS access through ingress controllers
 
+## Services created by the operator
+
+The operator names its Services by deployment **kind**, and the names are
+stable: they are baked into the issued TLS certificate's SANs and into each
+pod's stable DNS identity, so they are **not** interchangeable between cluster
+and standalone.
+
+| Service | `Neo4jEnterpriseCluster` | `Neo4jEnterpriseStandalone` | Ports |
+|---|---|---|---|
+| Client-facing (your apps connect here) | `{name}-client` | `{name}-service` | `bolt 7687`, `http 7474`, `https 7473` (TLS); standalone also exposes `metrics 2004` here when monitoring is on |
+| Headless (stable per-pod DNS) | `{name}-headless` | `{name}-headless` | `bolt 7687`, `http 7474`, `backup 6362`, `https 7473` (TLS) |
+| Discovery / internals (cluster only) | `{name}-discovery`, `{name}-internals` | — | clustering ports (`6000/7000/7688/7689`) |
+| Metrics (cluster only; standalone folds metrics into its client service) | `{name}-metrics` (`2004`) | — | `2004` |
+
+Notes:
+
+- **Client-service name differs by kind** (`-client` for clusters, `-service`
+  for standalone). This is intentional and load-bearing — use the right name
+  for the kind you deployed. A pod's stable address is always
+  `{name}-0.{name}-headless.<namespace>.svc.cluster.local`.
+- **The standalone headless service exposes `bolt`/`http`/`backup` (and `https`
+  under TLS)** for direct per-pod addressing, mirroring the cluster headless
+  service. It does **not** expose the clustering ports (`6000/7000/7688/7689`):
+  a standalone is a single non-clustered node, so nothing listens on them.
+
 ## Quick Start
 
 ### Development Access

--- a/internal/controller/neo4jenterprisestandalone_controller.go
+++ b/internal/controller/neo4jenterprisestandalone_controller.go
@@ -521,12 +521,32 @@ func (r *Neo4jEnterpriseStandaloneReconciler) reconcileService(ctx context.Conte
 	logger := log.FromContext(ctx)
 
 	// Headless Service first — the StatefulSet's spec.serviceName depends on it.
-	headless := r.createHeadlessService(standalone)
-	if err := controllerutil.SetControllerReference(standalone, headless, r.Scheme); err != nil {
-		return fmt.Errorf("failed to set owner reference on headless Service: %w", err)
-	}
+	// Capture the desired spec/labels up front: controllerutil.CreateOrUpdate
+	// Gets the live object into its argument before running the mutate fn, so a
+	// no-op mutate would drop our desired state on the update path — an existing
+	// headless Service would keep its old ports across an operator upgrade (the
+	// #184 port-parity additions would never apply). Re-assert the desired
+	// fields inside the closure instead. ClusterIP is immutable once set, so it
+	// is only assigned on create (empty live value).
+	desiredHeadless := r.createHeadlessService(standalone)
+	headless := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+		Name:      desiredHeadless.Name,
+		Namespace: desiredHeadless.Namespace,
+	}}
 	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		_, err := controllerutil.CreateOrUpdate(ctx, r.Client, headless, func() error { return nil })
+		_, err := controllerutil.CreateOrUpdate(ctx, r.Client, headless, func() error {
+			if err := controllerutil.SetControllerReference(standalone, headless, r.Scheme); err != nil {
+				return err
+			}
+			headless.Labels = desiredHeadless.Labels
+			if headless.Spec.ClusterIP == "" {
+				headless.Spec.ClusterIP = desiredHeadless.Spec.ClusterIP
+			}
+			headless.Spec.Selector = desiredHeadless.Spec.Selector
+			headless.Spec.PublishNotReadyAddresses = desiredHeadless.Spec.PublishNotReadyAddresses
+			headless.Spec.Ports = desiredHeadless.Spec.Ports
+			return nil
+		})
 		return err
 	}); err != nil {
 		return fmt.Errorf("failed to create or update headless Service: %w", err)
@@ -566,9 +586,52 @@ func (r *Neo4jEnterpriseStandaloneReconciler) reconcileService(ctx context.Conte
 // gives the standalone pod a stable DNS identity for backup, peer Bolt
 // connections, and any other pod-direct addressing. ClusterIP=None makes
 // it headless; the same `app: <name>` selector matches the pod created by
-// the StatefulSet. Only the backup port (6362) is exposed since the
-// client-facing Service ({name}-service) handles Bolt/HTTP.
+// the StatefulSet.
+//
+// Ports mirror the client-reachable ports the cluster headless service
+// exposes (#184): bolt + http (+ https under cert-manager TLS) for direct
+// pod addressing via {name}-0.{name}-headless, plus backup (6362). Combined
+// with PublishNotReadyAddresses below, this lets clients reach the pod over
+// the headless name even before the readiness probe goes green — the
+// client-facing {name}-service ClusterIP does NOT publish not-ready
+// addresses, so it can't during startup.
+//
+// The cluster-only clustering ports (discovery 6000, routing 7688, raft
+// 7000, tx 7689) are intentionally omitted: a standalone is a single
+// non-clustered node that doesn't run RAFT/discovery, so nothing listens
+// on them — exposing dead ports would be misleading.
 func (r *Neo4jEnterpriseStandaloneReconciler) createHeadlessService(standalone *neo4jv1beta1.Neo4jEnterpriseStandalone) *corev1.Service {
+	ports := []corev1.ServicePort{
+		{
+			Name:       "bolt",
+			Port:       resources.BoltPort,
+			TargetPort: intstr.FromInt(resources.BoltPort),
+			Protocol:   corev1.ProtocolTCP,
+		},
+		{
+			Name:       "http",
+			Port:       resources.HTTPPort,
+			TargetPort: intstr.FromInt(resources.HTTPPort),
+			Protocol:   corev1.ProtocolTCP,
+		},
+		{
+			Name:       "backup",
+			Port:       resources.BackupPort,
+			TargetPort: intstr.FromInt(resources.BackupPort),
+			Protocol:   corev1.ProtocolTCP,
+		},
+	}
+
+	// Mirror the client service's HTTPS exposure under cert-manager TLS.
+	if standalone.Spec.TLS != nil && standalone.Spec.TLS.Mode == "cert-manager" {
+		ports = append(ports, corev1.ServicePort{
+			Name:       "https",
+			Port:       resources.HTTPSPort,
+			TargetPort: intstr.FromInt(resources.HTTPSPort),
+			Protocol:   corev1.ProtocolTCP,
+		})
+	}
+
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-headless", standalone.Name),
@@ -591,14 +654,7 @@ func (r *Neo4jEnterpriseStandaloneReconciler) createHeadlessService(standalone *
 			Selector: map[string]string{
 				"app": standalone.Name,
 			},
-			Ports: []corev1.ServicePort{
-				{
-					Name:       "backup",
-					Port:       6362,
-					TargetPort: intstr.FromInt(6362),
-					Protocol:   corev1.ProtocolTCP,
-				},
-			},
+			Ports: ports,
 		},
 	}
 }

--- a/internal/controller/standalone_headless_service_test.go
+++ b/internal/controller/standalone_headless_service_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package controller
+
+// Contract tests for the standalone headless Service ({name}-headless).
+// Added with #184: the standalone headless service historically exposed only
+// the backup port (6362), unlike the cluster headless service which also
+// exposes bolt/http for direct pod addressing. These tests pin the parity
+// additions (bolt/http, +https under TLS) AND the deliberate omission of the
+// cluster-only clustering ports (a standalone is single-node, nothing listens
+// on RAFT/discovery/tx), so neither regresses.
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
+	"github.com/neo4j-partners/neo4j-kubernetes-operator/internal/resources"
+)
+
+func headlessPortNames(svc *corev1.Service) map[string]int32 {
+	out := map[string]int32{}
+	for _, p := range svc.Spec.Ports {
+		out[p.Name] = p.Port
+	}
+	return out
+}
+
+func TestStandaloneHeadlessService_ExposesClientPortsForParity(t *testing.T) {
+	standalone := &neo4jv1beta1.Neo4jEnterpriseStandalone{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-standalone", Namespace: "default"},
+		Spec: neo4jv1beta1.Neo4jEnterpriseStandaloneSpec{
+			Image:   neo4jv1beta1.ImageSpec{Repo: "neo4j", Tag: "5.26-enterprise"},
+			Storage: neo4jv1beta1.StorageSpec{ClassName: "standard", Size: "10Gi"},
+		},
+	}
+
+	r := &Neo4jEnterpriseStandaloneReconciler{}
+	svc := r.createHeadlessService(standalone)
+	require.NotNil(t, svc)
+
+	assert.Equal(t, "my-standalone-headless", svc.Name)
+	assert.Equal(t, corev1.ClusterIPNone, svc.Spec.ClusterIP, "headless service must have ClusterIP=None")
+	assert.True(t, svc.Spec.PublishNotReadyAddresses, "headless service must publish not-ready addresses for startup reachability")
+	assert.Equal(t, standalone.Name, svc.Spec.Selector["app"], "headless selector must match the standalone pod label")
+
+	ports := headlessPortNames(svc)
+
+	// Parity with the cluster headless service: bolt + http for direct pod
+	// addressing, plus the backup port.
+	assert.Equal(t, int32(resources.BoltPort), ports["bolt"], "bolt port must be exposed (#184 parity)")
+	assert.Equal(t, int32(resources.HTTPPort), ports["http"], "http port must be exposed (#184 parity)")
+	assert.Equal(t, int32(resources.BackupPort), ports["backup"], "backup port must remain exposed")
+
+	// Without TLS, https must NOT be present.
+	_, hasHTTPS := ports["https"]
+	assert.False(t, hasHTTPS, "https must not be exposed when TLS is disabled")
+
+	// Cluster-only clustering ports must NOT appear on a standalone: the single
+	// node runs no RAFT/discovery, so nothing listens on them.
+	for _, p := range []int32{resources.DiscoveryPort, resources.RoutingPort, resources.RaftPort, resources.TransactionPort} {
+		for name, port := range ports {
+			assert.NotEqual(t, p, port, "clustering port %d (%q) must not be exposed on a standalone headless service", p, name)
+		}
+	}
+}
+
+func TestStandaloneHeadlessService_ExposesHTTPSUnderTLS(t *testing.T) {
+	standalone := &neo4jv1beta1.Neo4jEnterpriseStandalone{
+		ObjectMeta: metav1.ObjectMeta{Name: "tls-standalone", Namespace: "default"},
+		Spec: neo4jv1beta1.Neo4jEnterpriseStandaloneSpec{
+			Image:   neo4jv1beta1.ImageSpec{Repo: "neo4j", Tag: "5.26-enterprise"},
+			Storage: neo4jv1beta1.StorageSpec{ClassName: "standard", Size: "10Gi"},
+			TLS:     &neo4jv1beta1.TLSSpec{Mode: "cert-manager"},
+		},
+	}
+
+	r := &Neo4jEnterpriseStandaloneReconciler{}
+	svc := r.createHeadlessService(standalone)
+	require.NotNil(t, svc)
+
+	ports := headlessPortNames(svc)
+	assert.Equal(t, int32(resources.HTTPSPort), ports["https"], "https must be exposed under cert-manager TLS, mirroring the client service")
+	// bolt/http/backup still present alongside https.
+	assert.Equal(t, int32(resources.BoltPort), ports["bolt"])
+	assert.Equal(t, int32(resources.HTTPPort), ports["http"])
+	assert.Equal(t, int32(resources.BackupPort), ports["backup"])
+}


### PR DESCRIPTION
## Summary

PS validation (#184) flagged that the standalone and cluster **headless** services expose different ports, and that the client-facing services have different names. This addresses the port asymmetry (additive, safe) and documents the naming convention; it deliberately does **not** rename services (see below).

## What changed

**1. Standalone headless service port parity.** `{name}-headless` exposed only `backup 6362`. It now also exposes `bolt 7687` + `http 7474` (and `https 7473` under cert-manager TLS), matching the cluster headless service for direct per-pod addressing (`{name}-0.{name}-headless...`). The cluster-only clustering ports (`6000/7000/7688/7689`) stay **omitted on purpose** — a standalone is a single non-clustered node, so nothing listens on them. These ports are already permitted to the pod by `BuildNetworkPolicyForStandalone`, so this is purely DNS-addressability, **not new exposure**.

**2. Headless reconcile now converges.** `reconcileService` used `CreateOrUpdate` with a no-op mutate, which Gets the live object and never re-applies desired state — so an **existing** standalone would keep its old single-port headless service across an operator upgrade and never gain the new ports. Desired spec is now re-asserted inside the mutate closure (ClusterIP is immutable → only set on create).

**3. Docs.** `docs/user_guide/external_access.md` gains a "Services created by the operator" table documenting the per-kind service names + ports.

## What was deliberately NOT changed: the `-client` / `-service` name split

The client-facing service is `{name}-client` for clusters and `{name}-service` for standalone. I audited every consumer — it's used consistently per-kind across TLS cert SANs, status `.endpoints`, `connection_helper.go`, MCP, and routes. The only place that crossed the wires was the restore path (#187/#196), **already fixed in #200**. Renaming is high-blast-radius: the issued TLS certificate's SANs are derived from the current name, so a rename breaks TLS for every existing instance until certs re-issue, plus breaks user-hardcoded connection strings. So the names are documented as intentional/load-bearing rather than renamed.

## Regression check

- `bolt`/`http`/`backup` reachability for the backup Job is unchanged (its FQDN helper hardcodes `:6362`).
- Convergence is deterministic (no oscillation); ClusterIP immutability respected; owner-ref set is idempotent; existing instances take exactly one update to add ports, then stable.
- `go build`, `go vet`, `internal/resources` tests, and the **full `internal/controller` envtest package** all pass.
- New: `TestStandaloneHeadlessService_ExposesClientPortsForParity`, `_ExposesHTTPSUnderTLS`.

Addresses #184 (kept OPEN until the next release ships + PS re-pins, per the team workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Service port definitions and a reconcile fix for existing headless Services; backup behavior is unchanged and clustering ports stay omitted on standalone.
> 
> **Overview**
> Standalone **`{name}-headless`** Services now expose **bolt**, **http**, and **backup** (plus **https** when cert-manager TLS is on), aligning with cluster headless behavior for per-pod DNS (`{name}-0.{name}-headless...`) while still omitting cluster-only clustering ports.
> 
> **`reconcileService`** no longer uses a no-op `CreateOrUpdate` mutate for the headless Service; it re-applies labels, selector, `PublishNotReadyAddresses`, and **ports** on update so upgraded operators can add the new ports to existing standalones (ClusterIP only set on create).
> 
> **`docs/user_guide/external_access.md`** adds a table of operator-created Services, ports, and the intentional **`{name}-client` vs `{name}-service`** naming split. New contract tests lock in headless port parity and TLS behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b337329601702611178d3dbf23883f56f93c8652. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->