### PR TITLE
fix(restore): Wave 3 — seedURI existingData fix, spec.timeout wiring, reserved-field truth (#218 #220)

### DIFF
--- a/api/v1beta1/neo4jbackup_types.go
+++ b/api/v1beta1/neo4jbackup_types.go
@@ -119,7 +119,9 @@ type RetentionPolicy struct {
 	// Maximum number of backups to keep
 	MaxCount int32 `json:"maxCount,omitempty"`
 
-	// Delete policy for expired backups
+	// Delete policy for expired backups. Only "Delete" is implemented;
+	// "Archive" is RESERVED and currently behaves as a no-op (#220) — no
+	// archival logic exists. Accepted for backward compatibility.
 	// +kubebuilder:validation:Enum=Delete;Archive
 	// +kubebuilder:default=Delete
 	DeletePolicy string `json:"deletePolicy,omitempty"`
@@ -148,7 +150,11 @@ type BackupOptions struct {
 	// +kubebuilder:default=true
 	Compress *bool `json:"compress,omitempty"`
 
-	// Verify backup integrity after creation
+	// Verify is RESERVED and currently a no-op (#220) — it is accepted for
+	// backward compatibility but the operator does not read it. For real
+	// artifact verification use options.validate, which runs
+	// `neo4j-admin backup validate` and records the result in
+	// status.history[].validation.
 	Verify bool `json:"verify,omitempty"`
 
 	// Backup type

--- a/api/v1beta1/neo4jenterprisecluster_types.go
+++ b/api/v1beta1/neo4jenterprisecluster_types.go
@@ -783,12 +783,17 @@ type CloudBlock struct {
 	ForcePathStyle bool `json:"forcePathStyle,omitempty"`
 }
 
-// CloudIdentity defines cloud identity configuration
+// CloudIdentity defines cloud identity (IRSA / Workload Identity / Managed
+// Identity) configuration for backup/restore Job pods.
 type CloudIdentity struct {
 	// +kubebuilder:validation:Enum=aws;gcp;azure
 	// +kubebuilder:validation:Required
 	Provider string `json:"provider"`
 
+	// ServiceAccount is RESERVED and currently a no-op (#220): backup Jobs
+	// always run as the operator-managed "neo4j-backup-sa" (restore Jobs:
+	// "neo4j-restore-sa"). Bind your cloud IAM role via
+	// autoCreate.annotations, which the operator applies to that SA.
 	ServiceAccount string `json:"serviceAccount,omitempty"`
 
 	AutoCreate *AutoCreateSpec `json:"autoCreate,omitempty"`
@@ -796,6 +801,10 @@ type CloudIdentity struct {
 
 // AutoCreateSpec defines auto-creation of service accounts
 type AutoCreateSpec struct {
+	// Enabled is RESERVED and currently a no-op (#220): the operator always
+	// ensures the backup/restore ServiceAccount exists. Only Annotations is
+	// honored — use it for IRSA ("eks.amazonaws.com/role-arn") or Workload
+	// Identity ("iam.gke.io/gcp-service-account") bindings.
 	// +kubebuilder:default=true
 	Enabled bool `json:"enabled,omitempty"`
 

--- a/api/v1beta1/neo4jrestore_types.go
+++ b/api/v1beta1/neo4jrestore_types.go
@@ -48,7 +48,10 @@ type Neo4jRestoreSpec struct {
 	// Stop cluster before restore (required for some restore operations)
 	StopCluster bool `json:"stopCluster,omitempty"`
 
-	// Timeout for restore operation
+	// Timeout bounds the cluster Cypher restore's online-convergence wait
+	// (Go duration, e.g. "30m"). Defaults to 5m when unset — increase for
+	// large stores seeded from object storage. The standalone Job path is
+	// bounded by the Job's own backoff/active-deadline semantics instead.
 	Timeout string `json:"timeout,omitempty"`
 }
 
@@ -117,7 +120,9 @@ type RestoreOptionsSpec struct {
 	// Replace existing database
 	ReplaceExisting bool `json:"replaceExisting,omitempty"`
 
-	// Verify backup before restore
+	// VerifyBackup is RESERVED and currently a no-op (#220) — accepted for
+	// backward compatibility but not read by the operator. Verify artifacts
+	// at backup time via Neo4jBackup.spec.options.validate instead.
 	VerifyBackup bool `json:"verifyBackup,omitempty"`
 
 	// Additional neo4j-admin restore arguments

--- a/bundle/manifests/neo4j.neo4j.com_neo4jbackups.yaml
+++ b/bundle/manifests/neo4j.neo4j.com_neo4jbackups.yaml
@@ -114,7 +114,9 @@ spec:
                       Only effective when EndpointURL is set.
                     type: boolean
                   identity:
-                    description: CloudIdentity defines cloud identity configuration
+                    description: |-
+                      CloudIdentity defines cloud identity (IRSA / Workload Identity / Managed
+                      Identity) configuration for backup/restore Job pods.
                     properties:
                       autoCreate:
                         description: AutoCreateSpec defines auto-creation of service
@@ -126,6 +128,11 @@ spec:
                             type: object
                           enabled:
                             default: true
+                            description: |-
+                              Enabled is RESERVED and currently a no-op (#220): the operator always
+                              ensures the backup/restore ServiceAccount exists. Only Annotations is
+                              honored — use it for IRSA ("eks.amazonaws.com/role-arn") or Workload
+                              Identity ("iam.gke.io/gcp-service-account") bindings.
                             type: boolean
                         type: object
                       provider:
@@ -135,6 +142,11 @@ spec:
                         - azure
                         type: string
                       serviceAccount:
+                        description: |-
+                          ServiceAccount is RESERVED and currently a no-op (#220): backup Jobs
+                          always run as the operator-managed "neo4j-backup-sa" (restore Jobs:
+                          "neo4j-restore-sa"). Bind your cloud IAM role via
+                          autoCreate.annotations, which the operator applies to that SA.
                         type: string
                     required:
                     - provider
@@ -327,7 +339,12 @@ spec:
                       parses validate's stdout into BackupRun.Validation.
                     type: boolean
                   verify:
-                    description: Verify backup integrity after creation
+                    description: |-
+                      Verify is RESERVED and currently a no-op (#220) — it is accepted for
+                      backward compatibility but the operator does not read it. For real
+                      artifact verification use options.validate, which runs
+                      `neo4j-admin backup validate` and records the result in
+                      status.history[].validation.
                     type: boolean
                 type: object
               retention:
@@ -335,7 +352,10 @@ spec:
                 properties:
                   deletePolicy:
                     default: Delete
-                    description: Delete policy for expired backups
+                    description: |-
+                      Delete policy for expired backups. Only "Delete" is implemented;
+                      "Archive" is RESERVED and currently behaves as a no-op (#220) — no
+                      archival logic exists. Accepted for backward compatibility.
                     enum:
                     - Delete
                     - Archive
@@ -384,7 +404,9 @@ spec:
                           Only effective when EndpointURL is set.
                         type: boolean
                       identity:
-                        description: CloudIdentity defines cloud identity configuration
+                        description: |-
+                          CloudIdentity defines cloud identity (IRSA / Workload Identity / Managed
+                          Identity) configuration for backup/restore Job pods.
                         properties:
                           autoCreate:
                             description: AutoCreateSpec defines auto-creation of service
@@ -396,6 +418,11 @@ spec:
                                 type: object
                               enabled:
                                 default: true
+                                description: |-
+                                  Enabled is RESERVED and currently a no-op (#220): the operator always
+                                  ensures the backup/restore ServiceAccount exists. Only Annotations is
+                                  honored — use it for IRSA ("eks.amazonaws.com/role-arn") or Workload
+                                  Identity ("iam.gke.io/gcp-service-account") bindings.
                                 type: boolean
                             type: object
                           provider:
@@ -405,6 +432,11 @@ spec:
                             - azure
                             type: string
                           serviceAccount:
+                            description: |-
+                              ServiceAccount is RESERVED and currently a no-op (#220): backup Jobs
+                              always run as the operator-managed "neo4j-backup-sa" (restore Jobs:
+                              "neo4j-restore-sa"). Bind your cloud IAM role via
+                              autoCreate.annotations, which the operator applies to that SA.
                             type: string
                         required:
                         - provider

--- a/bundle/manifests/neo4j.neo4j.com_neo4jdatabases.yaml
+++ b/bundle/manifests/neo4j.neo4j.com_neo4jdatabases.yaml
@@ -132,7 +132,9 @@ spec:
                               Only effective when EndpointURL is set.
                             type: boolean
                           identity:
-                            description: CloudIdentity defines cloud identity configuration
+                            description: |-
+                              CloudIdentity defines cloud identity (IRSA / Workload Identity / Managed
+                              Identity) configuration for backup/restore Job pods.
                             properties:
                               autoCreate:
                                 description: AutoCreateSpec defines auto-creation
@@ -144,6 +146,11 @@ spec:
                                     type: object
                                   enabled:
                                     default: true
+                                    description: |-
+                                      Enabled is RESERVED and currently a no-op (#220): the operator always
+                                      ensures the backup/restore ServiceAccount exists. Only Annotations is
+                                      honored — use it for IRSA ("eks.amazonaws.com/role-arn") or Workload
+                                      Identity ("iam.gke.io/gcp-service-account") bindings.
                                     type: boolean
                                 type: object
                               provider:
@@ -153,6 +160,11 @@ spec:
                                 - azure
                                 type: string
                               serviceAccount:
+                                description: |-
+                                  ServiceAccount is RESERVED and currently a no-op (#220): backup Jobs
+                                  always run as the operator-managed "neo4j-backup-sa" (restore Jobs:
+                                  "neo4j-restore-sa"). Bind your cloud IAM role via
+                                  autoCreate.annotations, which the operator applies to that SA.
                                 type: string
                             required:
                             - provider

--- a/bundle/manifests/neo4j.neo4j.com_neo4jrestores.yaml
+++ b/bundle/manifests/neo4j.neo4j.com_neo4jrestores.yaml
@@ -606,7 +606,10 @@ spec:
                     - size
                     type: object
                   verifyBackup:
-                    description: Verify backup before restore
+                    description: |-
+                      VerifyBackup is RESERVED and currently a no-op (#220) — accepted for
+                      backward compatibility but not read by the operator. Verify artifacts
+                      at backup time via Neo4jBackup.spec.options.validate instead.
                     type: boolean
                 type: object
               source:
@@ -664,8 +667,9 @@ spec:
                                       Only effective when EndpointURL is set.
                                     type: boolean
                                   identity:
-                                    description: CloudIdentity defines cloud identity
-                                      configuration
+                                    description: |-
+                                      CloudIdentity defines cloud identity (IRSA / Workload Identity / Managed
+                                      Identity) configuration for backup/restore Job pods.
                                     properties:
                                       autoCreate:
                                         description: AutoCreateSpec defines auto-creation
@@ -677,6 +681,11 @@ spec:
                                             type: object
                                           enabled:
                                             default: true
+                                            description: |-
+                                              Enabled is RESERVED and currently a no-op (#220): the operator always
+                                              ensures the backup/restore ServiceAccount exists. Only Annotations is
+                                              honored — use it for IRSA ("eks.amazonaws.com/role-arn") or Workload
+                                              Identity ("iam.gke.io/gcp-service-account") bindings.
                                             type: boolean
                                         type: object
                                       provider:
@@ -686,6 +695,11 @@ spec:
                                         - azure
                                         type: string
                                       serviceAccount:
+                                        description: |-
+                                          ServiceAccount is RESERVED and currently a no-op (#220): backup Jobs
+                                          always run as the operator-managed "neo4j-backup-sa" (restore Jobs:
+                                          "neo4j-restore-sa"). Bind your cloud IAM role via
+                                          autoCreate.annotations, which the operator applies to that SA.
                                         type: string
                                     required:
                                     - provider
@@ -764,8 +778,9 @@ spec:
                                   Only effective when EndpointURL is set.
                                 type: boolean
                               identity:
-                                description: CloudIdentity defines cloud identity
-                                  configuration
+                                description: |-
+                                  CloudIdentity defines cloud identity (IRSA / Workload Identity / Managed
+                                  Identity) configuration for backup/restore Job pods.
                                 properties:
                                   autoCreate:
                                     description: AutoCreateSpec defines auto-creation
@@ -777,6 +792,11 @@ spec:
                                         type: object
                                       enabled:
                                         default: true
+                                        description: |-
+                                          Enabled is RESERVED and currently a no-op (#220): the operator always
+                                          ensures the backup/restore ServiceAccount exists. Only Annotations is
+                                          honored — use it for IRSA ("eks.amazonaws.com/role-arn") or Workload
+                                          Identity ("iam.gke.io/gcp-service-account") bindings.
                                         type: boolean
                                     type: object
                                   provider:
@@ -786,6 +806,11 @@ spec:
                                     - azure
                                     type: string
                                   serviceAccount:
+                                    description: |-
+                                      ServiceAccount is RESERVED and currently a no-op (#220): backup Jobs
+                                      always run as the operator-managed "neo4j-backup-sa" (restore Jobs:
+                                      "neo4j-restore-sa"). Bind your cloud IAM role via
+                                      autoCreate.annotations, which the operator applies to that SA.
                                     type: string
                                 required:
                                 - provider
@@ -860,7 +885,9 @@ spec:
                               Only effective when EndpointURL is set.
                             type: boolean
                           identity:
-                            description: CloudIdentity defines cloud identity configuration
+                            description: |-
+                              CloudIdentity defines cloud identity (IRSA / Workload Identity / Managed
+                              Identity) configuration for backup/restore Job pods.
                             properties:
                               autoCreate:
                                 description: AutoCreateSpec defines auto-creation
@@ -872,6 +899,11 @@ spec:
                                     type: object
                                   enabled:
                                     default: true
+                                    description: |-
+                                      Enabled is RESERVED and currently a no-op (#220): the operator always
+                                      ensures the backup/restore ServiceAccount exists. Only Annotations is
+                                      honored — use it for IRSA ("eks.amazonaws.com/role-arn") or Workload
+                                      Identity ("iam.gke.io/gcp-service-account") bindings.
                                     type: boolean
                                 type: object
                               provider:
@@ -881,6 +913,11 @@ spec:
                                 - azure
                                 type: string
                               serviceAccount:
+                                description: |-
+                                  ServiceAccount is RESERVED and currently a no-op (#220): backup Jobs
+                                  always run as the operator-managed "neo4j-backup-sa" (restore Jobs:
+                                  "neo4j-restore-sa"). Bind your cloud IAM role via
+                                  autoCreate.annotations, which the operator applies to that SA.
                                 type: string
                             required:
                             - provider
@@ -931,7 +968,11 @@ spec:
                   operations)
                 type: boolean
               timeout:
-                description: Timeout for restore operation
+                description: |-
+                  Timeout bounds the cluster Cypher restore's online-convergence wait
+                  (Go duration, e.g. "30m"). Defaults to 5m when unset — increase for
+                  large stores seeded from object storage. The standalone Job path is
+                  bounded by the Job's own backoff/active-deadline semantics instead.
                 type: string
             required:
             - clusterRef
@@ -1101,7 +1142,9 @@ spec:
                               Only effective when EndpointURL is set.
                             type: boolean
                           identity:
-                            description: CloudIdentity defines cloud identity configuration
+                            description: |-
+                              CloudIdentity defines cloud identity (IRSA / Workload Identity / Managed
+                              Identity) configuration for backup/restore Job pods.
                             properties:
                               autoCreate:
                                 description: AutoCreateSpec defines auto-creation
@@ -1113,6 +1156,11 @@ spec:
                                     type: object
                                   enabled:
                                     default: true
+                                    description: |-
+                                      Enabled is RESERVED and currently a no-op (#220): the operator always
+                                      ensures the backup/restore ServiceAccount exists. Only Annotations is
+                                      honored — use it for IRSA ("eks.amazonaws.com/role-arn") or Workload
+                                      Identity ("iam.gke.io/gcp-service-account") bindings.
                                     type: boolean
                                 type: object
                               provider:
@@ -1122,6 +1170,11 @@ spec:
                                 - azure
                                 type: string
                               serviceAccount:
+                                description: |-
+                                  ServiceAccount is RESERVED and currently a no-op (#220): backup Jobs
+                                  always run as the operator-managed "neo4j-backup-sa" (restore Jobs:
+                                  "neo4j-restore-sa"). Bind your cloud IAM role via
+                                  autoCreate.annotations, which the operator applies to that SA.
                                 type: string
                             required:
                             - provider

--- a/charts/neo4j-operator/crds/neo4j.neo4j.com_neo4jbackups.yaml
+++ b/charts/neo4j-operator/crds/neo4j.neo4j.com_neo4jbackups.yaml
@@ -114,7 +114,9 @@ spec:
                       Only effective when EndpointURL is set.
                     type: boolean
                   identity:
-                    description: CloudIdentity defines cloud identity configuration
+                    description: |-
+                      CloudIdentity defines cloud identity (IRSA / Workload Identity / Managed
+                      Identity) configuration for backup/restore Job pods.
                     properties:
                       autoCreate:
                         description: AutoCreateSpec defines auto-creation of service
@@ -126,6 +128,11 @@ spec:
                             type: object
                           enabled:
                             default: true
+                            description: |-
+                              Enabled is RESERVED and currently a no-op (#220): the operator always
+                              ensures the backup/restore ServiceAccount exists. Only Annotations is
+                              honored — use it for IRSA ("eks.amazonaws.com/role-arn") or Workload
+                              Identity ("iam.gke.io/gcp-service-account") bindings.
                             type: boolean
                         type: object
                       provider:
@@ -135,6 +142,11 @@ spec:
                         - azure
                         type: string
                       serviceAccount:
+                        description: |-
+                          ServiceAccount is RESERVED and currently a no-op (#220): backup Jobs
+                          always run as the operator-managed "neo4j-backup-sa" (restore Jobs:
+                          "neo4j-restore-sa"). Bind your cloud IAM role via
+                          autoCreate.annotations, which the operator applies to that SA.
                         type: string
                     required:
                     - provider
@@ -327,7 +339,12 @@ spec:
                       parses validate's stdout into BackupRun.Validation.
                     type: boolean
                   verify:
-                    description: Verify backup integrity after creation
+                    description: |-
+                      Verify is RESERVED and currently a no-op (#220) — it is accepted for
+                      backward compatibility but the operator does not read it. For real
+                      artifact verification use options.validate, which runs
+                      `neo4j-admin backup validate` and records the result in
+                      status.history[].validation.
                     type: boolean
                 type: object
               retention:
@@ -335,7 +352,10 @@ spec:
                 properties:
                   deletePolicy:
                     default: Delete
-                    description: Delete policy for expired backups
+                    description: |-
+                      Delete policy for expired backups. Only "Delete" is implemented;
+                      "Archive" is RESERVED and currently behaves as a no-op (#220) — no
+                      archival logic exists. Accepted for backward compatibility.
                     enum:
                     - Delete
                     - Archive
@@ -384,7 +404,9 @@ spec:
                           Only effective when EndpointURL is set.
                         type: boolean
                       identity:
-                        description: CloudIdentity defines cloud identity configuration
+                        description: |-
+                          CloudIdentity defines cloud identity (IRSA / Workload Identity / Managed
+                          Identity) configuration for backup/restore Job pods.
                         properties:
                           autoCreate:
                             description: AutoCreateSpec defines auto-creation of service
@@ -396,6 +418,11 @@ spec:
                                 type: object
                               enabled:
                                 default: true
+                                description: |-
+                                  Enabled is RESERVED and currently a no-op (#220): the operator always
+                                  ensures the backup/restore ServiceAccount exists. Only Annotations is
+                                  honored — use it for IRSA ("eks.amazonaws.com/role-arn") or Workload
+                                  Identity ("iam.gke.io/gcp-service-account") bindings.
                                 type: boolean
                             type: object
                           provider:
@@ -405,6 +432,11 @@ spec:
                             - azure
                             type: string
                           serviceAccount:
+                            description: |-
+                              ServiceAccount is RESERVED and currently a no-op (#220): backup Jobs
+                              always run as the operator-managed "neo4j-backup-sa" (restore Jobs:
+                              "neo4j-restore-sa"). Bind your cloud IAM role via
+                              autoCreate.annotations, which the operator applies to that SA.
                             type: string
                         required:
                         - provider

--- a/charts/neo4j-operator/crds/neo4j.neo4j.com_neo4jdatabases.yaml
+++ b/charts/neo4j-operator/crds/neo4j.neo4j.com_neo4jdatabases.yaml
@@ -132,7 +132,9 @@ spec:
                               Only effective when EndpointURL is set.
                             type: boolean
                           identity:
-                            description: CloudIdentity defines cloud identity configuration
+                            description: |-
+                              CloudIdentity defines cloud identity (IRSA / Workload Identity / Managed
+                              Identity) configuration for backup/restore Job pods.
                             properties:
                               autoCreate:
                                 description: AutoCreateSpec defines auto-creation
@@ -144,6 +146,11 @@ spec:
                                     type: object
                                   enabled:
                                     default: true
+                                    description: |-
+                                      Enabled is RESERVED and currently a no-op (#220): the operator always
+                                      ensures the backup/restore ServiceAccount exists. Only Annotations is
+                                      honored — use it for IRSA ("eks.amazonaws.com/role-arn") or Workload
+                                      Identity ("iam.gke.io/gcp-service-account") bindings.
                                     type: boolean
                                 type: object
                               provider:
@@ -153,6 +160,11 @@ spec:
                                 - azure
                                 type: string
                               serviceAccount:
+                                description: |-
+                                  ServiceAccount is RESERVED and currently a no-op (#220): backup Jobs
+                                  always run as the operator-managed "neo4j-backup-sa" (restore Jobs:
+                                  "neo4j-restore-sa"). Bind your cloud IAM role via
+                                  autoCreate.annotations, which the operator applies to that SA.
                                 type: string
                             required:
                             - provider

--- a/charts/neo4j-operator/crds/neo4j.neo4j.com_neo4jrestores.yaml
+++ b/charts/neo4j-operator/crds/neo4j.neo4j.com_neo4jrestores.yaml
@@ -606,7 +606,10 @@ spec:
                     - size
                     type: object
                   verifyBackup:
-                    description: Verify backup before restore
+                    description: |-
+                      VerifyBackup is RESERVED and currently a no-op (#220) — accepted for
+                      backward compatibility but not read by the operator. Verify artifacts
+                      at backup time via Neo4jBackup.spec.options.validate instead.
                     type: boolean
                 type: object
               source:
@@ -664,8 +667,9 @@ spec:
                                       Only effective when EndpointURL is set.
                                     type: boolean
                                   identity:
-                                    description: CloudIdentity defines cloud identity
-                                      configuration
+                                    description: |-
+                                      CloudIdentity defines cloud identity (IRSA / Workload Identity / Managed
+                                      Identity) configuration for backup/restore Job pods.
                                     properties:
                                       autoCreate:
                                         description: AutoCreateSpec defines auto-creation
@@ -677,6 +681,11 @@ spec:
                                             type: object
                                           enabled:
                                             default: true
+                                            description: |-
+                                              Enabled is RESERVED and currently a no-op (#220): the operator always
+                                              ensures the backup/restore ServiceAccount exists. Only Annotations is
+                                              honored — use it for IRSA ("eks.amazonaws.com/role-arn") or Workload
+                                              Identity ("iam.gke.io/gcp-service-account") bindings.
                                             type: boolean
                                         type: object
                                       provider:
@@ -686,6 +695,11 @@ spec:
                                         - azure
                                         type: string
                                       serviceAccount:
+                                        description: |-
+                                          ServiceAccount is RESERVED and currently a no-op (#220): backup Jobs
+                                          always run as the operator-managed "neo4j-backup-sa" (restore Jobs:
+                                          "neo4j-restore-sa"). Bind your cloud IAM role via
+                                          autoCreate.annotations, which the operator applies to that SA.
                                         type: string
                                     required:
                                     - provider
@@ -764,8 +778,9 @@ spec:
                                   Only effective when EndpointURL is set.
                                 type: boolean
                               identity:
-                                description: CloudIdentity defines cloud identity
-                                  configuration
+                                description: |-
+                                  CloudIdentity defines cloud identity (IRSA / Workload Identity / Managed
+                                  Identity) configuration for backup/restore Job pods.
                                 properties:
                                   autoCreate:
                                     description: AutoCreateSpec defines auto-creation
@@ -777,6 +792,11 @@ spec:
                                         type: object
                                       enabled:
                                         default: true
+                                        description: |-
+                                          Enabled is RESERVED and currently a no-op (#220): the operator always
+                                          ensures the backup/restore ServiceAccount exists. Only Annotations is
+                                          honored — use it for IRSA ("eks.amazonaws.com/role-arn") or Workload
+                                          Identity ("iam.gke.io/gcp-service-account") bindings.
                                         type: boolean
                                     type: object
                                   provider:
@@ -786,6 +806,11 @@ spec:
                                     - azure
                                     type: string
                                   serviceAccount:
+                                    description: |-
+                                      ServiceAccount is RESERVED and currently a no-op (#220): backup Jobs
+                                      always run as the operator-managed "neo4j-backup-sa" (restore Jobs:
+                                      "neo4j-restore-sa"). Bind your cloud IAM role via
+                                      autoCreate.annotations, which the operator applies to that SA.
                                     type: string
                                 required:
                                 - provider
@@ -860,7 +885,9 @@ spec:
                               Only effective when EndpointURL is set.
                             type: boolean
                           identity:
-                            description: CloudIdentity defines cloud identity configuration
+                            description: |-
+                              CloudIdentity defines cloud identity (IRSA / Workload Identity / Managed
+                              Identity) configuration for backup/restore Job pods.
                             properties:
                               autoCreate:
                                 description: AutoCreateSpec defines auto-creation
@@ -872,6 +899,11 @@ spec:
                                     type: object
                                   enabled:
                                     default: true
+                                    description: |-
+                                      Enabled is RESERVED and currently a no-op (#220): the operator always
+                                      ensures the backup/restore ServiceAccount exists. Only Annotations is
+                                      honored — use it for IRSA ("eks.amazonaws.com/role-arn") or Workload
+                                      Identity ("iam.gke.io/gcp-service-account") bindings.
                                     type: boolean
                                 type: object
                               provider:
@@ -881,6 +913,11 @@ spec:
                                 - azure
                                 type: string
                               serviceAccount:
+                                description: |-
+                                  ServiceAccount is RESERVED and currently a no-op (#220): backup Jobs
+                                  always run as the operator-managed "neo4j-backup-sa" (restore Jobs:
+                                  "neo4j-restore-sa"). Bind your cloud IAM role via
+                                  autoCreate.annotations, which the operator applies to that SA.
                                 type: string
                             required:
                             - provider
@@ -931,7 +968,11 @@ spec:
                   operations)
                 type: boolean
               timeout:
-                description: Timeout for restore operation
+                description: |-
+                  Timeout bounds the cluster Cypher restore's online-convergence wait
+                  (Go duration, e.g. "30m"). Defaults to 5m when unset — increase for
+                  large stores seeded from object storage. The standalone Job path is
+                  bounded by the Job's own backoff/active-deadline semantics instead.
                 type: string
             required:
             - clusterRef
@@ -1101,7 +1142,9 @@ spec:
                               Only effective when EndpointURL is set.
                             type: boolean
                           identity:
-                            description: CloudIdentity defines cloud identity configuration
+                            description: |-
+                              CloudIdentity defines cloud identity (IRSA / Workload Identity / Managed
+                              Identity) configuration for backup/restore Job pods.
                             properties:
                               autoCreate:
                                 description: AutoCreateSpec defines auto-creation
@@ -1113,6 +1156,11 @@ spec:
                                     type: object
                                   enabled:
                                     default: true
+                                    description: |-
+                                      Enabled is RESERVED and currently a no-op (#220): the operator always
+                                      ensures the backup/restore ServiceAccount exists. Only Annotations is
+                                      honored — use it for IRSA ("eks.amazonaws.com/role-arn") or Workload
+                                      Identity ("iam.gke.io/gcp-service-account") bindings.
                                     type: boolean
                                 type: object
                               provider:
@@ -1122,6 +1170,11 @@ spec:
                                 - azure
                                 type: string
                               serviceAccount:
+                                description: |-
+                                  ServiceAccount is RESERVED and currently a no-op (#220): backup Jobs
+                                  always run as the operator-managed "neo4j-backup-sa" (restore Jobs:
+                                  "neo4j-restore-sa"). Bind your cloud IAM role via
+                                  autoCreate.annotations, which the operator applies to that SA.
                                 type: string
                             required:
                             - provider

--- a/config/crd/bases/neo4j.neo4j.com_neo4jbackups.yaml
+++ b/config/crd/bases/neo4j.neo4j.com_neo4jbackups.yaml
@@ -114,7 +114,9 @@ spec:
                       Only effective when EndpointURL is set.
                     type: boolean
                   identity:
-                    description: CloudIdentity defines cloud identity configuration
+                    description: |-
+                      CloudIdentity defines cloud identity (IRSA / Workload Identity / Managed
+                      Identity) configuration for backup/restore Job pods.
                     properties:
                       autoCreate:
                         description: AutoCreateSpec defines auto-creation of service
@@ -126,6 +128,11 @@ spec:
                             type: object
                           enabled:
                             default: true
+                            description: |-
+                              Enabled is RESERVED and currently a no-op (#220): the operator always
+                              ensures the backup/restore ServiceAccount exists. Only Annotations is
+                              honored — use it for IRSA ("eks.amazonaws.com/role-arn") or Workload
+                              Identity ("iam.gke.io/gcp-service-account") bindings.
                             type: boolean
                         type: object
                       provider:
@@ -135,6 +142,11 @@ spec:
                         - azure
                         type: string
                       serviceAccount:
+                        description: |-
+                          ServiceAccount is RESERVED and currently a no-op (#220): backup Jobs
+                          always run as the operator-managed "neo4j-backup-sa" (restore Jobs:
+                          "neo4j-restore-sa"). Bind your cloud IAM role via
+                          autoCreate.annotations, which the operator applies to that SA.
                         type: string
                     required:
                     - provider
@@ -327,7 +339,12 @@ spec:
                       parses validate's stdout into BackupRun.Validation.
                     type: boolean
                   verify:
-                    description: Verify backup integrity after creation
+                    description: |-
+                      Verify is RESERVED and currently a no-op (#220) — it is accepted for
+                      backward compatibility but the operator does not read it. For real
+                      artifact verification use options.validate, which runs
+                      `neo4j-admin backup validate` and records the result in
+                      status.history[].validation.
                     type: boolean
                 type: object
               retention:
@@ -335,7 +352,10 @@ spec:
                 properties:
                   deletePolicy:
                     default: Delete
-                    description: Delete policy for expired backups
+                    description: |-
+                      Delete policy for expired backups. Only "Delete" is implemented;
+                      "Archive" is RESERVED and currently behaves as a no-op (#220) — no
+                      archival logic exists. Accepted for backward compatibility.
                     enum:
                     - Delete
                     - Archive
@@ -384,7 +404,9 @@ spec:
                           Only effective when EndpointURL is set.
                         type: boolean
                       identity:
-                        description: CloudIdentity defines cloud identity configuration
+                        description: |-
+                          CloudIdentity defines cloud identity (IRSA / Workload Identity / Managed
+                          Identity) configuration for backup/restore Job pods.
                         properties:
                           autoCreate:
                             description: AutoCreateSpec defines auto-creation of service
@@ -396,6 +418,11 @@ spec:
                                 type: object
                               enabled:
                                 default: true
+                                description: |-
+                                  Enabled is RESERVED and currently a no-op (#220): the operator always
+                                  ensures the backup/restore ServiceAccount exists. Only Annotations is
+                                  honored — use it for IRSA ("eks.amazonaws.com/role-arn") or Workload
+                                  Identity ("iam.gke.io/gcp-service-account") bindings.
                                 type: boolean
                             type: object
                           provider:
@@ -405,6 +432,11 @@ spec:
                             - azure
                             type: string
                           serviceAccount:
+                            description: |-
+                              ServiceAccount is RESERVED and currently a no-op (#220): backup Jobs
+                              always run as the operator-managed "neo4j-backup-sa" (restore Jobs:
+                              "neo4j-restore-sa"). Bind your cloud IAM role via
+                              autoCreate.annotations, which the operator applies to that SA.
                             type: string
                         required:
                         - provider

--- a/config/crd/bases/neo4j.neo4j.com_neo4jdatabases.yaml
+++ b/config/crd/bases/neo4j.neo4j.com_neo4jdatabases.yaml
@@ -132,7 +132,9 @@ spec:
                               Only effective when EndpointURL is set.
                             type: boolean
                           identity:
-                            description: CloudIdentity defines cloud identity configuration
+                            description: |-
+                              CloudIdentity defines cloud identity (IRSA / Workload Identity / Managed
+                              Identity) configuration for backup/restore Job pods.
                             properties:
                               autoCreate:
                                 description: AutoCreateSpec defines auto-creation
@@ -144,6 +146,11 @@ spec:
                                     type: object
                                   enabled:
                                     default: true
+                                    description: |-
+                                      Enabled is RESERVED and currently a no-op (#220): the operator always
+                                      ensures the backup/restore ServiceAccount exists. Only Annotations is
+                                      honored — use it for IRSA ("eks.amazonaws.com/role-arn") or Workload
+                                      Identity ("iam.gke.io/gcp-service-account") bindings.
                                     type: boolean
                                 type: object
                               provider:
@@ -153,6 +160,11 @@ spec:
                                 - azure
                                 type: string
                               serviceAccount:
+                                description: |-
+                                  ServiceAccount is RESERVED and currently a no-op (#220): backup Jobs
+                                  always run as the operator-managed "neo4j-backup-sa" (restore Jobs:
+                                  "neo4j-restore-sa"). Bind your cloud IAM role via
+                                  autoCreate.annotations, which the operator applies to that SA.
                                 type: string
                             required:
                             - provider

--- a/config/crd/bases/neo4j.neo4j.com_neo4jrestores.yaml
+++ b/config/crd/bases/neo4j.neo4j.com_neo4jrestores.yaml
@@ -606,7 +606,10 @@ spec:
                     - size
                     type: object
                   verifyBackup:
-                    description: Verify backup before restore
+                    description: |-
+                      VerifyBackup is RESERVED and currently a no-op (#220) — accepted for
+                      backward compatibility but not read by the operator. Verify artifacts
+                      at backup time via Neo4jBackup.spec.options.validate instead.
                     type: boolean
                 type: object
               source:
@@ -664,8 +667,9 @@ spec:
                                       Only effective when EndpointURL is set.
                                     type: boolean
                                   identity:
-                                    description: CloudIdentity defines cloud identity
-                                      configuration
+                                    description: |-
+                                      CloudIdentity defines cloud identity (IRSA / Workload Identity / Managed
+                                      Identity) configuration for backup/restore Job pods.
                                     properties:
                                       autoCreate:
                                         description: AutoCreateSpec defines auto-creation
@@ -677,6 +681,11 @@ spec:
                                             type: object
                                           enabled:
                                             default: true
+                                            description: |-
+                                              Enabled is RESERVED and currently a no-op (#220): the operator always
+                                              ensures the backup/restore ServiceAccount exists. Only Annotations is
+                                              honored — use it for IRSA ("eks.amazonaws.com/role-arn") or Workload
+                                              Identity ("iam.gke.io/gcp-service-account") bindings.
                                             type: boolean
                                         type: object
                                       provider:
@@ -686,6 +695,11 @@ spec:
                                         - azure
                                         type: string
                                       serviceAccount:
+                                        description: |-
+                                          ServiceAccount is RESERVED and currently a no-op (#220): backup Jobs
+                                          always run as the operator-managed "neo4j-backup-sa" (restore Jobs:
+                                          "neo4j-restore-sa"). Bind your cloud IAM role via
+                                          autoCreate.annotations, which the operator applies to that SA.
                                         type: string
                                     required:
                                     - provider
@@ -764,8 +778,9 @@ spec:
                                   Only effective when EndpointURL is set.
                                 type: boolean
                               identity:
-                                description: CloudIdentity defines cloud identity
-                                  configuration
+                                description: |-
+                                  CloudIdentity defines cloud identity (IRSA / Workload Identity / Managed
+                                  Identity) configuration for backup/restore Job pods.
                                 properties:
                                   autoCreate:
                                     description: AutoCreateSpec defines auto-creation
@@ -777,6 +792,11 @@ spec:
                                         type: object
                                       enabled:
                                         default: true
+                                        description: |-
+                                          Enabled is RESERVED and currently a no-op (#220): the operator always
+                                          ensures the backup/restore ServiceAccount exists. Only Annotations is
+                                          honored — use it for IRSA ("eks.amazonaws.com/role-arn") or Workload
+                                          Identity ("iam.gke.io/gcp-service-account") bindings.
                                         type: boolean
                                     type: object
                                   provider:
@@ -786,6 +806,11 @@ spec:
                                     - azure
                                     type: string
                                   serviceAccount:
+                                    description: |-
+                                      ServiceAccount is RESERVED and currently a no-op (#220): backup Jobs
+                                      always run as the operator-managed "neo4j-backup-sa" (restore Jobs:
+                                      "neo4j-restore-sa"). Bind your cloud IAM role via
+                                      autoCreate.annotations, which the operator applies to that SA.
                                     type: string
                                 required:
                                 - provider
@@ -860,7 +885,9 @@ spec:
                               Only effective when EndpointURL is set.
                             type: boolean
                           identity:
-                            description: CloudIdentity defines cloud identity configuration
+                            description: |-
+                              CloudIdentity defines cloud identity (IRSA / Workload Identity / Managed
+                              Identity) configuration for backup/restore Job pods.
                             properties:
                               autoCreate:
                                 description: AutoCreateSpec defines auto-creation
@@ -872,6 +899,11 @@ spec:
                                     type: object
                                   enabled:
                                     default: true
+                                    description: |-
+                                      Enabled is RESERVED and currently a no-op (#220): the operator always
+                                      ensures the backup/restore ServiceAccount exists. Only Annotations is
+                                      honored — use it for IRSA ("eks.amazonaws.com/role-arn") or Workload
+                                      Identity ("iam.gke.io/gcp-service-account") bindings.
                                     type: boolean
                                 type: object
                               provider:
@@ -881,6 +913,11 @@ spec:
                                 - azure
                                 type: string
                               serviceAccount:
+                                description: |-
+                                  ServiceAccount is RESERVED and currently a no-op (#220): backup Jobs
+                                  always run as the operator-managed "neo4j-backup-sa" (restore Jobs:
+                                  "neo4j-restore-sa"). Bind your cloud IAM role via
+                                  autoCreate.annotations, which the operator applies to that SA.
                                 type: string
                             required:
                             - provider
@@ -931,7 +968,11 @@ spec:
                   operations)
                 type: boolean
               timeout:
-                description: Timeout for restore operation
+                description: |-
+                  Timeout bounds the cluster Cypher restore's online-convergence wait
+                  (Go duration, e.g. "30m"). Defaults to 5m when unset — increase for
+                  large stores seeded from object storage. The standalone Job path is
+                  bounded by the Job's own backoff/active-deadline semantics instead.
                 type: string
             required:
             - clusterRef
@@ -1101,7 +1142,9 @@ spec:
                               Only effective when EndpointURL is set.
                             type: boolean
                           identity:
-                            description: CloudIdentity defines cloud identity configuration
+                            description: |-
+                              CloudIdentity defines cloud identity (IRSA / Workload Identity / Managed
+                              Identity) configuration for backup/restore Job pods.
                             properties:
                               autoCreate:
                                 description: AutoCreateSpec defines auto-creation
@@ -1113,6 +1156,11 @@ spec:
                                     type: object
                                   enabled:
                                     default: true
+                                    description: |-
+                                      Enabled is RESERVED and currently a no-op (#220): the operator always
+                                      ensures the backup/restore ServiceAccount exists. Only Annotations is
+                                      honored — use it for IRSA ("eks.amazonaws.com/role-arn") or Workload
+                                      Identity ("iam.gke.io/gcp-service-account") bindings.
                                     type: boolean
                                 type: object
                               provider:
@@ -1122,6 +1170,11 @@ spec:
                                 - azure
                                 type: string
                               serviceAccount:
+                                description: |-
+                                  ServiceAccount is RESERVED and currently a no-op (#220): backup Jobs
+                                  always run as the operator-managed "neo4j-backup-sa" (restore Jobs:
+                                  "neo4j-restore-sa"). Bind your cloud IAM role via
+                                  autoCreate.annotations, which the operator applies to that SA.
                                 type: string
                             required:
                             - provider

--- a/internal/controller/neo4jrestore_controller.go
+++ b/internal/controller/neo4jrestore_controller.go
@@ -786,6 +786,16 @@ func (r *Neo4jRestoreReconciler) validateRestore(ctx context.Context, restore *n
 			restore.Spec.DatabaseName, validation.MaxDatabaseNameLength)
 	}
 
+	// spec.timeout must parse as a positive Go duration — silently falling
+	// back to the default and then telling the user to "increase
+	// spec.timeout" on expiry is misleading when they set a value the
+	// operator ignored (#225 review).
+	if restore.Spec.Timeout != "" {
+		if d, perr := time.ParseDuration(restore.Spec.Timeout); perr != nil || d <= 0 {
+			return fmt.Errorf("spec.timeout %q is not a valid positive Go duration (e.g. \"30m\", \"1h\")", restore.Spec.Timeout)
+		}
+	}
+
 	// spec.source.pointInTime is implemented by the standalone Job path
 	// (--restore-until) for EVERY source type — but the cluster Cypher path
 	// never reads it (#218). Silently returning latest-state when the user
@@ -2724,6 +2734,12 @@ func (r *Neo4jRestoreReconciler) pollClusterRestoreOnline(ctx context.Context, r
 	if restore.Spec.Timeout != "" {
 		if d, perr := time.ParseDuration(restore.Spec.Timeout); perr == nil && d > 0 {
 			budget = d
+		} else {
+			// validateRestore rejects this for new attempts; tolerate (with
+			// the default) for CRs admitted before that validation existed,
+			// but say so instead of silently ignoring the field.
+			logger.Info("Ignoring invalid spec.timeout; using default",
+				"timeout", restore.Spec.Timeout, "default", cypherRestoreOnlineTimeout.String())
 		}
 	}
 	deadline := time.Now().Add(budget)

--- a/internal/controller/neo4jrestore_controller.go
+++ b/internal/controller/neo4jrestore_controller.go
@@ -2717,10 +2717,19 @@ func (r *Neo4jRestoreReconciler) pollClusterRestoreOnline(ctx context.Context, r
 
 	// Derive the deadline from the issue timestamp. A malformed/missing stamp
 	// falls back to "now" so a single extra requeue re-stamps via the wait.
-	deadline := time.Now().Add(cypherRestoreOnlineTimeout)
+	// The budget comes from spec.timeout when set (#220 — the field existed
+	// but was never read; 5 minutes is far too small for multi-GB stores
+	// seeded from object storage), defaulting to cypherRestoreOnlineTimeout.
+	budget := cypherRestoreOnlineTimeout
+	if restore.Spec.Timeout != "" {
+		if d, perr := time.ParseDuration(restore.Spec.Timeout); perr == nil && d > 0 {
+			budget = d
+		}
+	}
+	deadline := time.Now().Add(budget)
 	if raw, ok := restore.Annotations[AnnotationCypherRestoreIssued]; ok {
 		if issuedAt, perr := time.Parse(time.RFC3339, raw); perr == nil {
-			deadline = issuedAt.Add(cypherRestoreOnlineTimeout)
+			deadline = issuedAt.Add(budget)
 		}
 	}
 	expired := time.Now().After(deadline)
@@ -2731,7 +2740,7 @@ func (r *Neo4jRestoreReconciler) pollClusterRestoreOnline(ctx context.Context, r
 		// the deadline, then fail.
 		if expired {
 			r.updateRestoreStatus(ctx, restore, StatusFailed,
-				fmt.Sprintf("Restore did not converge to online within %s: connect failed: %v", cypherRestoreOnlineTimeout, err))
+				fmt.Sprintf("Restore did not converge to online within %s: connect failed: %v", budget, err))
 			return ctrl.Result{}, nil
 		}
 		logger.V(1).Info("Poll: cluster not yet reachable, requeueing", "error", err.Error())
@@ -2756,8 +2765,8 @@ func (r *Neo4jRestoreReconciler) pollClusterRestoreOnline(ctx context.Context, r
 			detail = stateErr.Error()
 		}
 		r.updateRestoreStatus(ctx, restore, StatusFailed,
-			fmt.Sprintf("Restore did not converge to online within %s (%d/%d allocations online); last status: %s",
-				cypherRestoreOnlineTimeout, online, total, detail))
+			fmt.Sprintf("Restore did not converge to online within %s (%d/%d allocations online); last status: %s — increase spec.timeout for large stores",
+				budget, online, total, detail))
 		r.Recorder.Event(restore, corev1.EventTypeWarning, EventReasonRestoreFailed,
 			fmt.Sprintf("Cluster Cypher restore for database %q did not converge online", restore.Spec.DatabaseName))
 		return ctrl.Result{}, nil

--- a/internal/neo4j/client.go
+++ b/internal/neo4j/client.go
@@ -2037,7 +2037,11 @@ func (c *Client) CreateDatabaseWithSeedURIOptions(
 	if ifNotExists {
 		ine = " IF NOT EXISTS"
 	}
-	query := fmt.Sprintf("CREATE DATABASE `%s`%s OPTIONS { seedURI: $uri } WAIT", databaseName, ine)
+	// `existingData: 'use'` is REQUIRED alongside seedURI — without it Neo4j
+	// rejects the statement with "OPTIONS specify 'seedURI' expecting
+	// 'existingData' to be present" (found live on 5.26 during #218
+	// verification; the Neo4jDatabase seed path has carried it since #191).
+	query := fmt.Sprintf("CREATE DATABASE `%s`%s OPTIONS { existingData: 'use', seedURI: $uri } WAIT", databaseName, ine)
 	if _, err := session.Run(ctx, query, map[string]any{"uri": seedURI}); err != nil {
 		return fmt.Errorf("CREATE DATABASE %q OPTIONS{seedURI}: %w", databaseName, err)
 	}


### PR DESCRIPTION
Third of the progressive audit-burndown PRs. **Stacked on #224 (Wave 2)** — base is `fix/backup-restore-wave2`. The #221 docs sweep follows as a separate PR.

## The live-found blocker: `existingData: 'use'`
The cluster restore-to-NEW-database path emitted `CREATE DATABASE … OPTIONS{seedURI}` without `existingData: 'use'`, which Neo4j rejects outright (`OPTIONS specify 'seedURI' expecting 'existingData' to be present`) — **restoring a backup to a new database name on a cluster never worked**. Found during live verification on Kind; the Neo4jDatabase seed path has carried the option since #191. Fixed.

## #220
- `Neo4jRestore.spec.timeout` (existed, never read) now bounds the cluster restore's online-convergence poll (default 5m is far too small for multi-GB seeds); the timeout error message points at the field.
- Dead-but-accepted fields documented as RESERVED no-ops in the CRD descriptions (generated API docs stop promising behavior that doesn't exist): backup `options.verify` (use `options.validate`), restore `options.verifyBackup`, `retention.deletePolicy=Archive`, `cloud.identity.serviceAccount` (SA is operator-managed; bind IAM via `autoCreate.annotations`), `cloud.identity.autoCreate.enabled`. Removal needs a CRD version bump — marking reserved is the honest non-breaking step.

## Live verification (fresh Kind cluster, operator built from this branch — all three restore paths)

| Path | Evidence |
|---|---|
| **PVC standalone round-trip** | Sentinel written → PVC backup Completed (`history[0]` Succeeded, RunID=Job name, artifact captured) → data mutated → restore with force+stopCluster → **sentinel restored, post-backup junk gone** (`sentinels=1, junk=0`). stopCluster re-entry/original-replicas fixes exercised. |
| **MinIO S3 cluster restore** | Backup landed at `s3://neo4j-backups/verify/s3-bk/neo4j-….backup` (verified via `mc ls`; AWS_REGION + endpointURL + forcePathStyle wiring all live). Restore to NEW db `restoredb` via backupRef → `CREATE DATABASE OPTIONS{existingData:'use', seedURI}` — server pods fetched from MinIO via `spec.extraEnvFrom` creds incl. `AWS_ENDPOINT_URL_S3`. **`restoredb` online with the sentinel.** Fresh-attempt retry (Wave 1) exercised live twice via spec bumps; `spec.timeout` exercised. |
| **PVC cluster restore (seed proxy)** | Restore to `restoredb2` via backupRef → proxy Deployment+Service+**NetworkPolicy** spun up, seeded from `http://backup-seed-proxy-….:8080/c1-pvc-bk/….backup`, **sentinel present** — and the entire proxy stack was **torn down on completion** (Wave 2 lifecycle: deployment/svc/netpol all gone post-terminal). |

Full unit suite green; drift gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster restore Cypher and convergence timing for backup/restore paths; behavior fixes are high impact but scoped, with doc-only API surface elsewhere.
> 
> **Overview**
> **Fixes cluster restore to a new database** by adding `existingData: 'use'` to `CREATE DATABASE … OPTIONS { seedURI }` in the Neo4j client — without it Neo4j rejects the Cypher and seeding to a new name on a cluster could not succeed.
> 
> **Wires `Neo4jRestore.spec.timeout`** into the cluster Cypher restore online-convergence poll (still defaults to 5m when unset). Validation now rejects invalid or non-positive durations on new attempts; failure messages tell users to raise `spec.timeout` for large seeds.
> 
> **Clarifies API/CRD docs (#220)** for fields that are accepted but not implemented: backup `options.verify` (use `options.validate`), restore `options.verifyBackup`, retention `deletePolicy=Archive`, and cloud identity `serviceAccount` / `autoCreate.enabled`. Regenerated CRDs in bundle, charts, and `config/crd/bases` match the Go type comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea3a02ab6d6b9210e180c9ec355488d9210297a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->