### PR TITLE
fix(cluster): surface un-drained servers after scale-down (#173, PR1)

### DIFF
--- a/docs/user_guide/clustering.md
+++ b/docs/user_guide/clustering.md
@@ -347,6 +347,28 @@ kubectl patch neo4jenterprisecluster my-cluster --type='merge' -p='{"spec":{"top
 kubectl edit neo4jenterprisecluster my-cluster
 ```
 
+> **Scaling down requires manual server drain (for now).** Reducing
+> `spec.topology.servers` lowers the StatefulSet replica count, but the
+> operator does **not yet** deallocate and drop the removed Neo4j servers
+> automatically (tracked in issue #173). Until it does, the removed servers linger in
+> `SHOW SERVERS` and any databases allocated to them can be left
+> **under-replicated**. The operator surfaces this as a `ServersPendingDrain`
+> condition (`status.conditions`) and a `ScaleDownPendingDrain` warning event.
+> To complete a scale-down safely, drain the removed servers yourself before/
+> after the replica reduction:
+>
+> ```cypher
+> -- on the system database, for each removed server (by id from SHOW SERVERS):
+> DEALLOCATE DATABASES FROM SERVER '<server-id>';   -- wait until SHOW SERVERS shows 'Deallocated'
+> DROP SERVER '<server-id>';
+> ```
+>
+> If `DEALLOCATE` fails because a database's topology can no longer be
+> satisfied by the remaining servers, reduce that database's topology first
+> (`ALTER DATABASE … SET TOPOLOGY …`) or add servers — do not force-remove a
+> server hosting the only/majority primary of a database (that path is
+> disaster recovery, not scaling).
+
 ### Rolling Upgrades
 
 ```yaml

--- a/internal/controller/conditions.go
+++ b/internal/controller/conditions.go
@@ -19,6 +19,13 @@ const (
 
 	// ConditionTypeDatabasesHealthy indicates all expected user databases are online.
 	ConditionTypeDatabasesHealthy = "DatabasesHealthy"
+
+	// ConditionTypeServersPendingDrain indicates the cluster still has Neo4j
+	// servers registered beyond spec.topology.servers (i.e. a scale-down whose
+	// removed servers have not yet been deallocated + dropped). True means
+	// databases may be under-replicated on those servers; the operator does not
+	// yet auto-drain them (#173).
+	ConditionTypeServersPendingDrain = "ServersPendingDrain"
 )
 
 // Reason constants for the Ready condition across all CRDs.
@@ -43,6 +50,8 @@ const (
 	ConditionReasonAllDatabasesOnline     = "AllDatabasesOnline"
 	ConditionReasonDatabaseOffline        = "DatabaseOffline"
 	ConditionReasonDiagnosticsUnavailable = "DiagnosticsUnavailable"
+	ConditionReasonServersPendingDrain    = "ServersPendingDrain"
+	ConditionReasonNoServersPendingDrain  = "NoServersPendingDrain"
 )
 
 // SetReadyCondition sets the standard "Ready" condition on a conditions slice.

--- a/internal/controller/events.go
+++ b/internal/controller/events.go
@@ -14,6 +14,7 @@ const (
 	EventReasonRouteAPINotFound        = "RouteAPINotFound"
 	EventReasonMCPApocMissing          = "MCPApocMissing"
 	EventReasonReconcileFailed         = "ReconcileFailed"
+	EventReasonScaleDownPendingDrain   = "ScaleDownPendingDrain"
 )
 
 // Rolling upgrade events

--- a/internal/controller/neo4jenterprisecluster_controller.go
+++ b/internal/controller/neo4jenterprisecluster_controller.go
@@ -595,6 +595,12 @@ func (r *Neo4jEnterpriseClusterReconciler) Reconcile(ctx context.Context, req ct
 	// Note: Split-brain detection is already performed in verifyNeo4jClusterFormation
 	statusChanged := r.updateClusterStatus(ctx, cluster, "Ready", "Neo4j cluster is fully formed and ready")
 
+	// Surface any servers still registered beyond spec.topology.servers after a
+	// scale-down (not yet deallocated/dropped) as a condition + Warning event.
+	// The Ready check above compares against the new, smaller server count, so
+	// without this an incomplete scale-down silently looks healthy (#173).
+	r.reconcileScaleDownDrainStatus(ctx, cluster)
+
 	// Update property sharding readiness status if enabled
 	if cluster.Spec.PropertySharding != nil && cluster.Spec.PropertySharding.Enabled {
 		if err := r.updatePropertyShardingStatus(ctx, cluster, true); err != nil {

--- a/internal/controller/scale_down.go
+++ b/internal/controller/scale_down.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
+	neo4jclient "github.com/neo4j-partners/neo4j-kubernetes-operator/internal/neo4j"
+)
+
+// parseServerOrdinal extracts the StatefulSet pod ordinal N from a Neo4j server
+// address or name of the form "<cluster>-server-<N>[...]". Server identity in
+// SHOW SERVERS is by address; the operator's pods are "<cluster>-server-<N>",
+// so the ordinal tells us which server a row corresponds to (rule 47).
+func parseServerOrdinal(s, clusterName string) (int, bool) {
+	prefix := clusterName + "-server-"
+	idx := strings.Index(s, prefix)
+	if idx < 0 {
+		return 0, false
+	}
+	rest := s[idx+len(prefix):]
+	end := 0
+	for end < len(rest) && rest[end] >= '0' && rest[end] <= '9' {
+		end++
+	}
+	if end == 0 {
+		return 0, false
+	}
+	n, err := strconv.Atoi(rest[:end])
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// serversPendingDrain returns the identifiers of servers still registered with
+// the cluster whose pod ordinal is >= desiredServers — i.e. servers slated for
+// removal by a scale-down that have NOT yet been deallocated and dropped. They
+// linger in SHOW SERVERS (often Enabled but Unavailable once their pod is gone)
+// and their databases may be left under-replicated. Servers already in a
+// terminal removal state (Deallocated/Dropped) are excluded — they're being
+// handled. Pure function so the detection is unit-testable without a cluster.
+func serversPendingDrain(servers []neo4jclient.ServerInfo, clusterName string, desiredServers int) []string {
+	var pending []string
+	for _, s := range servers {
+		ord, ok := parseServerOrdinal(s.Address, clusterName)
+		if !ok {
+			ord, ok = parseServerOrdinal(s.Name, clusterName)
+		}
+		if !ok || ord < desiredServers {
+			continue
+		}
+		switch strings.ToLower(s.State) {
+		case "dropped", "deallocated":
+			continue
+		}
+		id := s.Name
+		if id == "" {
+			id = s.Address
+		}
+		pending = append(pending, id)
+	}
+	return pending
+}
+
+// reconcileScaleDownDrainStatus surfaces, as a status condition + a one-shot
+// Warning event, any servers left registered beyond spec.topology.servers after
+// a scale-down. The operator does not yet auto-deallocate/drop removed servers
+// (#173), so this makes the resulting under-replication VISIBLE instead of it
+// silently passing the Ready check (which compares against the new, smaller
+// server count). Non-fatal: connection / query / status-write failures are
+// swallowed — this is observability, never a reconcile gate.
+func (r *Neo4jEnterpriseClusterReconciler) reconcileScaleDownDrainStatus(ctx context.Context, cluster *neo4jv1beta1.Neo4jEnterpriseCluster) {
+	logger := log.FromContext(ctx)
+	desired := int(cluster.Spec.Topology.Servers)
+	if desired <= 0 {
+		return
+	}
+
+	nc, err := r.createNeo4jClient(ctx, cluster)
+	if err != nil {
+		logger.V(1).Info("Skipping scale-down drain status: could not create Neo4j client", "error", err)
+		return
+	}
+	defer nc.Close()
+
+	servers, err := nc.ListServers(ctx)
+	if err != nil {
+		logger.V(1).Info("Skipping scale-down drain status: SHOW SERVERS failed", "error", err)
+		return
+	}
+
+	pending := serversPendingDrain(servers, cluster.Name, desired)
+
+	status := metav1.ConditionFalse
+	reason := ConditionReasonNoServersPendingDrain
+	message := "No servers pending drain"
+	if len(pending) > 0 {
+		status = metav1.ConditionTrue
+		reason = ConditionReasonServersPendingDrain
+		message = fmt.Sprintf("%d server(s) registered beyond spec.topology.servers=%d and not yet deallocated/dropped: %s. Databases may be under-replicated on these servers — the operator does not yet auto-drain removed servers (#173). Deallocate them (DEALLOCATE DATABASES FROM SERVER) and DROP SERVER manually, or scale back up.",
+			len(pending), desired, strings.Join(pending, ", "))
+	}
+
+	// Emit the Warning only on transition INTO the pending state to avoid
+	// per-reconcile spam.
+	prev := findCondition(cluster.Status.Conditions, ConditionTypeServersPendingDrain)
+	wasPending := prev != nil && prev.Status == metav1.ConditionTrue
+
+	// Persist via refetch + RetryOnConflict (never write a stale in-memory
+	// object — cf. #207).
+	writeErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest := &neo4jv1beta1.Neo4jEnterpriseCluster{}
+		if getErr := r.Get(ctx, client.ObjectKeyFromObject(cluster), latest); getErr != nil {
+			return getErr
+		}
+		SetNamedCondition(&latest.Status.Conditions, ConditionTypeServersPendingDrain,
+			latest.Generation, status, reason, message)
+		return r.Status().Update(ctx, latest)
+	})
+	if writeErr != nil {
+		logger.Error(writeErr, "Failed to update ServersPendingDrain condition (non-fatal)")
+		return
+	}
+
+	if len(pending) > 0 && !wasPending {
+		r.Recorder.Event(cluster, corev1.EventTypeWarning, EventReasonScaleDownPendingDrain, message)
+	}
+}

--- a/internal/controller/scale_down.go
+++ b/internal/controller/scale_down.go
@@ -69,7 +69,14 @@ func serversPendingDrain(servers []neo4jclient.ServerInfo, clusterName string, d
 		case "dropped", "deallocated":
 			continue
 		}
-		id := s.Name
+		// Report the serverId — it's always populated and is what
+		// DEALLOCATE/DROP SERVER accept. The `name` column is often empty
+		// (defaults to the id) and the bolt `address` (…:7687) is NOT a valid
+		// server-management argument. Fall back only if id is somehow missing.
+		id := s.ID
+		if id == "" {
+			id = s.Name
+		}
 		if id == "" {
 			id = s.Address
 		}

--- a/internal/controller/scale_down_test.go
+++ b/internal/controller/scale_down_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package controller
+
+// Unit tests for the #173 scale-down drain detection (PR1: honest status). The
+// detection is pure over a SHOW SERVERS result + desired server count, so it's
+// verified without a live cluster.
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	neo4jclient "github.com/neo4j-partners/neo4j-kubernetes-operator/internal/neo4j"
+)
+
+func TestParseServerOrdinal(t *testing.T) {
+	cases := []struct {
+		in      string
+		cluster string
+		want    int
+		ok      bool
+	}{
+		{"my-cluster-server-2.my-cluster-headless.ns.svc.cluster.local:7687", "my-cluster", 2, true},
+		{"my-cluster-server-0:6000", "my-cluster", 0, true},
+		{"my-cluster-server-11", "my-cluster", 11, true},
+		{"10.0.0.5:7687", "my-cluster", 0, false},       // bare IP — no match
+		{"other-server-3", "my-cluster", 0, false},      // wrong cluster prefix
+		{"my-cluster-server-", "my-cluster", 0, false},  // no digits
+		{"my-cluster-server-x", "my-cluster", 0, false}, // non-numeric
+	}
+	for _, c := range cases {
+		got, ok := parseServerOrdinal(c.in, c.cluster)
+		assert.Equal(t, c.ok, ok, "ok mismatch for %q", c.in)
+		if c.ok {
+			assert.Equal(t, c.want, got, "ordinal mismatch for %q", c.in)
+		}
+	}
+}
+
+func srv(addr, state string) neo4jclient.ServerInfo {
+	return neo4jclient.ServerInfo{Name: addr, Address: addr, State: state, Health: "Available"}
+}
+
+func TestServersPendingDrain(t *testing.T) {
+	cluster := "c"
+	addr := func(n int) string { return "c-server-" + strconv.Itoa(n) + ".c-headless.ns.svc.cluster.local:7687" }
+
+	t.Run("no scale-down: all ordinals < desired", func(t *testing.T) {
+		servers := []neo4jclient.ServerInfo{srv(addr(0), "Enabled"), srv(addr(1), "Enabled"), srv(addr(2), "Enabled")}
+		assert.Empty(t, serversPendingDrain(servers, cluster, 3))
+	})
+
+	t.Run("5->3 scale-down: ordinals 3,4 still Enabled are pending", func(t *testing.T) {
+		servers := []neo4jclient.ServerInfo{
+			srv(addr(0), "Enabled"), srv(addr(1), "Enabled"), srv(addr(2), "Enabled"),
+			srv(addr(3), "Enabled"), srv(addr(4), "Enabled"),
+		}
+		pending := serversPendingDrain(servers, cluster, 3)
+		assert.ElementsMatch(t, []string{addr(3), addr(4)}, pending)
+	})
+
+	t.Run("servers already Dropped/Deallocated are excluded", func(t *testing.T) {
+		servers := []neo4jclient.ServerInfo{
+			srv(addr(0), "Enabled"), srv(addr(1), "Enabled"), srv(addr(2), "Enabled"),
+			srv(addr(3), "Dropped"), srv(addr(4), "Deallocated"),
+		}
+		assert.Empty(t, serversPendingDrain(servers, cluster, 3), "terminal-state servers are being handled, not pending")
+	})
+
+	t.Run("unmatched addresses are ignored", func(t *testing.T) {
+		servers := []neo4jclient.ServerInfo{srv("10.0.0.9:7687", "Enabled"), srv(addr(3), "Enabled")}
+		assert.Equal(t, []string{addr(3)}, serversPendingDrain(servers, cluster, 3))
+	})
+}

--- a/internal/controller/scale_down_test.go
+++ b/internal/controller/scale_down_test.go
@@ -78,4 +78,14 @@ func TestServersPendingDrain(t *testing.T) {
 		servers := []neo4jclient.ServerInfo{srv("10.0.0.9:7687", "Enabled"), srv(addr(3), "Enabled")}
 		assert.Equal(t, []string{addr(3)}, serversPendingDrain(servers, cluster, 3))
 	})
