### PR TITLE
feat(helm): per-namespace Roles for operatorMode=namespaces (#206)

### DIFF
--- a/charts/neo4j-operator/templates/_helpers.tpl
+++ b/charts/neo4j-operator/templates/_helpers.tpl
@@ -88,11 +88,67 @@ Get the watch namespace configuration
 {{- end }}
 
 {{/*
-Determine if ClusterRole should be created
+Whether every watchNamespaces entry is a plain (static) namespace name, i.e.
+none is a pattern. MUST mirror the operator's own pattern detection in
+cmd/main.go (parseWatchNamespaceConfig / hasGlobChars): the "glob:", "regex:",
+"re:", "label:" prefixes (case-insensitive) and the bare glob metacharacters
+"*", "?", "[". If the template's notion of "static" diverged from the
+operator's, the chart could lay down per-namespace Roles for a config the
+operator then tries to resolve via cluster-scoped namespace discovery — a
+broken install. Returns "true"/"false". An empty list is vacuously static.
+*/}}
+{{- define "neo4j-operator.watchNamespacesStatic" -}}
+{{- $static := true -}}
+{{- range .Values.watchNamespaces -}}
+{{- $lower := lower (toString .) -}}
+{{- if or (hasPrefix "glob:" $lower) (hasPrefix "regex:" $lower) (hasPrefix "re:" $lower) (hasPrefix "label:" $lower) (contains "*" $lower) (contains "?" $lower) (contains "[" $lower) -}}
+{{- $static = false -}}
+{{- end -}}
+{{- end -}}
+{{- $static -}}
+{{- end }}
+
+{{/*
+Whether to use per-namespace Roles (and therefore suppress the manager
+ClusterRole + ClusterRoleBinding). True only for: rbac.create +
+operatorMode=namespaces + rbac.perNamespaceRoles + a non-empty, STATIC
+watchNamespaces list. Returns "true"/"false".
+
+Fails the render (so `helm install` aborts with a clear message) when
+perNamespaceRoles is requested but the preconditions can't hold — an empty
+list (no namespaces to scope to, and suppressing the ClusterRole would leave
+the operator with zero manager permissions) or a pattern entry (pattern
+discovery needs a cluster-scoped namespace list/watch a Role can't grant).
+Failing fast is deliberate: someone who set perNamespaceRoles=true to forbid
+ClusterRoles must never be silently handed one.
+*/}}
+{{- define "neo4j-operator.perNamespaceRoles" -}}
+{{- if and .Values.rbac.create (eq .Values.operatorMode "namespaces") .Values.rbac.perNamespaceRoles -}}
+{{- if empty .Values.watchNamespaces -}}
+{{- fail "rbac.perNamespaceRoles=true requires a non-empty watchNamespaces list (the namespaces to scope the per-namespace Roles to). Set watchNamespaces, or set rbac.perNamespaceRoles=false to use the ClusterRole." -}}
+{{- else if ne (include "neo4j-operator.watchNamespacesStatic" .) "true" -}}
+{{- fail "rbac.perNamespaceRoles=true requires a static watchNamespaces list (plain namespace names only). A glob/regex/label/prefix pattern needs a ClusterRole because matching namespaces are discovered via a cluster-scoped namespace list/watch, which a namespaced Role cannot grant. List the namespaces explicitly, or set rbac.perNamespaceRoles=false to use the ClusterRole." -}}
+{{- else -}}
+true
+{{- end -}}
+{{- else -}}
+false
+{{- end -}}
+{{- end }}
+
+{{/*
+Determine if ClusterRole should be created. The manager ClusterRole is used for
+cluster scope and for namespaces scope EXCEPT when per-namespace Roles are in
+effect (a static list with rbac.perNamespaceRoles=true), where it is suppressed
+in favour of one Role per namespace.
 */}}
 {{- define "neo4j-operator.createClusterRole" -}}
 {{- if and .Values.rbac.create (or (eq .Values.operatorMode "cluster") (eq .Values.operatorMode "namespaces")) -}}
+{{- if eq (include "neo4j-operator.perNamespaceRoles" .) "true" -}}
+false
+{{- else -}}
 true
+{{- end -}}
 {{- else -}}
 false
 {{- end -}}

--- a/charts/neo4j-operator/templates/namespaced-roles.yaml
+++ b/charts/neo4j-operator/templates/namespaced-roles.yaml
@@ -1,0 +1,274 @@
+# This file is GENERATED. DO NOT EDIT.
+#
+# Source of truth: +kubebuilder:rbac:* markers in internal/controller/*.go.
+# To change the operator's permissions:
+#   1. Edit the relevant +kubebuilder:rbac:groups=...,resources=...,verbs=... marker
+#   2. Run 'make manifests' (regenerates config/rbac/role.yaml)
+#   3. Run 'make helm-sync-rbac' (regenerates this file)
+#
+# CI's 'make check-drift' fails if these are out of sync.
+#
+# Emitted only for operatorMode=namespaces + a static watchNamespaces list +
+# rbac.perNamespaceRoles=true (the helper fails the render on a pattern/empty
+# list). One Role + RoleBinding per listed namespace; no manager ClusterRole.
+{{- if eq (include "neo4j-operator.perNamespaceRoles" .) "true" }}
+{{- range $ns := .Values.watchNamespaces }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "neo4j-operator.fullname" $ }}-manager-role
+  namespace: {{ $ns }}
+  labels:
+    {{- include "neo4j-operator.labels" $ | nindent 4 }}
+rules:
+- apiGroups:
+    - ""
+  resources:
+    - configmaps
+    - endpoints
+    - persistentvolumeclaims
+    - secrets
+    - serviceaccounts
+    - services
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - ""
+  resources:
+    - events
+  verbs:
+    - create
+    - patch
+- apiGroups:
+    - ""
+  resources:
+    - nodes
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - ""
+  resources:
+    - pods
+  verbs:
+    - delete
+    - get
+    - list
+    - watch
+- apiGroups:
+    - ""
+  resources:
+    - pods/log
+  verbs:
+    - get
+- apiGroups:
+    - apps
+  resources:
+    - deployments
+    - statefulsets
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - batch
+  resources:
+    - cronjobs
+    - jobs
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - cert-manager.io
+  resources:
+    - certificates
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - cert-manager.io
+  resources:
+    - clusterissuers
+    - issuers
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - monitoring.coreos.com
+  resources:
+    - prometheusrules
+    - servicemonitors
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - neo4j.neo4j.com
+  resources:
+    - neo4jauthrules
+    - neo4jbackups
+    - neo4jdatabases
+    - neo4jenterpriseclusters
+    - neo4jenterprisestandalones
+    - neo4jplugins
+    - neo4jrestores
+    - neo4jrolebindings
+    - neo4jroles
+    - neo4jshardeddatabases
+    - neo4jusers
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - neo4j.neo4j.com
+  resources:
+    - neo4jauthrules/finalizers
+    - neo4jbackups/finalizers
+    - neo4jdatabases/finalizers
+    - neo4jenterpriseclusters/finalizers
+    - neo4jenterprisestandalones/finalizers
+    - neo4jplugins/finalizers
+    - neo4jrestores/finalizers
+    - neo4jrolebindings/finalizers
+    - neo4jroles/finalizers
+    - neo4jshardeddatabases/finalizers
+    - neo4jusers/finalizers
+  verbs:
+    - update
+- apiGroups:
+    - neo4j.neo4j.com
+  resources:
+    - neo4jauthrules/status
+    - neo4jbackups/status
+    - neo4jdatabases/status
+    - neo4jenterpriseclusters/status
+    - neo4jenterprisestandalones/status
+    - neo4jplugins/status
+    - neo4jrestores/status
+    - neo4jrolebindings/status
+    - neo4jroles/status
+    - neo4jshardeddatabases/status
+    - neo4jusers/status
+  verbs:
+    - get
+    - patch
+    - update
+- apiGroups:
+    - networking.k8s.io
+  resources:
+    - ingresses
+    - networkpolicies
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - rbac.authorization.k8s.io
+  resources:
+    - rolebindings
+    - roles
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - route.openshift.io
+  resources:
+    - routes
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - storage.k8s.io
+  resources:
+    - storageclasses
+  verbs:
+    - get
+    - list
+    - watch
+{{- if $.Values.rbac.externalSecretsIntegration }}
+- apiGroups:
+    - external-secrets.io
+  resources:
+    - clustersecretstores
+    - secretstores
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - external-secrets.io
+  resources:
+    - externalsecrets
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "neo4j-operator.fullname" $ }}-manager-rolebinding
+  namespace: {{ $ns }}
+  labels:
+    {{- include "neo4j-operator.labels" $ | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "neo4j-operator.fullname" $ }}-manager-role
+subjects:
+- kind: ServiceAccount
+  name: {{ include "neo4j-operator.serviceAccountName" $ }}
+  namespace: {{ $.Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/charts/neo4j-operator/values.yaml
+++ b/charts/neo4j-operator/values.yaml
@@ -58,6 +58,29 @@ rbac:
   # operator will get RBAC-denied when trying to create the ExternalSecret
   # — clear failure mode, easy to debug.
   externalSecretsIntegration: false
+  # Use per-namespace Roles instead of a manager ClusterRole, for
+  # operatorMode=namespaces with a STATIC watchNamespaces list (plain
+  # namespace names). Lets security-strict clusters that forbid ClusterRoles
+  # run one operator across several namespaces with least privilege. Default:
+  # off — the manager ClusterRole is used, so existing installs are unchanged.
+  #
+  # When enabled, the chart emits one Role + RoleBinding per listed namespace
+  # (same rule set as the ClusterRole, generated from the same source so it
+  # can't drift) and emits NO manager ClusterRole/ClusterRoleBinding. The
+  # metrics ClusterRoles are unaffected (the authn/authz APIs are
+  # cluster-scoped regardless of operatorMode).
+  #
+  # Requirements (enforced at render time — `helm install` fails fast with a
+  # clear message otherwise):
+  #   * operatorMode MUST be "namespaces".
+  #   * Every watchNamespaces entry MUST be a plain namespace name. A
+  #     glob/regex/label/prefix pattern (e.g. "team-*", "regex:^team-",
+  #     "label:env=prod") is rejected: matching namespaces are discovered via
+  #     a cluster-scoped namespace list/watch, which a namespaced Role cannot
+  #     grant. Use perNamespaceRoles=false (ClusterRole) for patterns.
+  #   * Each listed namespace MUST already exist — Helm creates the
+  #     Role+RoleBinding in it but does not create the namespace itself.
+  perNamespaceRoles: false
 
 # Init container image used by Neo4jPlugin spec.installMode=VerifiedDownload.
 # When a Neo4jPlugin opts into VerifiedDownload, the operator injects this

--- a/docs/user_guide/operator-modes.md
+++ b/docs/user_guide/operator-modes.md
@@ -44,6 +44,7 @@ CLI flags and Helm values always override these defaults.
 - `metrics.enabled` controls `--metrics-bind-address` (`0` disables). Port comes from `metrics.service.port`.
 - `--health-probe-bind-address=:8081` is always set by the chart.
 - `leaderElection.enabled: true` passes `--leader-elect=true`.
+- `rbac.perNamespaceRoles: true` (with `operatorMode=namespaces` + a static `watchNamespaces` list) replaces the manager ClusterRole with one Role per namespace — see [Multi-Namespace Scope](#multi-namespace-scope).
 
 ### Health and metrics endpoints (production defaults)
 
@@ -197,7 +198,7 @@ The only case that needs action from you is `spec.topology.enforceDistribution: 
 
 ### Multi-Namespace Scope
 
-- **RBAC**: ClusterRole + ClusterRoleBinding
+- **RBAC**: ClusterRole + ClusterRoleBinding (default), or per-namespace Roles — see below.
 - **Use when**: One operator should manage a fixed list of namespaces.
 - **Helm**:
   ```yaml
@@ -216,6 +217,31 @@ The only case that needs action from you is `spec.topology.enforceDistribution: 
 - **Labels**: `label:{env=prod,tier=backend}` (braces allow commas)
 - Patterns require cluster-scope RBAC because the operator must list/watch namespaces.
 - The operator restarts its manager when namespace matches change.
+
+**Per-namespace Roles (no ClusterRole) — `rbac.perNamespaceRoles`:**
+
+Security-strict clusters that forbid ClusterRoles can run a multi-namespace operator with **only** namespaced `Role` + `RoleBinding` objects. Set `rbac.perNamespaceRoles=true` (default `false`):
+
+```yaml
+operatorMode: namespaces
+watchNamespaces:
+  - team-a
+  - team-b
+rbac:
+  perNamespaceRoles: true
+```
+
+This emits one `Role` + `RoleBinding` per listed namespace (identical permissions to the ClusterRole, generated from the same source so they can't drift) and **no manager ClusterRole/ClusterRoleBinding**. A static list watches scoped caches only — it never lists/watches the cluster-scoped `namespaces` resource — so it needs no cluster-scoped manager grants.
+
+Requirements (each enforced at `helm` render time — install fails fast with a clear message otherwise):
+
+- **`operatorMode` must be `namespaces`.** Ignored in `cluster`/`namespace` mode.
+- **Every `watchNamespaces` entry must be a plain namespace name.** A glob/regex/label/prefix pattern (`team-*`, `regex:…`, `label:…`) is **rejected** — pattern matching needs a cluster-scoped namespace list/watch a Role cannot grant. Use `perNamespaceRoles=false` (ClusterRole) if you need patterns. You cannot have *no ClusterRole* **and** *pattern matching*.
+- **Each listed namespace must already exist** — Helm creates the `Role`+`RoleBinding` *in* each namespace but does not create the namespace.
+
+What you lose vs. the ClusterRole: only **availability-zone auto-discovery** (the same documented namespace-scope limitation — see "Namespace Scope" above; the operator falls back to best-effort zone spread and emits `TopologyZoneDiscoveryDegraded`). TLS via `ClusterIssuer`, external-secrets, backups, and all CR reconciliation work unchanged.
+
+> For a **completely** ClusterRole-free install, also set `preInstallChecks.enabled=false`. The optional pre-install check runs as a Helm hook that reads cluster-scoped CRDs via a transient ClusterRole (auto-deleted after the hook); the metrics endpoint's `metrics-auth`/`metrics-reader` ClusterRoles remain only when `metrics.secure=true`, because the Kubernetes authn/authz APIs they use are inherently cluster-scoped.
 
 Note: backup workflows create per-namespace RBAC (ServiceAccount/Role/RoleBinding) as needed for backup jobs.
 

--- a/scripts/helm-install-test.sh
+++ b/scripts/helm-install-test.sh
@@ -45,6 +45,50 @@ kind export kubeconfig --name "${KIND_CLUSTER}"
 log "Linting Helm chart"
 helm lint "${CHART_DIR}"
 
+# --- RBAC render assertions (no cluster needed) -----------------------------
+# Locks the operatorMode / rbac.perNamespaceRoles RBAC matrix (#206) so a chart
+# edit can't silently regress which Role/ClusterRole objects get emitted. Pure
+# `helm template` — runs locally; not wired into per-PR CI.
+log "Verifying RBAC render matrix"
+render_tpl() { # <template-file> <extra --set args...>
+    local tpl="$1"; shift
+    helm template "${RELEASE_NAME}" "${CHART_DIR}" --namespace "${NAMESPACE}" \
+        --show-only "templates/${tpl}" "$@" 2>/dev/null
+}
+assert_has()    { grep -q "$2" <<<"$1" || { echo "RBAC assert FAILED: expected '$3'"; exit 1; }; }
+assert_absent() { if grep -q "$2" <<<"$1"; then echo "RBAC assert FAILED: did not expect '$3'"; exit 1; fi; }
+
+# Default (cluster scope): manager ClusterRole present, no per-namespace Roles.
+assert_has    "$(render_tpl clusterrole.yaml)"      'kind: ClusterRole' "manager ClusterRole (cluster mode)"
+assert_absent "$(render_tpl namespaced-roles.yaml)" 'kind: Role'        "per-namespace Role (cluster mode)"
+
+# namespaces + perNamespaceRoles=false (default): manager ClusterRole present.
+assert_has "$(render_tpl clusterrole.yaml --set operatorMode=namespaces --set 'watchNamespaces={team-a,team-b}')" \
+    'kind: ClusterRole' "manager ClusterRole (namespaces, perNamespaceRoles off)"
+
+# namespaces + perNamespaceRoles=true + static list: per-namespace Roles, NO manager ClusterRole.
+NS_ARGS=(--set operatorMode=namespaces --set rbac.perNamespaceRoles=true --set 'watchNamespaces={team-a,team-b}')
+assert_absent "$(render_tpl clusterrole.yaml "${NS_ARGS[@]}")" 'kind: ClusterRole' "manager ClusterRole (perNamespaceRoles=true)"
+out_ns="$(render_tpl namespaced-roles.yaml "${NS_ARGS[@]}")"
+assert_has "$out_ns" 'namespace: team-a' "manager Role in team-a"
+assert_has "$out_ns" 'namespace: team-b' "manager Role in team-b"
+assert_has "$out_ns" 'kind: RoleBinding'  "per-namespace RoleBinding"
+# metrics ClusterRoles must survive (authn/authz APIs are cluster-scoped).
+assert_has "$(render_tpl metrics-rbac.yaml "${NS_ARGS[@]}" --set metrics.secure=true)" \
+    'kind: ClusterRole' "metrics ClusterRole retained"
+
+# perNamespaceRoles=true + a pattern → must fail fast.
+if helm template "${RELEASE_NAME}" "${CHART_DIR}" --namespace "${NAMESPACE}" \
+    --set operatorMode=namespaces --set rbac.perNamespaceRoles=true --set 'watchNamespaces={team-*}' >/dev/null 2>&1; then
+    echo "RBAC assert FAILED: pattern + perNamespaceRoles=true should fail render"; exit 1
+fi
+# perNamespaceRoles=true + empty list → must fail fast.
+if helm template "${RELEASE_NAME}" "${CHART_DIR}" --namespace "${NAMESPACE}" \
+    --set operatorMode=namespaces --set rbac.perNamespaceRoles=true >/dev/null 2>&1; then
+    echo "RBAC assert FAILED: empty watchNamespaces + perNamespaceRoles=true should fail render"; exit 1
+fi
+log "RBAC render matrix verified"
+
 log "Installing Helm chart"
 helm upgrade --install "${RELEASE_NAME}" "${CHART_DIR}" \
     --namespace "${NAMESPACE}" \

--- a/scripts/helm-sync-rbac.sh
+++ b/scripts/helm-sync-rbac.sh
@@ -131,6 +131,71 @@ EOF
 
 echo "Wrote $ROLE_DST from $SRC"
 
+# --- Per-namespace manager Roles (operatorMode=namespaces, static list) -----
+# When operatorMode=namespaces with a STATIC watchNamespaces list and
+# rbac.perNamespaceRoles=true, the operator needs NO cluster-scoped manager
+# grants (a static list builds scoped caches and never lists/watches the
+# cluster-scoped `namespaces` resource — see cmd/main.go runManagerWithWatchConfig
+# !hasPatterns()). So instead of the manager ClusterRole, emit one Role +
+# RoleBinding per listed namespace. Same rules as the ClusterRole/role.yaml
+# above (CORE_RULES, drift-proof) so they can't fall behind the markers. The
+# `neo4j-operator.perNamespaceRoles` helper gates this AND fails the render on a
+# pattern/empty list; the gate here is belt-and-suspenders with that helper.
+# Cluster-scoped resources named in CORE_RULES (nodes, cluster*issuers,
+# cluster*stores) are inert in a namespaced Role — same documented
+# namespace-mode limitation as role.yaml (#197).
+NS_ROLE_DST="${ROOT}/charts/neo4j-operator/templates/namespaced-roles.yaml"
+cat > "$NS_ROLE_DST" <<EOF
+# This file is GENERATED. DO NOT EDIT.
+#
+# Source of truth: +kubebuilder:rbac:* markers in internal/controller/*.go.
+# To change the operator's permissions:
+#   1. Edit the relevant +kubebuilder:rbac:groups=...,resources=...,verbs=... marker
+#   2. Run 'make manifests' (regenerates config/rbac/role.yaml)
+#   3. Run 'make helm-sync-rbac' (regenerates this file)
+#
+# CI's 'make check-drift' fails if these are out of sync.
+#
+# Emitted only for operatorMode=namespaces + a static watchNamespaces list +
+# rbac.perNamespaceRoles=true (the helper fails the render on a pattern/empty
+# list). One Role + RoleBinding per listed namespace; no manager ClusterRole.
+{{- if eq (include "neo4j-operator.perNamespaceRoles" .) "true" }}
+{{- range \$ns := .Values.watchNamespaces }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "neo4j-operator.fullname" \$ }}-manager-role
+  namespace: {{ \$ns }}
+  labels:
+    {{- include "neo4j-operator.labels" \$ | nindent 4 }}
+rules:
+${CORE_RULES}
+{{- if \$.Values.rbac.externalSecretsIntegration }}
+${EXT_SECRETS_RULES}
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "neo4j-operator.fullname" \$ }}-manager-rolebinding
+  namespace: {{ \$ns }}
+  labels:
+    {{- include "neo4j-operator.labels" \$ | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "neo4j-operator.fullname" \$ }}-manager-role
+subjects:
+- kind: ServiceAccount
+  name: {{ include "neo4j-operator.serviceAccountName" \$ }}
+  namespace: {{ \$.Release.Namespace }}
+{{- end }}
+{{- end }}
+EOF
+
+echo "Wrote $NS_ROLE_DST from $SRC"
+
 # --- Metrics RBAC -----------------------------------------------------------
 # controller-runtime's secure metrics endpoint authenticates scrapers via
 # TokenReview and authorizes them via SubjectAccessReview. That requires the


### PR DESCRIPTION
Closes #206.

Lets `operatorMode=namespaces` with a **static** `watchNamespaces` list run with **per-namespace `Role` + `RoleBinding` and no manager `ClusterRole`** — so security-strict clusters that forbid ClusterRoles can run one operator across several namespaces with least privilege. Builds on #199/#201 (singular-namespace Role) and #205/#202 (confirmed static-list namespaces mode needs no cluster-scoped manager grants).

## Behaviour

New `rbac.perNamespaceRoles`, **default `false`** — existing installs are byte-for-byte unchanged. When `true` (with `operatorMode=namespaces`):

- Emits one manager `Role` + `RoleBinding` **per listed namespace** (same rule set as the ClusterRole, generated from the same source → can't drift).
- Emits **no** manager `ClusterRole` / `ClusterRoleBinding`.
- Metrics `ClusterRole`s are untouched (the authn/authz APIs are cluster-scoped regardless of mode).

## Why static-only (the regex/prefix question)

A **static** list builds scoped caches and never lists/watches the cluster-scoped `namespaces` resource (`cmd/main.go` `runManagerWithWatchConfig`, `!hasPatterns()`), so it needs **zero** cluster-scoped manager grants. A **pattern** (`glob:`/`regex:`/`re:`/`label:`/bare `*?[`) is resolved via cluster-scoped namespace discovery, which a namespaced `Role` fundamentally cannot grant — and Helm can't pre-create Roles for a match set that changes at runtime.

So the gate is enforced at render time — `helm install` **fails fast** with an actionable message when `perNamespaceRoles=true` is combined with a pattern entry or an empty list, rather than silently handing back a ClusterRole the user opted out of. Patterns keep working exactly as today on the ClusterRole path.

## Safety / no-regression

- `rbac.perNamespaceRoles` defaults off → no change to any existing install in any mode.
- `templates/namespaced-roles.yaml` is **generated** by `scripts/helm-sync-rbac.sh` from the same `CORE_RULES`/`EXT_SECRETS_RULES` as `clusterrole.yaml`/`role.yaml`; `make check-drift` enforces parity with the kubebuilder markers.
- The chart's static-list detection in `_helpers.tpl` mirrors the operator's own `*?[` + prefix detection **exactly**, so the template and runtime can't disagree about what "static" means.
- Verified `helm lint` + `helm template` across the full matrix (cluster / namespace / namespaces±perNamespaceRoles / static / glob / regex / label / empty / cluster-mode-ignore). Local (non-CI) render assertions added to `scripts/helm-install-test.sh` to lock it.

## Docs

`operator-modes.md` Multi-Namespace section documents the model, the static-list requirement, the namespace-must-exist caveat, what's lost (only AZ auto-discovery — already a namespace-scope limitation), and the `preInstallChecks.enabled=false` note for a *fully* ClusterRole-free install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes operator RBAC layout for a new opt-in Helm mode; misconfiguration is blocked at render time, but wrong static/pattern alignment or missing target namespaces could break installs or permissions.
> 
> **Overview**
> Adds **`rbac.perNamespaceRoles`** (default **`false`**) so `operatorMode=namespaces` with a **static** `watchNamespaces` list can install with one manager **Role + RoleBinding per namespace** and **no manager ClusterRole/ClusterRoleBinding**, for clusters that forbid ClusterRoles.
> 
> Chart helpers detect static vs pattern entries (aligned with `cmd/main.go` glob/prefix rules), **fail Helm render** on empty lists or patterns when `perNamespaceRoles=true`, and gate the existing manager ClusterRole off when per-namespace Roles apply. **`namespaced-roles.yaml`** is generated from the same `CORE_RULES` as the ClusterRole via **`helm-sync-rbac.sh`**. Docs cover requirements and limitations; **`helm-install-test.sh`** adds local `helm template` checks for the RBAC matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f96ec0fde4015c06ce3c4099f21d84294a70e34e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->