### PR TITLE
fix(cluster): persist status.version via refetch+retry after rolling upgrade (#207)

### DIFF
--- a/internal/controller/neo4jenterprisecluster_controller.go
+++ b/internal/controller/neo4jenterprisecluster_controller.go
@@ -1273,6 +1273,17 @@ func (r *Neo4jEnterpriseClusterReconciler) initContainersEqual(current, desired 
 }
 
 func (r *Neo4jEnterpriseClusterReconciler) updateClusterStatus(ctx context.Context, cluster *neo4jv1beta1.Neo4jEnterpriseCluster, phase, message string) bool {
+	return r.updateClusterStatusWithVersion(ctx, cluster, phase, message, "")
+}
+
+// updateClusterStatusWithVersion is updateClusterStatus plus an optional
+// status.version write, folded into the SAME refetch + RetryOnConflict closure.
+// When version != "" it is written onto the freshly-Get'd `latest` object —
+// never on the caller's in-memory `cluster`, whose resourceVersion may already
+// be stale from an earlier status write in the same reconcile (the rolling-
+// upgrade completion path did exactly that, so the bare follow-up
+// Status().Update conflicted and the version bump was silently dropped — #207).
+func (r *Neo4jEnterpriseClusterReconciler) updateClusterStatusWithVersion(ctx context.Context, cluster *neo4jv1beta1.Neo4jEnterpriseCluster, phase, message, version string) bool {
 	logger := log.FromContext(ctx)
 	statusChanged := false
 
@@ -1286,7 +1297,8 @@ func (r *Neo4jEnterpriseClusterReconciler) updateClusterStatus(ctx context.Conte
 		// Check if status is already exactly what we want
 		readyBool := (phase == "Ready")
 		statusNeedsUpdate := latest.Status.Phase != phase || latest.Status.Message != message ||
-			latest.Status.Ready != readyBool || latest.Status.ObservedGeneration != latest.Generation
+			latest.Status.Ready != readyBool || latest.Status.ObservedGeneration != latest.Generation ||
+			(version != "" && latest.Status.Version != version)
 
 		// Determine standard condition status and reason
 		condStatus, condReason := PhaseToConditionStatus(phase)
@@ -1321,6 +1333,9 @@ func (r *Neo4jEnterpriseClusterReconciler) updateClusterStatus(ctx context.Conte
 		latest.Status.Message = message
 		latest.Status.Ready = readyBool
 		latest.Status.ObservedGeneration = latest.Generation
+		if version != "" {
+			latest.Status.Version = version
+		}
 
 		// Populate connection endpoints + connection examples. Cluster
 		// previously left status.endpoints unset; surfacing these lets users
@@ -1697,12 +1712,12 @@ func (r *Neo4jEnterpriseClusterReconciler) handleRollingUpgrade(ctx context.Cont
 		return ctrl.Result{RequeueAfter: r.RequeueAfter}, err
 	}
 
-	// Update cluster status and version
-	_ = r.updateClusterStatus(ctx, cluster, "Ready", "Rolling upgrade completed successfully")
-	cluster.Status.Version = cluster.Spec.Image.Tag
-	if err := r.Status().Update(ctx, cluster); err != nil {
-		logger.Error(err, "Failed to update cluster status")
-	}
+	// Update cluster status and version in ONE refetch+RetryOnConflict write.
+	// Previously this set cluster.Status.Version then did a bare
+	// r.Status().Update(ctx, cluster) AFTER updateClusterStatus had already
+	// refetched + updated a fresh copy — so the second write used a stale
+	// resourceVersion, 409'd, and the version bump was silently lost (#207).
+	_ = r.updateClusterStatusWithVersion(ctx, cluster, "Ready", "Rolling upgrade completed successfully", cluster.Spec.Image.Tag)
 
 	r.Recorder.Event(cluster, corev1.EventTypeNormal, EventReasonUpgradeCompleted, "Rolling upgrade completed successfully")
 	logger.Info("Rolling upgrade completed successfully")

--- a/internal/controller/status_write_test.go
+++ b/internal/controller/status_write_test.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -29,6 +31,65 @@ import (
 
 	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
 )
+
+// TestUpdateClusterStatusWithVersion_PersistsAfterPriorStatusWrite pins the
+// #207 fix: the rolling-upgrade completion path does TWO status writes in one
+// reconcile. The first (updateClusterStatus) refetches + updates a fresh copy,
+// leaving the in-memory `cluster` at a stale resourceVersion. The old code then
+// did `cluster.Status.Version = tag; r.Status().Update(ctx, cluster)` on that
+// stale object — a guaranteed 409 that was logged and swallowed, so the version
+// bump was lost. Folding the version into updateClusterStatusWithVersion (its
+// own refetch + RetryOnConflict) makes it land regardless.
+func TestUpdateClusterStatusWithVersion_PersistsAfterPriorStatusWrite(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, neo4jv1beta1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	cluster := &neo4jv1beta1.Neo4jEnterpriseCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: "default", Generation: 3},
+		Spec: neo4jv1beta1.Neo4jEnterpriseClusterSpec{
+			Image:    neo4jv1beta1.ImageSpec{Tag: "2025.04.0-enterprise"},
+			Topology: neo4jv1beta1.TopologyConfiguration{Servers: 3},
+		},
+	}
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster).WithStatusSubresource(cluster).Build()
+	r := &Neo4jEnterpriseClusterReconciler{Client: fc}
+
+	// First write leaves the in-memory `cluster` resourceVersion stale.
+	r.updateClusterStatus(context.Background(), cluster, "Ready", "ready")
+	// Version write must still land despite the stale in-memory object.
+	r.updateClusterStatusWithVersion(context.Background(), cluster, "Ready", "Rolling upgrade completed successfully", cluster.Spec.Image.Tag)
+
+	latest := &neo4jv1beta1.Neo4jEnterpriseCluster{}
+	require.NoError(t, fc.Get(context.Background(), types.NamespacedName{Name: "c", Namespace: "default"}, latest))
+	assert.Equal(t, "2025.04.0-enterprise", latest.Status.Version,
+		"status.version must reflect spec.image.tag after a successful upgrade (#207)")
+	assert.Equal(t, "Ready", latest.Status.Phase)
+	assert.Equal(t, "Rolling upgrade completed successfully", latest.Status.Message)
+}
+
+// TestUpdateClusterStatus_NoVersionWrite confirms the plain (no-version) path is
+// unchanged: it never touches status.version.
+func TestUpdateClusterStatus_NoVersionWrite(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, neo4jv1beta1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	cluster := &neo4jv1beta1.Neo4jEnterpriseCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: "default", Generation: 1},
+		Spec:       neo4jv1beta1.Neo4jEnterpriseClusterSpec{Topology: neo4jv1beta1.TopologyConfiguration{Servers: 3}},
+		Status:     neo4jv1beta1.Neo4jEnterpriseClusterStatus{Version: "preexisting"},
+	}
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster).WithStatusSubresource(cluster).Build()
+	r := &Neo4jEnterpriseClusterReconciler{Client: fc}
+
+	r.updateClusterStatus(context.Background(), cluster, "Forming", "forming")
+
+	latest := &neo4jv1beta1.Neo4jEnterpriseCluster{}
+	require.NoError(t, fc.Get(context.Background(), types.NamespacedName{Name: "c", Namespace: "default"}, latest))
+	assert.Equal(t, "preexisting", latest.Status.Version, "plain updateClusterStatus must not alter status.version")
+	assert.Equal(t, "Forming", latest.Status.Phase)
+}
 
 // TestSetFleetManagementStatus_Cluster_RefetchesAndPersists pins the cluster
 // fleet status fix: the write goes to the refetched object (not the stale