+
+	t.Run("reports serverId (not name/address) — name often empty", func(t *testing.T) {
+		// Matches the real shape: ordinal lives in the address, the reportable
+		// identifier is the serverId, and name is blank.
+		servers := []neo4jclient.ServerInfo{
+			{ID: "uuid-3", Name: "", Address: addr(3), State: "Enabled"},
+		}
+		assert.Equal(t, []string{"uuid-3"}, serversPendingDrain(servers, cluster, 3),
+			"DEALLOCATE/DROP SERVER take the serverId, not the bolt address")
+	})
 }


### PR DESCRIPTION
First of two PRs for #173. This one is the **non-destructive safety/visibility slice**; PR2 is the automated drain.

## Problem

Reducing `spec.topology.servers` lowers the StatefulSet replica count, but the operator never tells Neo4j to **deallocate/drop** the removed servers. Databases allocated to them are left **under-replicated**, and `verifyNeo4jClusterFormation` reports Ready because it compares `availableServers` against the *new, smaller* count (`:1826`). The operator gave **no signal** that a scale-down was incomplete.

## This PR — make it visible (no behavior change, no destructive action)

After the cluster is Ready, `reconcileScaleDownDrainStatus` runs `SHOW SERVERS` and flags any server still registered with pod ordinal ≥ `spec.topology.servers` that isn't already `Deallocated`/`Dropped`:
- Sets a **`ServersPendingDrain`** status condition (True with the offending servers + remediation).
- Emits a one-shot **`ScaleDownPendingDrain`** Warning event (only on transition into pending, no per-reconcile spam).
- Persisted via refetch + `RetryOnConflict` (no stale-object write — cf. #207).
- Fully **non-fatal**: connection/query/write failures are swallowed. It's observability, never a reconcile gate.

The detection is a pure, unit-tested helper (`serversPendingDrain`) that maps server address → ordinal (rule 47).

## Deliberately deferred to PR2

- The automated **cordon → `DRYRUN DEALLOCATE` (refuse-if-infeasible) → `DEALLOCATE` → wait-`Deallocated` → `DROP` → lower replicas** state machine + client primitives.
- **`PVCRetentionPolicy{WhenScaled: Delete}`** — only safe *after* the drain (deleting a removed server's PVC before its data is deallocated would risk data loss).
- Needs live **Kind 5→3 verification on 5.26 + CalVer, including a sharded case** (per the docs deep-dive: sharded DBs hit the topology-feasibility refusal far more often).

## Docs

`clustering.md` now documents scale-down as manual-drain-for-now, with the exact `DEALLOCATE DATABASES FROM SERVER` → wait-`Deallocated` → `DROP SERVER` sequence and the topology-feasibility caveat (reduce `ALTER DATABASE … SET TOPOLOGY` or add servers; never force-remove a sole/majority primary — that's disaster recovery, not scaling).

## Tests / regression

`TestParseServerOrdinal` + `TestServersPendingDrain`; `go vet`, drift gate, and the full `internal/controller` envtest package all pass. No CRD/RBAC/generated changes (condition is a standard `metav1.Condition`; `SHOW SERVERS` is Bolt, not K8s API).

Part of #173 (kept open until PR2 lands + the next release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only: no change to StatefulSet scaling or destructive Neo4j actions; adds status/events that may alert operators to under-replication after scale-down.
> 
> **Overview**
> Addresses **#173 (PR1)**: incomplete scale-downs no longer look healthy when `spec.topology.servers` is reduced but Neo4j still has extra servers registered.
> 
> After the cluster reaches **Ready**, the reconciler runs **`reconcileScaleDownDrainStatus`**, which queries **`SHOW SERVERS`** and flags servers whose pod ordinal is **≥** the desired count and are not yet **Deallocated**/**Dropped**. It sets a **`ServersPendingDrain`** status condition (with server IDs and remediation text), emits a one-shot **`ScaleDownPendingDrain`** Warning event on first transition into pending, and persists via refetch + conflict retry. Failures are **non-fatal**—observability only; no automatic deallocate/drop.
> 
> **`clustering.md`** documents that scale-down still requires **manual** `DEALLOCATE DATABASES FROM SERVER` → `DROP SERVER`, including topology-feasibility caveats. Pure helpers **`parseServerOrdinal`** / **`serversPendingDrain`** are unit-tested.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca9a6b0998366e0e9fe3ae9bec9cd4bdcfb84178. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->