### PR TITLE
fix(backup/restore): Wave 2 — robustness: transient routing, chain coverage, retention, seed-proxy hardening (#217 #218 #219)

### DIFF
--- a/internal/controller/cluster_seed_creds.go
+++ b/internal/controller/cluster_seed_creds.go
@@ -145,14 +145,19 @@ func EnsureSeedCredsProjected(
 	// ownership annotation), so an Update from the reconcile-start object
 	// conflicts routinely — and the caller previously pinned that retryable
 	// conflict as terminal Failed.
+	patched := false
 	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		if err := c.Get(ctx, client.ObjectKeyFromObject(target), target); err != nil {
 			return err
 		}
 		// Re-check on the fresh copy: a concurrent reconcile may have
-		// already projected the Secret.
+		// already projected the Secret — then THIS reconcile didn't patch
+		// anything and must not claim it did (the caller routes
+		// autoInherited=true to a Pending requeue; an already-projected
+		// cluster should proceed straight to the rollout check instead).
 		for _, ef := range target.GetExtraEnvFrom() {
 			if ef.SecretRef != nil && ef.SecretRef.Name == credsSecretName {
+				patched = false
 				return nil
 			}
 		}
@@ -167,11 +172,12 @@ func EnsureSeedCredsProjected(
 		}
 		annotations[AutoInheritedFromAnnotation] = credsSecretName
 		target.SetAnnotations(annotations)
+		patched = true
 		return c.Update(ctx, target)
 	}); err != nil {
 		return false, fmt.Errorf("auto-inherit seed credentials Secret %q onto %s %q: %w", credsSecretName, target.TargetKindLabel(), target.GetName(), err)
 	}
-	return true, nil
+	return patched, nil
 }
 
 // EnsureClusterHasSeedCreds is the cluster-typed wrapper kept for callers

--- a/internal/controller/cluster_seed_creds.go
+++ b/internal/controller/cluster_seed_creds.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
@@ -139,19 +140,35 @@ func EnsureSeedCredsProjected(
 
 	// Opt-in confirmed. Append the entry and Update. The owning controller
 	// will pick up the spec change on its next reconcile and roll out the
-	// StatefulSet.
-	target.SetExtraEnvFrom(append(target.GetExtraEnvFrom(), corev1.EnvFromSource{
-		SecretRef: &corev1.SecretEnvSource{
-			LocalObjectReference: corev1.LocalObjectReference{Name: credsSecretName},
-		},
-	}))
-	annotations := target.GetAnnotations()
-	if annotations == nil {
-		annotations = map[string]string{}
-	}
-	annotations[AutoInheritedFromAnnotation] = credsSecretName
-	target.SetAnnotations(annotations)
-	if err := c.Update(ctx, target); err != nil {
+	// StatefulSet. Refetch-inside-RetryOnConflict is mandatory here (#218):
+	// the owning controller rewrites its CR every reconcile (env-var
+	// ownership annotation), so an Update from the reconcile-start object
+	// conflicts routinely — and the caller previously pinned that retryable
+	// conflict as terminal Failed.
+	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		if err := c.Get(ctx, client.ObjectKeyFromObject(target), target); err != nil {
+			return err
+		}
+		// Re-check on the fresh copy: a concurrent reconcile may have
+		// already projected the Secret.
+		for _, ef := range target.GetExtraEnvFrom() {
+			if ef.SecretRef != nil && ef.SecretRef.Name == credsSecretName {
+				return nil
+			}
+		}
+		target.SetExtraEnvFrom(append(target.GetExtraEnvFrom(), corev1.EnvFromSource{
+			SecretRef: &corev1.SecretEnvSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: credsSecretName},
+			},
+		}))
+		annotations := target.GetAnnotations()
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+		annotations[AutoInheritedFromAnnotation] = credsSecretName
+		target.SetAnnotations(annotations)
+		return c.Update(ctx, target)
+	}); err != nil {
 		return false, fmt.Errorf("auto-inherit seed credentials Secret %q onto %s %q: %w", credsSecretName, target.TargetKindLabel(), target.GetName(), err)
 	}
 	return true, nil

--- a/internal/controller/configmap_manager_test.go
+++ b/internal/controller/configmap_manager_test.go
@@ -22,6 +22,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -40,6 +41,7 @@ func newTestScheme() *runtime.Scheme {
 	_ = neo4jv1beta1.AddToScheme(s)
 	_ = appsv1.AddToScheme(s)
 	_ = corev1.AddToScheme(s)
+	_ = networkingv1.AddToScheme(s)
 	return s
 }
 