### PR DESCRIPTION
Closes #207.

## Problem

The rolling-upgrade success path did **two** status writes in one reconcile:

```go
_ = r.updateClusterStatus(ctx, cluster, "Ready", "...")   // refetches `latest` + RetryOnConflict → in-memory `cluster` now stale
cluster.Status.Version = cluster.Spec.Image.Tag
if err := r.Status().Update(ctx, cluster); err != nil {    // stale resourceVersion → 409
    logger.Error(err, "...")                               // logged and swallowed
}
```

The second write used the now-stale `cluster` object, hit a resourceVersion conflict, and was silently dropped — so after a successful upgrade `status.version` could stay on the old tag. `status.version` is the signal that the upgrade landed, so this made a successful upgrade look incomplete.

## Fix

Fold the version into the **same** refetch + `RetryOnConflict` closure:

- New `updateClusterStatusWithVersion(ctx, cluster, phase, message, version)` writes `status.version` onto the freshly-`Get`'d `latest` object (and includes version in the needs-update check, so a version-only change still writes).
- `updateClusterStatus` stays a thin delegate (`version=""`) — the **33 existing callers are untouched**.
- The rolling-upgrade completion makes one combined write and no longer touches the stale in-memory object. No status write in the cluster reconcile now uses an object left stale by a prior write in the same pass (acceptance #2).

Sibling of the #175 `updateUpgradeStatus` cleanup; can land independently of the #174 state-machine refactor.

## Tests

Fake-client unit tests (run in the existing Unit Tests job — no new CI surface):
- version lands despite a prior same-reconcile status write (the exact #207 sequence);
- the plain `updateClusterStatus` path leaves `status.version` untouched.

Full controller envtest suite + `go vet` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized status-write fix reusing the existing RetryOnConflict pattern; no API or caller behavior change beyond fixing upgrade completion version persistence.
> 
> **Overview**
> Fixes **#207**, where a successful rolling upgrade could leave **`status.version`** on the old image tag even though the cluster was **Ready**.
> 
> The rolling-upgrade success path used to call **`updateClusterStatus`** (refetch + **`RetryOnConflict`**) and then a second **`Status().Update`** on the in-memory **`cluster`**. That object’s **resourceVersion** was already stale after the first write, so the follow-up often **409**’d and the version bump was dropped.
> 
> **`updateClusterStatusWithVersion`** adds an optional version write in the **same** refetch/retry closure; **`updateClusterStatus`** delegates with an empty version so existing callers stay unchanged. Completion now uses one **`updateClusterStatusWithVersion(..., cluster.Spec.Image.Tag)`** call instead of two writes.
> 
> Fake-client tests cover the two-write sequence and confirm the plain path does not touch **`status.version`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cceff641112747c9cd6a02fca68b5cc185a02001. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->