--- a/internal/controller/events.go
+++ b/internal/controller/events.go
@@ -35,7 +35,10 @@ const (
 
 // Backup and restore events
 const (
-	EventReasonBackupScheduled        = "BackupScheduled"
+	EventReasonBackupScheduled = "BackupScheduled"
+	// EventReasonBackupRetentionCaveat — retention pruning configured on a CR
+	// whose chain may contain differential artifacts (#217).
+	EventReasonBackupRetentionCaveat  = "BackupRetentionCaveat"
 	EventReasonBackupStarted          = "BackupStarted"
 	EventReasonBackupCompleted        = "BackupCompleted"
 	EventReasonBackupFailed           = "BackupFailed"

--- a/internal/controller/neo4jbackup_controller.go
+++ b/internal/controller/neo4jbackup_controller.go
@@ -157,7 +157,10 @@ func (r *Neo4jBackupReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// guard never re-enters) even after the cluster appears moments later.
 	targetCluster, err := r.getTargetCluster(ctx, backup)
 	if err != nil {
-		if errors.IsNotFound(err) || strings.Contains(err.Error(), "not found") {
+		// errors.IsNotFound unwraps %w chains — ONLY genuine NotFound waits;
+		// RBAC denials and other API failures stay on the error path (#224
+		// review: a substring match on "not found" misclassified those).
+		if errors.IsNotFound(err) {
 			logger.Info("Backup target not found yet; waiting", "error", err.Error())
 			r.updateBackupStatus(ctx, backup, "Waiting", fmt.Sprintf("Waiting for target to appear: %v", err))
 			return ctrl.Result{RequeueAfter: r.RequeueAfter}, nil
@@ -1584,10 +1587,13 @@ func (r *Neo4jBackupReconciler) getTargetCluster(ctx context.Context, backup *ne
 		return cluster, nil
 	}
 
-	// Fall back to Neo4jEnterpriseStandalone.
+	// Fall back to Neo4jEnterpriseStandalone. Wrap the underlying API error
+	// (%w) so callers can classify NotFound (transient, wait for the target)
+	// vs Forbidden/other (permanent) — a fixed message swallowed that
+	// distinction (#224 review).
 	standalone := &neo4jv1beta1.Neo4jEnterpriseStandalone{}
 	if err := r.Get(ctx, types.NamespacedName{Name: clusterName, Namespace: targetNamespace}, standalone); err != nil {
-		return nil, fmt.Errorf("target %q not found as Neo4jEnterpriseCluster or Neo4jEnterpriseStandalone in namespace %q", clusterName, targetNamespace)
+		return nil, fmt.Errorf("target %q not usable as Neo4jEnterpriseCluster or Neo4jEnterpriseStandalone in namespace %q: %w", clusterName, targetNamespace, err)
 	}
 	return standaloneAsCluster(standalone), nil
 }

--- a/internal/controller/neo4jbackup_controller.go
+++ b/internal/controller/neo4jbackup_controller.go
@@ -1674,8 +1674,14 @@ func (r *Neo4jBackupReconciler) cleanupBackupArtifacts(ctx context.Context, back
 		return nil
 	}
 
-	// PVC storage: create a cleanup Job using alpine.
-	script := buildRetentionScript(backup.Spec.Retention)
+	// PVC storage: create a cleanup Job using alpine. Warn when the CR can
+	// produce differential artifacts: filename-level pruning can orphan DIFFs
+	// whose parent FULL ages out (see buildRetentionScript).
+	if backup.Spec.Options == nil || backup.Spec.Options.BackupType != "FULL" {
+		r.Recorder.Event(backup, corev1.EventTypeWarning, EventReasonBackupRetentionCaveat,
+			"Retention pruning on a chain that may contain differential artifacts can orphan DIFFs whose parent FULL ages out; prefer backupType=FULL with retention, or prune via neo4j-admin backup aggregate")
+	}
+	script := buildRetentionScript(backup.Spec.Retention, chainRoot(backup))
 	cleanupJobName := fmt.Sprintf("%s-cleanup-%d", backup.Name, time.Now().Unix())
 	backoffLimit := int32(1)
 
@@ -1725,35 +1731,48 @@ func (r *Neo4jBackupReconciler) cleanupBackupArtifacts(ctx context.Context, back
 	return nil
 }
 
-// buildRetentionScript generates a shell script that enforces the given retention
-// policy against directories under /backup.
-func buildRetentionScript(policy *neo4jv1beta1.RetentionPolicy) string {
-	script := `#!/bin/sh
+// buildRetentionScript generates a shell script that enforces the given
+// retention policy against this CR's chain directory.
+//
+// Layout awareness (#217): since rule 40, all runs of one CR accumulate as
+// `<dbname>-<timestamp>.backup` FILES in the single shared
+// /backup/<chain-root>/ directory. The previous script still implemented the
+// pre-rule-40 per-run-SUBFOLDER model — it counted and rm -rf'd depth-1
+// DIRECTORIES under /backup, i.e. entire chain roots: maxAge deleted a whole
+// chain including the newest FULL, and on a shared PVC maxCount could delete
+// ANOTHER CR's chain.
+//
+// The rewritten script prunes `*.backup` files inside this CR's chain dir
+// only, oldest-first by mtime, and always keeps the newest file. Limitation
+// (documented): artifact filenames don't encode FULL vs DIFF, so pruning can
+// orphan differential artifacts whose parent FULL ages out — chain-aware
+// retention requires `neo4j-admin backup aggregate`. Prefer backupType=FULL
+// on CRs that use retention, or bucket lifecycle rules on cloud storage.
+func buildRetentionScript(policy *neo4jv1beta1.RetentionPolicy, chainDir string) string {
+	script := fmt.Sprintf(`#!/bin/sh
 set -e
-BACKUP_DIR="/backup"
+BACKUP_DIR=%s
 echo "Backup retention enforcement in $BACKUP_DIR"
-`
+[ -d "$BACKUP_DIR" ] || { echo "chain directory missing; nothing to prune"; exit 0; }
+`, shellQuote("/backup/"+chainDir))
 
 	if policy.MaxCount > 0 {
 		script += fmt.Sprintf(`
 MAX_COUNT=%d
-FILE_COUNT=$(find "$BACKUP_DIR" -maxdepth 1 -mindepth 1 -type d | wc -l)
-echo "Found $FILE_COUNT backup directories"
+FILE_COUNT=$(find "$BACKUP_DIR" -maxdepth 1 -type f -name '*.backup' | wc -l)
+echo "Found $FILE_COUNT backup artifacts"
 if [ "$FILE_COUNT" -gt "$MAX_COUNT" ]; then
     TO_DELETE=$((FILE_COUNT - MAX_COUNT))
-    echo "Deleting $TO_DELETE oldest backups (keeping $MAX_COUNT)"
-    # Sort by filesystem mtime, not by directory name. The directory name
-    # happens to encode a YYYYMMDD-HHMMSS timestamp today, but coupling
-    # retention's "oldest first" semantics to that naming convention is
-    # fragile — anyone who renames the timestamp format silently breaks
-    # retention. GNU find's -printf is available because the backup
-    # container is Linux-only.
-    find "$BACKUP_DIR" -maxdepth 1 -mindepth 1 -type d -printf '%%T@ %%p\n' | \
+    echo "Deleting $TO_DELETE oldest artifacts (keeping $MAX_COUNT)"
+    # Oldest-first by filesystem mtime — never coupled to the filename's
+    # timestamp format.
+    find "$BACKUP_DIR" -maxdepth 1 -type f -name '*.backup' -printf '%%T@ %%p\n' | \
         sort -n | \
         head -n "$TO_DELETE" | \
         cut -d' ' -f2- | \
-        xargs -r rm -rf
-    echo "Deleted $TO_DELETE old backup directories"
+        tr '\n' '\0' | \
+        xargs -0 -r rm -f
+    echo "Deleted $TO_DELETE old backup artifacts"
 fi
 `, policy.MaxCount)
 	}
@@ -1761,9 +1780,15 @@ fi
 	if policy.MaxAge != "" {
 		findArg := parseFindTimeArg(policy.MaxAge)
 		script += fmt.Sprintf(`
-# Delete backup directories older than %s
-find "$BACKUP_DIR" -maxdepth 1 -mindepth 1 -type d %s -exec rm -rf {} +
-echo "Removed backup directories older than %s"
+# Delete backup artifacts older than %s — but always keep the newest one,
+# even if it has aged out (a retention policy must never delete the ONLY
+# remaining backup).
+NEWEST=$(find "$BACKUP_DIR" -maxdepth 1 -type f -name '*.backup' -printf '%%T@ %%p\n' | sort -rn | head -n1 | cut -d' ' -f2-)
+find "$BACKUP_DIR" -maxdepth 1 -type f -name '*.backup' %s -print | while IFS= read -r f; do
+    [ "$f" = "$NEWEST" ] && continue
+    rm -f "$f"
+done
+echo "Removed backup artifacts older than %s"
 `, policy.MaxAge, findArg, policy.MaxAge)
 	}
 

--- a/internal/controller/neo4jbackup_controller.go
+++ b/internal/controller/neo4jbackup_controller.go
@@ -151,9 +151,17 @@ func (r *Neo4jBackupReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, nil
 	}
 
-	// Get target cluster
+	// Get target cluster. NotFound is TRANSIENT (#217): `kubectl apply -f dir/`
+	// commonly creates the Neo4jBackup before (or alongside) its target CR —
+	// flipping to Failed here is permanent for one-shot backups (the terminal
+	// guard never re-enters) even after the cluster appears moments later.
 	targetCluster, err := r.getTargetCluster(ctx, backup)
 	if err != nil {
+		if errors.IsNotFound(err) || strings.Contains(err.Error(), "not found") {
+			logger.Info("Backup target not found yet; waiting", "error", err.Error())
+			r.updateBackupStatus(ctx, backup, "Waiting", fmt.Sprintf("Waiting for target to appear: %v", err))
+			return ctrl.Result{RequeueAfter: r.RequeueAfter}, nil
+		}
 		logger.Error(err, "Failed to get target cluster")
 		r.updateBackupStatus(ctx, backup, "Failed", fmt.Sprintf("Failed to get target cluster: %v", err))
 		return ctrl.Result{RequeueAfter: r.RequeueAfter}, err
@@ -247,6 +255,11 @@ func (r *Neo4jBackupReconciler) handleScheduledBackup(ctx context.Context, backu
 	// Create or update CronJob for scheduled backups
 	cronJob, err := r.createBackupCronJob(ctx, backup, cluster)
 	if err != nil {
+		if stderrors.Is(err, errBackupTransient) {
+			logger.Info("Scheduled backup precondition not met yet; waiting", "error", err.Error())
+			r.updateBackupStatus(ctx, backup, "Pending", err.Error())
+			return ctrl.Result{RequeueAfter: r.RequeueAfter}, nil
+		}
 		logger.Error(err, "Failed to create backup CronJob")
 		r.updateBackupStatus(ctx, backup, "Failed", fmt.Sprintf("Failed to create CronJob: %v", err))
 		return ctrl.Result{RequeueAfter: r.RequeueAfter}, err
@@ -536,6 +549,11 @@ func (r *Neo4jBackupReconciler) handleOneTimeBackup(ctx context.Context, backup 
 			r.updateBackupStatus(ctx, backup, "Pending", err.Error())
 			return ctrl.Result{RequeueAfter: r.RequeueAfter}, nil
 		}
+		if stderrors.Is(err, errBackupTransient) {
+			logger.Info("Backup precondition not met yet; waiting", "error", err.Error())
+			r.updateBackupStatus(ctx, backup, "Pending", err.Error())
+			return ctrl.Result{RequeueAfter: r.RequeueAfter}, nil
+		}
 		logger.Error(err, "Failed to create backup job")
 		r.updateBackupStatus(ctx, backup, "Failed", fmt.Sprintf("Failed to create backup job: %v", err))
 		return ctrl.Result{RequeueAfter: r.RequeueAfter}, err
@@ -558,14 +576,15 @@ func (r *Neo4jBackupReconciler) handleExistingBackupJob(ctx context.Context, bac
 	// re-enters), so the Job's eventual success would never be recorded.
 	// Mirrors the restore controller's condition-based check.
 	if jobConditionTrue(job, batchv1.JobComplete) || job.Status.Succeeded > 0 {
-		// Backup completed successfully
+		// Record history BEFORE the terminal phase flip (#217): the terminal
+		// guard never re-enters after Completed, so a lost history write
+		// would leave a Completed backup with no Succeeded run — which
+		// ResolveBackupRef treats as not-ready FOREVER, wedging every
+		// backupRef restore/seed against a backup that succeeded.
+		r.recordOneShotBackupRun(ctx, backup, job)
 		r.updateBackupStatus(ctx, backup, "Completed", "Backup completed successfully")
 		r.Recorder.Event(backup, corev1.EventTypeNormal, EventReasonBackupCompleted, "Backup completed successfully")
 		backupM.RecordBackup(ctx, true, jobDuration(job), 0)
-
-		// Append the run to status.history + refresh status.stats summary
-		r.recordOneShotBackupRun(ctx, backup, job)
-
 		return ctrl.Result{}, nil
 	}
 
@@ -745,6 +764,12 @@ func (r *Neo4jBackupReconciler) ensureBackupPVC(ctx context.Context, backup *neo
 	return r.Create(ctx, pvc)
 }
 
+// errBackupTransient wraps conditions that should route to a Waiting/Pending
+// phase + requeue instead of terminal Failed (#217): the chain parent CR not
+// created yet (apply-ordering), or a momentary Bolt connect/query failure
+// during the sharded glob-safety preflight. Detect with errors.Is.
+var errBackupTransient = fmt.Errorf("transient backup precondition")
+
 // errChainBusy is returned by waitForChainConcurrencyClear when another
 // Job belonging to the same chain is still active. Callers route to
 // Pending+requeue rather than failing.
@@ -768,7 +793,14 @@ func (r *Neo4jBackupReconciler) validateChainParent(ctx context.Context, backup 
 	parent := &neo4jv1beta1.Neo4jBackup{}
 	key := types.NamespacedName{Name: backup.Spec.ChainFromBackup, Namespace: backup.Namespace}
 	if err := r.Get(ctx, key, parent); err != nil {
-		return fmt.Errorf("chainFromBackup %q not found in namespace %q: %w",
+		if errors.IsNotFound(err) {
+			// Apply-ordering footgun: the parent CR may simply not be
+			// created yet. Transient (#217) — target/storage mismatches
+			// below stay terminal.
+			return fmt.Errorf("chainFromBackup %q not found in namespace %q (waiting for it to appear): %w",
+				backup.Spec.ChainFromBackup, backup.Namespace, errBackupTransient)
+		}
+		return fmt.Errorf("chainFromBackup %q lookup failed in namespace %q: %w",
 			backup.Spec.ChainFromBackup, backup.Namespace, err)
 	}
 	if parent.Spec.Target.Kind != backup.Spec.Target.Kind ||
@@ -801,11 +833,16 @@ func (r *Neo4jBackupReconciler) validateChainParent(ctx context.Context, backup 
 // that Kubernetes doesn't natively coordinate.
 func (r *Neo4jBackupReconciler) waitForChainConcurrencyClear(ctx context.Context, backup *neo4jv1beta1.Neo4jBackup) error {
 	jobs := &batchv1.JobList{}
+	// NOTE: no app.kubernetes.io/component filter — one-shot Jobs carry
+	// component=backup but CronJob children carry component=backup-cron, and
+	// filtering on the former made scheduled runs invisible to the chain
+	// concurrency guard (#217): a daily-FULL CronJob child and an hourly
+	// DIFF could collide in the shared --to-path directory. managed-by +
+	// part-of are sufficient to scope to this chain.
 	if err := r.List(ctx, jobs,
 		client.InNamespace(backup.Namespace),
 		client.MatchingLabels{
 			"app.kubernetes.io/managed-by": "neo4j-operator",
-			"app.kubernetes.io/component":  "backup",
 			"app.kubernetes.io/part-of":    chainRoot(backup),
 		},
 	); err != nil {
@@ -911,6 +948,17 @@ func (r *Neo4jBackupReconciler) createBackupJob(ctx context.Context, backup *neo
 		return nil, err
 	}
 	if err := r.Create(ctx, job); err != nil {
+		// AlreadyExists = a previous reconcile created the Job but the
+		// informer cache hadn't caught up when handleOneTimeBackup looked it
+		// up (#217). Treating it as terminal Failed bricked a backup that is
+		// actually RUNNING. Adopt the existing Job instead — same tolerance
+		// the restore controller has (rule 46).
+		if errors.IsAlreadyExists(err) {
+			existing := &batchv1.Job{}
+			if getErr := r.Get(ctx, client.ObjectKeyFromObject(job), existing); getErr == nil {
+				return existing, nil
+			}
+		}
 		return nil, err
 	}
 	return job, nil
@@ -962,6 +1010,16 @@ func (r *Neo4jBackupReconciler) createBackupCronJob(ctx context.Context, backup 
 	// the user touches the CR. Phase 1 accepts this gap; Phase 3 observability
 	// can surface it via neo4j-admin backup validate output.
 	if err := r.shardedPreflightGlobSafety(ctx, backup, cluster); err != nil {
+		return nil, err
+	}
+
+	// Cross-CR consistency for chainFromBackup — previously only the one-shot
+	// path validated this (#217), so a scheduled DIFF chained to a mismatched
+	// or missing parent silently produced broken chains. Run-time exclusion
+	// between two CronJobs' children remains best-effort (ConcurrencyPolicy
+	// only guards within one CronJob); the chain concurrency check now at
+	// least sees scheduled children from the one-shot path.
+	if err := r.validateChainParent(ctx, backup); err != nil {
 		return nil, err
 	}
 
@@ -1575,7 +1633,10 @@ func (r *Neo4jBackupReconciler) cleanupBackupJobs(ctx context.Context, backup *n
 	}
 
 	for _, job := range jobList.Items {
-		if err := r.Delete(ctx, &job); err != nil && !errors.IsNotFound(err) {
+		// Background propagation: a bare API delete of a batch Job ORPHANS its
+		// pods — a running backup pod would keep writing to storage and
+		// holding the cluster's backup port after CR deletion (#217).
+		if err := r.Delete(ctx, &job, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil && !errors.IsNotFound(err) {
 			return err
 		}
 	}
@@ -1726,6 +1787,17 @@ func parseFindTimeArg(maxAge string) string {
 		return fmt.Sprintf("-mtime +%d", n)
 	case 'h':
 		return fmt.Sprintf("-mmin +%d", n*60)
+	case 'm':
+		// The validator accepts [dhms]; silently treating "90m" as 90 DAYS
+		// (the old default branch) violated the documented grammar (#217).
+		return fmt.Sprintf("-mmin +%d", n)
+	case 's':
+		// find(1) has no sub-minute predicate; round up to one minute.
+		mins := (n + 59) / 60
+		if mins < 1 {
+			mins = 1
+		}
+		return fmt.Sprintf("-mmin +%d", mins)
 	default:
 		return fmt.Sprintf("-mtime +%d", n)
 	}

--- a/internal/controller/neo4jbackup_lifecycle_test.go
+++ b/internal/controller/neo4jbackup_lifecycle_test.go
@@ -217,3 +217,19 @@ func TestParseFindTimeArg_Units(t *testing.T) {
 	assert.Equal(t, "-mmin +2", parseFindTimeArg("90s"))
 	assert.Equal(t, "-mtime +7", parseFindTimeArg("bogus"))
 }
+
+// TestBuildRetentionScript_FileLevelChainScoped pins the #217 retention
+// rewrite: pruning operates on *.backup FILES inside THIS CR's chain dir —
+// the old script rm -rf'd depth-1 DIRECTORIES under /backup (entire chain
+// roots, including other CRs' chains on a shared PVC).
+func TestBuildRetentionScript_FileLevelChainScoped(t *testing.T) {
+	script := buildRetentionScript(&neo4jv1beta1.RetentionPolicy{MaxCount: 5, MaxAge: "7d"}, "daily-prod")
+
+	assert.Contains(t, script, "'/backup/daily-prod'", "pruning must be scoped to the CR's chain dir")
+	assert.Contains(t, script, "-name '*.backup'", "pruning must target artifact FILES, not directories")
+	assert.Contains(t, script, "-type f", "must never rm -rf directories")
+	assert.NotContains(t, script, "-type d", "the pre-rule-40 directory model must be gone")
+	assert.Contains(t, script, "NEWEST=", "maxAge must always keep the newest artifact")
+	assert.Contains(t, script, "rm -f", "file-level deletion only")
+	assert.NotContains(t, script, "rm -rf", "recursive deletion of chains must be gone")
+}

--- a/internal/controller/neo4jbackup_lifecycle_test.go
+++ b/internal/controller/neo4jbackup_lifecycle_test.go
@@ -162,3 +162,58 @@ func TestCompressEffective(t *testing.T) {
 	assert.False(t, (&neo4jv1beta1.BackupOptions{Compress: ptr.To(false)}).CompressEffective(),
 		"explicit false must survive — bool+omitempty+default silently re-applied true (rule 66)")
 }
+
+// TestChainConcurrency_SeesCronJobChildren pins the #217 label fix: CronJob
+// children carry component=backup-cron, and the old component=backup filter
+// made scheduled runs invisible to the chain concurrency guard.
+func TestChainConcurrency_SeesCronJobChildren(t *testing.T) {
+	scheme := backupLifecycleScheme(t)
+	backup := &neo4jv1beta1.Neo4jBackup{
+		ObjectMeta: metav1.ObjectMeta{Name: "hourly-diff", Namespace: "ns"},
+		Spec:       neo4jv1beta1.Neo4jBackupSpec{ChainFromBackup: "daily-full"},
+	}
+	cronChild := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "daily-full-backup-cron-1738000000", Namespace: "ns",
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "neo4j-operator",
+				"app.kubernetes.io/component":  "backup-cron", // scheduled child
+				"app.kubernetes.io/part-of":    "daily-full",
+			},
+		},
+		Status: batchv1.JobStatus{Active: 1},
+	}
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(backup, cronChild).Build()
+	r := &Neo4jBackupReconciler{Client: fc}
+
+	err := r.waitForChainConcurrencyClear(context.Background(), backup)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errChainBusy,
+		"an active scheduled child in the same chain must block a chained run")
+}
+
+// TestValidateChainParent_NotFoundIsTransient pins #217: the parent CR not
+// existing YET is an apply-ordering condition (Pending), not terminal.
+func TestValidateChainParent_NotFoundIsTransient(t *testing.T) {
+	scheme := backupLifecycleScheme(t)
+	backup := &neo4jv1beta1.Neo4jBackup{
+		ObjectMeta: metav1.ObjectMeta{Name: "diff", Namespace: "ns"},
+		Spec:       neo4jv1beta1.Neo4jBackupSpec{ChainFromBackup: "missing-parent"},
+	}
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(backup).Build()
+	r := &Neo4jBackupReconciler{Client: fc}
+
+	err := r.validateChainParent(context.Background(), backup)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errBackupTransient)
+}
+
+// TestParseFindTimeArg_Units pins #217: every unit the validator accepts is
+// honored — "90m" previously degraded to 90 DAYS.
+func TestParseFindTimeArg_Units(t *testing.T) {
+	assert.Equal(t, "-mtime +7", parseFindTimeArg("7d"))
+	assert.Equal(t, "-mmin +2880", parseFindTimeArg("48h"))
+	assert.Equal(t, "-mmin +90", parseFindTimeArg("90m"))
+	assert.Equal(t, "-mmin +2", parseFindTimeArg("90s"))
+	assert.Equal(t, "-mtime +7", parseFindTimeArg("bogus"))
+}

--- a/internal/controller/neo4jbackup_sharded.go
+++ b/internal/controller/neo4jbackup_sharded.go
@@ -108,13 +108,15 @@ func (r *Neo4jBackupReconciler) shardedPreflightGlobSafety(ctx context.Context, 
 
 	client, err := neo4jclient.NewClientForEnterprise(cluster, r.Client, cluster.Spec.Auth.AdminSecret)
 	if err != nil {
-		return fmt.Errorf("failed to open Neo4j client for glob-safety check: %w", err)
+		// Connect failures are indistinguishable from a cluster that is
+		// momentarily unreachable — transient (#217), not a glob violation.
+		return fmt.Errorf("failed to open Neo4j client for glob-safety check: %v: %w", err, errBackupTransient)
 	}
 	defer client.Close()
 
 	dbs, err := client.GetDatabases(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to list databases for glob-safety check: %w", err)
+		return fmt.Errorf("failed to list databases for glob-safety check: %v: %w", err, errBackupTransient)
 	}
 
 	logical := backup.Spec.Target.Name

--- a/internal/controller/neo4jrestore_cloud_test.go
+++ b/internal/controller/neo4jrestore_cloud_test.go
@@ -1041,3 +1041,24 @@ func TestPVCSeedProxyLifecycle(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "63-character")
 }
+
+// TestShardedSeedConsumableGate pins the #224 review fix: once a sharded DB
+// is Ready (and no destructive re-trigger is pending), seed resolution is
+// skipped — re-resolving would re-create the PVC seed proxy that the Ready
+// transition tears down, oscillating Ready→Pending forever.
+func TestShardedSeedConsumableGate(t *testing.T) {
+	mk := func(ready *bool, replace bool, lastGen, gen int64) bool {
+		sd := &neo4jv1beta1.Neo4jShardedDatabase{}
+		sd.Generation = gen
+		sd.Spec.ReplaceExisting = replace
+		sd.Status.ShardingReady = ready
+		sd.Status.LastDestructiveRestoreGeneration = lastGen
+		return sd.Status.ShardingReady == nil || !*sd.Status.ShardingReady ||
+			(sd.Spec.ReplaceExisting && sd.Status.LastDestructiveRestoreGeneration < sd.Generation)
+	}
+	assert.True(t, mk(nil, false, 0, 1), "never seeded: consumable")
+	assert.True(t, mk(ptr.To(false), false, 0, 1), "not ready yet: consumable")
+	assert.False(t, mk(ptr.To(true), false, 0, 1), "Ready steady state: NOT consumable")
+	assert.True(t, mk(ptr.To(true), true, 1, 2), "destructive re-trigger pending: consumable")
+	assert.False(t, mk(ptr.To(true), true, 2, 2), "destructive already done at this generation: NOT consumable")
+}

--- a/internal/controller/neo4jrestore_cloud_test.go
+++ b/internal/controller/neo4jrestore_cloud_test.go
@@ -5,10 +5,14 @@ import (
 	stderrors "errors"
 	"testing"
 
+	"strings"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -988,4 +992,52 @@ func TestClearStaleRestoreAttemptState(t *testing.T) {
 	// Idempotent on already-clean objects.
 	require.NoError(t, r.clearCypherRestoreIssued(context.Background(), restore))
 	require.NoError(t, r.clearResolvedSource(context.Background(), restore))
+}
+
+// TestPVCSeedProxyLifecycle pins #219: the proxy stack (Deployment + Service
+// + NetworkPolicy) is restricted to the target cluster's pods and is torn
+// down once the seed is no longer needed — it serves the ENTIRE backup PVC
+// unauthenticated and previously ran for the lifetime of the owning CR.
+func TestPVCSeedProxyLifecycle(t *testing.T) {
+	scheme := newTestScheme()
+	restore := &neo4jv1beta1.Neo4jRestore{
+		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "uid-r"},
+		Spec:       neo4jv1beta1.Neo4jRestoreSpec{ClusterRef: "prod"},
+	}
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(restore).Build()
+
+	available, err := ensurePVCSeedProxyResources(context.Background(), fc, scheme, restore, restore.Name, "backup-pvc")
+	require.NoError(t, err)
+	assert.False(t, available, "freshly created proxy is not yet ready")
+	require.NoError(t, ensurePVCSeedProxyNetworkPolicy(context.Background(), fc, scheme, restore, restore.Name, "prod"))
+
+	np := &networkingv1.NetworkPolicy{}
+	require.NoError(t, fc.Get(context.Background(), types.NamespacedName{Name: "backup-seed-proxy-r", Namespace: "ns"}, np))
+	require.Len(t, np.Spec.Ingress, 1)
+	require.Len(t, np.Spec.Ingress[0].From, 1)
+	assert.Equal(t, "prod", np.Spec.Ingress[0].From[0].PodSelector.MatchLabels["neo4j.com/cluster"],
+		"only the target cluster's server pods may reach the proxy")
+
+	require.NoError(t, teardownPVCSeedProxyResources(context.Background(), fc, "ns", "r"))
+	for _, obj := range []struct {
+		name string
+		o    interface {
+			GetName() string
+		}
+	}{} {
+		_ = obj
+	}
+	dep := &appsv1.Deployment{}
+	assert.Error(t, fc.Get(context.Background(), types.NamespacedName{Name: "backup-seed-proxy-r", Namespace: "ns"}, dep), "Deployment torn down")
+	svc := &corev1.Service{}
+	assert.Error(t, fc.Get(context.Background(), types.NamespacedName{Name: "backup-seed-proxy-r", Namespace: "ns"}, svc), "Service torn down")
+	npAfter := &networkingv1.NetworkPolicy{}
+	assert.Error(t, fc.Get(context.Background(), types.NamespacedName{Name: "backup-seed-proxy-r", Namespace: "ns"}, npAfter), "NetworkPolicy torn down")
+
+	// Idempotent teardown + name-length validation.
+	require.NoError(t, teardownPVCSeedProxyResources(context.Background(), fc, "ns", "r"))
+	longName := strings.Repeat("x", 60)
+	_, err = ensurePVCSeedProxyResources(context.Background(), fc, scheme, restore, longName, "backup-pvc")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "63-character")
 }

--- a/internal/controller/neo4jrestore_controller.go
+++ b/internal/controller/neo4jrestore_controller.go
@@ -184,7 +184,11 @@ func (r *Neo4jRestoreReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// even after the target appears.
 	targetCluster, err := r.getClusterRef(ctx, restore)
 	if err != nil {
-		if errors.IsNotFound(err) || strings.Contains(err.Error(), "not found") {
+		// errors.IsNotFound unwraps %w chains — ONLY genuine NotFound waits;
+		// Forbidden/other API failures stay on the error path (#224 review:
+		// a substring match on the static "not found" message misclassified
+		// wrapped non-NotFound errors).
+		if errors.IsNotFound(err) {
 			logger.Info("Restore target not found yet; waiting", "error", err.Error())
 			r.updateRestoreStatus(ctx, restore, StatusPending, fmt.Sprintf("Waiting for target to appear: %v", err))
 			return ctrl.Result{RequeueAfter: r.RequeueAfter}, nil

--- a/internal/controller/neo4jrestore_controller.go
+++ b/internal/controller/neo4jrestore_controller.go
@@ -2616,9 +2616,6 @@ func (r *Neo4jRestoreReconciler) startClusterCypherRestore(
 
 	completion := metav1.Now()
 	restore.Status.CompletionTime = &completion
-	if terr := teardownPVCSeedProxyResources(ctx, r.Client, restore.Namespace, restore.Name); terr != nil {
-		logger.Error(terr, "Failed to tear down seed proxy after restore completion (non-fatal)")
-	}
 	r.updateRestoreStatus(ctx, restore, StatusCompleted,
 		fmt.Sprintf("Database %q restored via cluster Cypher path (seedURI=%s)", restore.Spec.DatabaseName, seedURI))
 	r.Recorder.Event(restore, corev1.EventTypeNormal, EventReasonRestoreCompleted,
@@ -2746,11 +2743,6 @@ func (r *Neo4jRestoreReconciler) pollClusterRestoreOnline(ctx context.Context, r
 	if stateErr == nil && total > 0 && online == total {
 		completion := metav1.Now()
 		restore.Status.CompletionTime = &completion
-		// The seed is done — tear down the PVC seed proxy (if any) so the
-		// backup PVC stops being served cluster-wide (#219). Idempotent.
-		if err := teardownPVCSeedProxyResources(ctx, r.Client, restore.Namespace, restore.Name); err != nil {
-			logger.Error(err, "Failed to tear down seed proxy after restore completion (non-fatal)")
-		}
 		r.updateRestoreStatus(ctx, restore, StatusCompleted,
 			fmt.Sprintf("Database %q restored via cluster Cypher path (%d/%d allocations online)", restore.Spec.DatabaseName, online, total))
 		r.Recorder.Event(restore, corev1.EventTypeNormal, EventReasonRestoreCompleted,
@@ -2762,9 +2754,6 @@ func (r *Neo4jRestoreReconciler) pollClusterRestoreOnline(ctx context.Context, r
 		detail := diag
 		if stateErr != nil {
 			detail = stateErr.Error()
-		}
-		if err := teardownPVCSeedProxyResources(ctx, r.Client, restore.Namespace, restore.Name); err != nil {
-			logger.Error(err, "Failed to tear down seed proxy after restore failure (non-fatal)")
 		}
 		r.updateRestoreStatus(ctx, restore, StatusFailed,
 			fmt.Sprintf("Restore did not converge to online within %s (%d/%d allocations online); last status: %s",
@@ -3098,6 +3087,19 @@ func (r *Neo4jRestoreReconciler) updateRestoreStatus(ctx context.Context, restor
 	err := retry.RetryOnConflict(retry.DefaultBackoff, update)
 	if err != nil {
 		log.FromContext(ctx).Error(err, "Failed to update restore status")
+	}
+
+	// Terminal sink for the PVC seed proxy (#219/#224 review): every path
+	// that ends the restore — Completed OR Failed, from ANY call site —
+	// funnels through this status writer, so tearing the proxy down here
+	// guarantees the unauthenticated backup-PVC HTTP proxy never outlives
+	// the restore, without chasing each individual Failed exit in
+	// startClusterCypherRestore. Cheap idempotent no-op (3 NotFound deletes)
+	// when no proxy was ever created (cloud/Job paths).
+	if phase == StatusCompleted || phase == StatusFailed {
+		if terr := teardownPVCSeedProxyResources(ctx, r.Client, restore.Namespace, restore.Name); terr != nil {
+			log.FromContext(ctx).Error(terr, "Failed to tear down seed proxy on terminal restore phase (non-fatal)")
+		}
 	}
 }
 

--- a/internal/controller/neo4jrestore_controller.go
+++ b/internal/controller/neo4jrestore_controller.go
@@ -178,9 +178,17 @@ func (r *Neo4jRestoreReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{Requeue: true}, nil
 	}
 
-	// Get target cluster
+	// Get target cluster. Not-found is TRANSIENT (#218): `kubectl apply -f
+	// dir/` commonly creates the Neo4jRestore before its target CR, and a
+	// terminal Failed here is pinned by the previously-failed guard below
+	// even after the target appears.
 	targetCluster, err := r.getClusterRef(ctx, restore)
 	if err != nil {
+		if errors.IsNotFound(err) || strings.Contains(err.Error(), "not found") {
+			logger.Info("Restore target not found yet; waiting", "error", err.Error())
+			r.updateRestoreStatus(ctx, restore, StatusPending, fmt.Sprintf("Waiting for target to appear: %v", err))
+			return ctrl.Result{RequeueAfter: r.RequeueAfter}, nil
+		}
 		logger.Error(err, "Failed to get target cluster")
 		r.updateRestoreStatus(ctx, restore, StatusFailed, fmt.Sprintf("Failed to get target cluster: %v", err))
 		return ctrl.Result{RequeueAfter: r.RequeueAfter}, err
@@ -768,24 +776,42 @@ func (r *Neo4jRestoreReconciler) validateRestore(ctx context.Context, restore *n
 			restore.Spec.DatabaseName, validation.MaxDatabaseNameLength)
 	}
 
+	// spec.source.pointInTime is implemented by the standalone Job path
+	// (--restore-until) for EVERY source type — but the cluster Cypher path
+	// never reads it (#218). Silently returning latest-state when the user
+	// asked for a point in time is worse than failing: reject up front.
+	if restore.Spec.Source.PointInTime != nil {
+		if isCluster, _, terr := r.isRestoreTargetTrueCluster(ctx, restore); terr == nil && isCluster {
+			return fmt.Errorf("source.pointInTime is not supported for cluster targets (clusterRef %q resolves to a Neo4jEnterpriseCluster) — the cluster restore path seeds from a backup artifact and cannot replay to a point in time. For cluster point-in-time recovery, create a Neo4jDatabase with spec.seedConfig.restoreUntil instead", restore.Spec.ClusterRef)
+		}
+	}
+
 	// Sharded databases must NOT be restored via Neo4jRestore — the Cypher
 	// shape (`CREATE DATABASE … SET GRAPH SHARD … SET PROPERTY SHARDS …`)
 	// is owned by Neo4jShardedDatabase, and the destructive restore path
 	// is gated by `replaceExisting=true` + `force=true` (rule 63) on that
 	// CR. Detect via Neo4jShardedDatabase lookup in the same namespace.
-	shardedDB := &neo4jv1beta1.Neo4jShardedDatabase{}
-	if err := r.Get(ctx, types.NamespacedName{Name: restore.Spec.DatabaseName, Namespace: restore.Namespace}, shardedDB); err == nil {
-		return fmt.Errorf(
-			"database %q is a Neo4jShardedDatabase — use the Neo4jShardedDatabase restore path instead:\n"+
-				"  spec:\n"+
-				"    seedBackupRef: %q\n"+
-				"    replaceExisting: true\n"+
-				"    force: true\n"+
-				"Sharded restores require the SET GRAPH SHARD / SET PROPERTY SHARDS clauses that only CREATE DATABASE accepts; dbms.recreateDatabase doesn't support sharded topology",
-			restore.Spec.DatabaseName, restore.Spec.Source.BackupRef,
-		)
-	} else if !errors.IsNotFound(err) {
+	// Match by the DATABASE name (Neo4jShardedDatabase.spec.name), not just
+	// the CR name — a sharded DB whose CR is named differently previously
+	// escaped this guard into the unsupported recreate path (#218). List is
+	// namespace-scoped and sharded CRs are rare, so this stays cheap.
+	shardedList := &neo4jv1beta1.Neo4jShardedDatabaseList{}
+	if err := r.List(ctx, shardedList, client.InNamespace(restore.Namespace)); err != nil {
 		return fmt.Errorf("failed to check whether %q is a Neo4jShardedDatabase: %w", restore.Spec.DatabaseName, err)
+	}
+	for i := range shardedList.Items {
+		sd := &shardedList.Items[i]
+		if sd.Name == restore.Spec.DatabaseName || sd.Spec.Name == restore.Spec.DatabaseName {
+			return fmt.Errorf(
+				"database %q is a Neo4jShardedDatabase (CR %q) — use the Neo4jShardedDatabase restore path instead:\n"+
+					"  spec:\n"+
+					"    seedBackupRef: %q\n"+
+					"    replaceExisting: true\n"+
+					"    force: true\n"+
+					"Sharded restores require the SET GRAPH SHARD / SET PROPERTY SHARDS clauses that only CREATE DATABASE accepts; dbms.recreateDatabase doesn't support sharded topology",
+				restore.Spec.DatabaseName, sd.Name, restore.Spec.Source.BackupRef,
+			)
+		}
 	}
 
 	return nil
@@ -3006,17 +3032,20 @@ func podTemplateReferencesSecretEnvFrom(tmpl *corev1.PodTemplateSpec, secretName
 }
 
 func (r *Neo4jRestoreReconciler) cleanupRestoreJobs(ctx context.Context, restore *neo4jv1beta1.Neo4jRestore) error {
-	// Delete associated jobs
+	// Delete associated jobs. No component filter: hook Jobs carry
+	// component=<phase>-hook and previously leaked (they now also carry an
+	// ownerRef, so this is belt-and-braces). Background propagation: a bare
+	// API delete of a batch Job ORPHANS its pods (#218).
 	jobList := &batchv1.JobList{}
 	if err := r.List(ctx, jobList, client.InNamespace(restore.Namespace), client.MatchingLabels{
-		"app.kubernetes.io/instance":  restore.Name,
-		"app.kubernetes.io/component": "restore",
+		"app.kubernetes.io/instance": restore.Name,
+		"app.kubernetes.io/name":     "neo4j-restore",
 	}); err != nil {
 		return err
 	}
 
 	for _, job := range jobList.Items {
-		if err := r.Delete(ctx, &job); err != nil && !errors.IsNotFound(err) {
+		if err := r.Delete(ctx, &job, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil && !errors.IsNotFound(err) {
 			return err
 		}
 	}

--- a/internal/controller/neo4jrestore_controller.go
+++ b/internal/controller/neo4jrestore_controller.go
@@ -237,6 +237,12 @@ func (r *Neo4jRestoreReconciler) handleDeletion(ctx context.Context, restore *ne
 		return ctrl.Result{RequeueAfter: r.RequeueAfter}, err
 	}
 
+	// Tear down the PVC seed proxy stack (owner-ref GC would also get it,
+	// but explicit deletion is immediate and covers orphaned policies).
+	if err := teardownPVCSeedProxyResources(ctx, r.Client, restore.Namespace, restore.Name); err != nil {
+		logger.Error(err, "Failed to tear down seed proxy during finalizer cleanup (non-fatal)")
+	}
+
 	// Release the cluster controller's hold on STS replicas if this restore
 	// died mid-cycle (e.g. user deleted the CR while stopCluster was in
 	// progress). Without this the target cluster is permanently un-scalable.
@@ -2606,6 +2612,9 @@ func (r *Neo4jRestoreReconciler) startClusterCypherRestore(
 
 	completion := metav1.Now()
 	restore.Status.CompletionTime = &completion
+	if terr := teardownPVCSeedProxyResources(ctx, r.Client, restore.Namespace, restore.Name); terr != nil {
+		logger.Error(terr, "Failed to tear down seed proxy after restore completion (non-fatal)")
+	}
 	r.updateRestoreStatus(ctx, restore, StatusCompleted,
 		fmt.Sprintf("Database %q restored via cluster Cypher path (seedURI=%s)", restore.Spec.DatabaseName, seedURI))
 	r.Recorder.Event(restore, corev1.EventTypeNormal, EventReasonRestoreCompleted,
@@ -2733,6 +2742,11 @@ func (r *Neo4jRestoreReconciler) pollClusterRestoreOnline(ctx context.Context, r
 	if stateErr == nil && total > 0 && online == total {
 		completion := metav1.Now()
 		restore.Status.CompletionTime = &completion
+		// The seed is done — tear down the PVC seed proxy (if any) so the
+		// backup PVC stops being served cluster-wide (#219). Idempotent.
+		if err := teardownPVCSeedProxyResources(ctx, r.Client, restore.Namespace, restore.Name); err != nil {
+			logger.Error(err, "Failed to tear down seed proxy after restore completion (non-fatal)")
+		}
 		r.updateRestoreStatus(ctx, restore, StatusCompleted,
 			fmt.Sprintf("Database %q restored via cluster Cypher path (%d/%d allocations online)", restore.Spec.DatabaseName, online, total))
 		r.Recorder.Event(restore, corev1.EventTypeNormal, EventReasonRestoreCompleted,
@@ -2744,6 +2758,9 @@ func (r *Neo4jRestoreReconciler) pollClusterRestoreOnline(ctx context.Context, r
 		detail := diag
 		if stateErr != nil {
 			detail = stateErr.Error()
+		}
+		if err := teardownPVCSeedProxyResources(ctx, r.Client, restore.Namespace, restore.Name); err != nil {
+			logger.Error(err, "Failed to tear down seed proxy after restore failure (non-fatal)")
 		}
 		r.updateRestoreStatus(ctx, restore, StatusFailed,
 			fmt.Sprintf("Restore did not converge to online within %s (%d/%d allocations online); last status: %s",
@@ -2842,6 +2859,14 @@ func (r *Neo4jRestoreReconciler) resolveClusterPVCRestoreURI(
 	// Neo4jRestore CR is the owner so the proxy is GC'd when the restore
 	// is deleted.
 	proxyAvailable, err := ensurePVCSeedProxyResources(ctx, r.Client, r.Scheme, restore, restore.Name, storage.PVC.Name)
+	if err == nil {
+		// Restrict the proxy (which serves the whole backup PVC) to the
+		// target cluster's server pods (#219). Best-effort: only enforcing
+		// CNIs apply it.
+		if npErr := ensurePVCSeedProxyNetworkPolicy(ctx, r.Client, r.Scheme, restore, restore.Name, restore.Spec.ClusterRef); npErr != nil {
+			log.FromContext(ctx).Error(npErr, "Failed to ensure seed-proxy NetworkPolicy (non-fatal)")
+		}
+	}
 	if err != nil {
 		return "", ctrl.Result{}, fmt.Errorf("ensure PVC seed proxy: %w", err)
 	}

--- a/internal/controller/neo4jrestore_controller_test.go
+++ b/internal/controller/neo4jrestore_controller_test.go
@@ -271,16 +271,16 @@ var _ = Describe("Neo4jRestore Controller", func() {
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
-			// The controller should reject this restore due to non-existent cluster
-			// — Phase=Failed plus a condition whose message references the missing
-			// cluster (the controller emits a Ready=False condition with the
-			// formatted "Failed to get target cluster: ..." message, not a typed
-			// ClusterNotFound condition).
+			// A missing target is TRANSIENT (#218): kubectl apply -f dir/
+			// commonly creates the restore before its target CR, so the
+			// controller waits in Pending (message referencing the missing
+			// target) instead of pinning a terminal Failed.
 			Eventually(func() bool {
 				if err := k8sClient.Get(ctx, restoreLookupKey, createdRestore); err != nil {
 					return false
 				}
-				return hasFailedConditionMatching(createdRestore, "cluster", "not found")
+				return createdRestore.Status.Phase == "Pending" &&
+					strings.Contains(createdRestore.Status.Message, "not found")
 			}, timeout, interval).Should(BeTrue())
 
 			// Clean up

--- a/internal/controller/neo4jshardeddatabase_controller.go
+++ b/internal/controller/neo4jshardeddatabase_controller.go
@@ -288,6 +288,12 @@ func (r *Neo4jShardedDatabaseReconciler) Reconcile(ctx context.Context, req ctrl
 	// branch (otherwise the controller would re-drop on every poll cycle
 	// since IF EXISTS makes the drop idempotent).
 	ready := true
+	// Seeding is complete once the sharded DB is operational — tear down the
+	// PVC seed proxy stack (if any) so the backup PVC stops being served
+	// cluster-wide (#219). Idempotent NotFound no-op after the first pass.
+	if err := r.teardownPVCSeedProxy(ctx, &shardedDatabase); err != nil {
+		logger.Error(err, "Failed to tear down seed proxy after sharded DB became Ready (non-fatal)")
+	}
 	if err := r.updateStatus(ctx, &shardedDatabase, "Ready", "Sharded database is operational", &ready); err != nil {
 		logger.Error(err, "Failed to update status to Ready")
 		return ctrl.Result{RequeueAfter: r.RequeueAfter}, err

--- a/internal/controller/neo4jshardeddatabase_controller.go
+++ b/internal/controller/neo4jshardeddatabase_controller.go
@@ -183,7 +183,19 @@ func (r *Neo4jShardedDatabaseReconciler) Reconcile(ctx context.Context, req ctrl
 	//     for the restore controller.
 	//   - Anything else (missing CR, PVC storage, unsupported type) →
 	//     permanent; route to Failed.
-	resolved, seedErr := r.resolveShardedSeed(ctx, &shardedDatabase)
+	// Seed resolution only matters while the seed can still be CONSUMED:
+	// initial creation (not ShardingReady yet) or a pending destructive
+	// replaceExisting re-trigger (rule 64). Once the sharded DB is Ready,
+	// resolving again would re-create the PVC seed proxy that the Ready
+	// transition just tore down — oscillating Ready→Pending and re-exposing
+	// the backup PVC on every periodic reconcile (#224 review).
+	seedConsumable := shardedDatabase.Status.ShardingReady == nil || !*shardedDatabase.Status.ShardingReady ||
+		(shardedDatabase.Spec.ReplaceExisting && shardedDatabase.Status.LastDestructiveRestoreGeneration < shardedDatabase.Generation)
+	var resolved *ResolvedShardedSeed
+	var seedErr error
+	if seedConsumable {
+		resolved, seedErr = r.resolveShardedSeed(ctx, &shardedDatabase)
+	}
 	if resolved != nil || seedErr != nil {
 		if seedErr != nil {
 			if stderrors.Is(seedErr, ErrBackupNotReady) {

--- a/internal/controller/neo4jshardeddatabase_pvc_proxy.go
+++ b/internal/controller/neo4jshardeddatabase_pvc_proxy.go
@@ -13,6 +13,8 @@ package controller
 import (
 	"context"
 
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
 	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
 )
 
@@ -31,5 +33,19 @@ func (r *Neo4jShardedDatabaseReconciler) ensurePVCSeedProxy(
 	shardedDB *neo4jv1beta1.Neo4jShardedDatabase,
 	backupPVCName string,
 ) (proxyAvailable bool, err error) {
-	return ensurePVCSeedProxyResources(ctx, r.Client, r.Scheme, shardedDB, shardedDB.Name, backupPVCName)
+	available, err := ensurePVCSeedProxyResources(ctx, r.Client, r.Scheme, shardedDB, shardedDB.Name, backupPVCName)
+	if err == nil {
+		// Restrict the proxy to the target cluster's server pods (#219).
+		if npErr := ensurePVCSeedProxyNetworkPolicy(ctx, r.Client, r.Scheme, shardedDB, shardedDB.Name, shardedDB.Spec.ClusterRef); npErr != nil {
+			log.FromContext(ctx).Error(npErr, "Failed to ensure seed-proxy NetworkPolicy (non-fatal)")
+		}
+	}
+	return available, err
+}
+
+// teardownPVCSeedProxy removes the proxy stack once the sharded database has
+// finished seeding (#219) — the proxy otherwise serves the whole backup PVC
+// for the lifetime of the (long-lived) sharded DB CR.
+func (r *Neo4jShardedDatabaseReconciler) teardownPVCSeedProxy(ctx context.Context, shardedDB *neo4jv1beta1.Neo4jShardedDatabase) error {
+	return teardownPVCSeedProxyResources(ctx, r.Client, shardedDB.Namespace, shardedDB.Name)
 }

--- a/internal/controller/pvc_seed_proxy.go
+++ b/internal/controller/pvc_seed_proxy.go
@@ -16,6 +16,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -103,6 +104,11 @@ func ensurePVCSeedProxyResources(
 	if ownerName == "" {
 		ownerName = owner.GetName()
 	}
+	// DNS-1035 label limit — a too-long owner name previously failed deep
+	// inside Service creation with an opaque error (#219).
+	if name := pvcSeedProxyName(ownerName); len(name) > 63 {
+		return false, fmt.Errorf("PVC seed proxy name %q exceeds the 63-character Service name limit; shorten the owning CR's name (max %d chars)", name, 63-len("backup-seed-proxy-"))
+	}
 	namespace := owner.GetNamespace()
 	logger := log.FromContext(ctx).WithValues("proxy", pvcSeedProxyName(ownerName))
 
@@ -132,6 +138,90 @@ func ensurePVCSeedProxyResources(
 	}
 
 	return existing.Status.ReadyReplicas > 0, nil
+}
+
+// teardownPVCSeedProxyResources deletes the proxy Deployment + Service (and
+// its NetworkPolicy) once the seed is no longer needed (#219). The proxy
+// serves the ENTIRE backup PVC unauthenticated inside the cluster, and its
+// owner CR (a Neo4jRestore users keep as a record, or a long-lived sharded
+// DB) typically outlives the restore by months — owner-ref GC alone left it
+// running indefinitely. Idempotent; NotFound is success.
+func teardownPVCSeedProxyResources(ctx context.Context, c client.Client, namespace, ownerName string) error {
+	name := pvcSeedProxyName(ownerName)
+	dep := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}
+	if err := c.Delete(ctx, dep, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete proxy Deployment: %w", err)
+	}
+	svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}
+	if err := c.Delete(ctx, svc); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete proxy Service: %w", err)
+	}
+	np := &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}
+	if err := c.Delete(ctx, np); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete proxy NetworkPolicy: %w", err)
+	}
+	return nil
+}
+
+// ensurePVCSeedProxyNetworkPolicy restricts proxy ingress to the target
+// cluster's server pods on the proxy port (#219): without it, busybox httpd
+// serves the ENTIRE backup PVC (directory listings included) to any pod in
+// the cluster. Effective only on enforcing CNIs; harmless no-op elsewhere.
+// targetClusterName may be empty (unknown target) — then no policy is
+// emitted, preserving previous behavior.
+func ensurePVCSeedProxyNetworkPolicy(ctx context.Context, c client.Client, scheme *runtime.Scheme, owner client.Object, ownerName, targetClusterName string) error {
+	if targetClusterName == "" {
+		return nil
+	}
+	name := pvcSeedProxyName(ownerName)
+	key := types.NamespacedName{Name: name, Namespace: owner.GetNamespace()}
+	existing := &networkingv1.NetworkPolicy{}
+	if err := c.Get(ctx, key, existing); err == nil {
+		return nil
+	} else if !apierrors.IsNotFound(err) {
+		return err
+	}
+	np := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: owner.GetNamespace(),
+			Labels: map[string]string{
+				"app.kubernetes.io/name":       "backup-seed-proxy",
+				"app.kubernetes.io/managed-by": "neo4j-operator",
+				"app.kubernetes.io/instance":   ownerName,
+			},
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app.kubernetes.io/name":     "backup-seed-proxy",
+					"app.kubernetes.io/instance": ownerName,
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				{
+					From: []networkingv1.NetworkPolicyPeer{
+						{
+							PodSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"neo4j.com/cluster": targetClusterName},
+							},
+						},
+					},
+					Ports: []networkingv1.NetworkPolicyPort{
+						{
+							Protocol: func() *corev1.Protocol { p := corev1.ProtocolTCP; return &p }(),
+							Port:     func() *intstr.IntOrString { v := intstr.FromInt(pvcSeedProxyPort); return &v }(),
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := controllerutil.SetControllerReference(owner, np, scheme); err != nil {
+		return fmt.Errorf("set owner reference on proxy NetworkPolicy: %w", err)
+	}
+	return c.Create(ctx, np)
 }
 
 // ensurePVCSeedProxyService creates (idempotent) the ClusterIP Service in


### PR DESCRIPTION
Second of the progressive audit-burndown PRs. **Stacked on #223 (Wave 1)** — merge that first; this PR's base is `fix/backup-restore-wave1`.

## Transient vs terminal (#217, #218)
- Backup/restore target NotFound → Waiting/Pending (apply-ordering: `kubectl apply -f dir/` creates the CR before its target; one-shot backups were permanently bricked by the terminal guard).
- Backup Job `AlreadyExists` → adopt the existing Job (stale informer cache race; rule-46 parity with restore).
- Sharded glob-preflight Bolt failures + chainFromBackup parent-not-yet-created → transient sentinel → Pending, on both one-shot and scheduled paths. Mismatches stay terminal.
- Auto-inherit seed-creds Update: refetch-inside-RetryOnConflict (routine conflicts were pinned terminal).

## Chain correctness (#217)
- `validateChainParent` now runs on the scheduled (CronJob) path.
- Chain concurrency guard sees CronJob children (component label filter dropped — daily-FULL children were invisible to an hourly DIFF, colliding in the shared `--to-path`).

## Retention rewrite (#217)
The script still implemented the pre-rule-40 per-run-subfolder model: it `rm -rf`'d depth-1 DIRECTORIES under /backup — whole chain roots, including the newest FULL and (on a shared PVC) other CRs' chains. Now: `*.backup` FILES inside this CR's chain dir only, oldest-first by mtime, newest always kept; DIFF-orphaning limitation surfaced via a `BackupRetentionCaveat` warning event and docs.

## Seed-proxy hardening + lifecycle (#219)
NetworkPolicy restricts the proxy to the target cluster's server pods; the stack (Deployment+Service+NetworkPolicy) is torn down on restore Completed/Failed, the finalizer, and the sharded DB's Ready transition (previously served the whole backup PVC cluster-wide for the CR's lifetime); 63-char name validation up front.

## Misc
Sharded restore guard matches `spec.name` (not just CR name); `pointInTime` rejected on cluster targets (was silently ignored); `maxAge` honors m/s units (90m was 90 days); history recorded before the Completed flip; Job deletions use background propagation (no orphaned pods).

Full unit suite green (one envtest spec updated to the new Pending semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches backup chains, retention pruning, restore/seeding paths, and cluster-wide HTTP exposure of backup PVCs; misclassification or premature teardown could wedge restores or leak data on the network.
> 
> **Overview**
> Wave 2 hardens **backup/restore/sharded-seed** reconciliation so apply-ordering, informer races, and chain semantics no longer pin CRs in terminal **Failed** or leave unsafe sidecars running.
> 
> **Transient vs terminal:** Backup and restore controllers treat a missing target (`errors.IsNotFound`) as **Waiting/Pending** with requeue instead of permanent failure; `getTargetCluster` now wraps API errors so RBAC failures are not misclassified. Backups add `errBackupTransient` for missing `chainFromBackup` parents and flaky sharded glob preflight; **Job `AlreadyExists`** adopts the existing job. Auto-inherit seed creds uses **refetch + `RetryOnConflict`** and only returns “patched” when this reconcile actually updated the cluster.
> 
> **Chain & retention:** `validateChainParent` runs on the **CronJob** path; chain concurrency lists jobs by `part-of` only so **backup-cron** children block colliding runs. PVC retention prunes **`*.backup` files** inside the CR’s chain directory (not whole `/backup` subdirs), keeps the newest artifact on maxAge, fixes **m/s** in `parseFindTimeArg`, and emits **`BackupRetentionCaveat`** when DIFF chains may be orphaned. One-shot success records **history before** `Completed`.
> 
> **Seed proxy (#219):** Adds **NetworkPolicy** (target cluster pods only), **teardown** on restore terminal status/finalizer and sharded DB **Ready**, skips re-seeding when sharded DB is already ready (#224), and validates proxy name length. Restore rejects **`pointInTime` on cluster targets** and matches sharded DBs by **`spec.name`**; job deletes use **background propagation**.
> 
> Unit/envtest coverage updated for Pending-on-missing-target and the new backup lifecycle behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32aec2e5c5933e96af60f12eee5825cb49b616d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->