### PR TITLE
docs(backup/restore): truth sweep — align api_reference, troubleshooting and examples with the code (#221)

### DIFF
--- a/docs/api_reference/neo4jbackup.md
+++ b/docs/api_reference/neo4jbackup.md
@@ -21,7 +21,8 @@ Key implementation details:
 - For cloud storage, `--to-path` uses native cloud URIs: `s3://`, `gs://`, `azb://`.
 - For PVC storage, `--to-path` uses the local path within the mounted PVC.
 - RBAC: Only a `neo4j-backup-sa` ServiceAccount is created. No Role or RoleBinding is created because the backup Job requires no Kubernetes API access.
-- Cloud retention: The operator logs a notice to configure bucket lifecycle rules on the cloud provider side. PVC retention uses `find` + `rm` in a cleanup Job.
+- Retention: cloud storage (S3/GCS/Azure) is pruned by **your bucket's lifecycle rules**, not the operator. For PVC storage, the operator runs a cleanup Job **only when the Neo4jBackup CR is deleted** — see [RetentionPolicy](#retentionpolicy).
+- `target.kind: Cluster` backs up **every database** on the instance in one `neo4j-admin database backup "*"` invocation — one `.backup` artifact per database lands in the chain directory. Restore is per-database: create one `Neo4jRestore` per database you want back (an all-databases restore mode is tracked in [#222](https://github.com/neo4j-partners/neo4j-kubernetes-operator/issues/222)).
 
 ## Spec
 
@@ -31,12 +32,12 @@ The `Neo4jBackupSpec` defines the desired state of a Neo4j backup configuration.
 |-------|------|----------|-------------|
 | `target` | [`BackupTarget`](#backuptarget) | ✅ | What to back up |
 | `storage` | [`StorageLocation`](#storagelocation) | ✅ | Where to store the backup |
-| `schedule` | `string` | ❌ | Cron expression for automated backups (e.g., `"0 2 * * *"`) |
+| `schedule` | `string` | ❌ | Cron expression for automated backups (e.g., `"0 2 * * *"`). Plain 5-field UTC syntax only — `TZ=`/`CRON_TZ=` prefixes are **rejected** (Kubernetes refuses timezone-embedded CronJob schedules). Scheduled backup names are limited to **40 characters** (the generated `<name>-backup-cron` CronJob must fit Kubernetes' 52-char CronJob-name limit). Removing `schedule` from an existing CR **deletes the CronJob** (the CR becomes a one-shot backup). |
 | `cloud` | [`*CloudBlock`](#cloudblock) | ❌ | Top-level cloud provider configuration (used for workload identity) |
 | `retention` | [`*RetentionPolicy`](#retentionpolicy) | ❌ | Backup retention policy |
 | `options` | [`*BackupOptions`](#backupoptions) | ❌ | Backup-specific options |
-| `suspend` | `bool` | ❌ | Suspend the backup schedule without deleting the resource |
-| `chainFromBackup` | `string` | ❌ | Names another `Neo4jBackup` CR in the **same namespace** whose `<base>/<cr-name>/` directory this CR should write into instead of its own. Used to compose mixed-cadence workflows (e.g. a daily `FULL` CR plus an hourly `DIFF` CR that chains off the daily's artifacts). See [Chaining mixed-cadence backups](#chaining-mixed-cadence-backups). |
+| `suspend` | `bool` | ❌ | Suspend backups without deleting the resource. For scheduled backups, the operator propagates this to `CronJob.spec.suspend`, so Kubernetes stops firing scheduled Jobs; setting it back to `false` resumes the schedule. `suspend: true` also pauses one-shot backups that haven't run yet. |
+| `chainFromBackup` | `string` | ❌ | Names another `Neo4jBackup` CR in the **same namespace** whose `<base>/<cr-name>/` directory this CR should write into instead of its own. Used to compose mixed-cadence workflows (e.g. a daily `FULL` CR plus an hourly `DIFF` CR that chains off the daily's artifacts). Must be a DNS-1123 name (validator-enforced). See [Chaining mixed-cadence backups](#chaining-mixed-cadence-backups). |
 
 ## Type Definitions
 
@@ -46,7 +47,7 @@ Defines what to back up. The `kind` field controls how `name` and `clusterRef` a
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `kind` | `string` | ✅ | Type of resource to back up: `"Cluster"`, `"Database"`, or `"ShardedDatabase"` |
+| `kind` | `string` | ✅ | Type of resource to back up: `"Cluster"` (every database on the instance — `neo4j-admin` is invoked with the `"*"` glob, producing one artifact per database), `"Database"` (a single database), or `"ShardedDatabase"` |
 | `name` | `string` | ✅ | When `kind=Cluster`: name of the `Neo4jEnterpriseCluster` or `Neo4jEnterpriseStandalone`. When `kind=Database`: name of the Neo4j database (e.g., `"neo4j"`, `"mydb"`). When `kind=ShardedDatabase`: the logical sharded-database name (e.g. `"products"`); the operator backs up all shards (`products-g000`, `products-p000`, …) in one `neo4j-admin` invocation via a glob. |
 | `clusterRef` | `string` | ✅ when `kind=Database` or `kind=ShardedDatabase` | Name of the `Neo4jEnterpriseCluster` or `Neo4jEnterpriseStandalone` that owns the database. Unused when `kind=Cluster`. |
 | `namespace` | `string` | ❌ | Namespace of the target resource (defaults to the backup namespace) |
@@ -76,8 +77,8 @@ Defines where to store backups.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `type` | `string` | ✅ | Storage type: `"s3"`, `"gcs"`, `"azure"`, `"pvc"` |
-| `bucket` | `string` | ❌ | Bucket or container name (required for cloud storage types) |
-| `path` | `string` | ❌ | Path within the bucket or PVC |
+| `bucket` | `string` | ❌ | Bucket or container name (required for cloud storage types). Restricted to `A-Z a-z 0-9 . _ / -` — the validator rejects other characters (the value is interpolated into the Job's shell command). |
+| `path` | `string` | ❌ | Path within the bucket or PVC. Same `A-Z a-z 0-9 . _ / -` charset restriction as `bucket`. Defaults to `backups` for cloud storage when empty. |
 | `pvc` | [`*PVCSpec`](#pvcspec) | ❌ | PVC configuration (required when `type=pvc`) |
 | `cloud` | [`*CloudBlock`](#cloudblock) | ❌ | Cloud provider configuration including optional credentials secret |
 
@@ -150,16 +151,16 @@ Cloud identity configuration for workload identity scenarios (no static credenti
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `provider` | `string` | ✅ | Identity provider: `"aws"`, `"gcp"`, `"azure"` |
-| `serviceAccount` | `string` | ❌ | Name of an existing ServiceAccount to use. When absent and `autoCreate.enabled=true`, the operator creates `neo4j-backup-sa`. |
-| `autoCreate` | [`*AutoCreateSpec`](#autocreatespec) | ❌ | Auto-create ServiceAccount with workload-identity annotations |
+| `serviceAccount` | `string` | ❌ | **RESERVED — currently a no-op.** Backup Jobs always run as the operator-managed `neo4j-backup-sa` (restore Jobs: `neo4j-restore-sa`); this field is accepted for backward compatibility but not read. Bind your cloud IAM role via `autoCreate.annotations` instead. |
+| `autoCreate` | [`*AutoCreateSpec`](#autocreatespec) | ❌ | Workload-identity annotations for the operator-managed ServiceAccount |
 
 ### AutoCreateSpec
 
-Controls automatic ServiceAccount creation with workload-identity annotations.
+Carries workload-identity annotations for the operator-managed ServiceAccount.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `enabled` | `bool` | ❌ | Enable auto-creation of the `neo4j-backup-sa` ServiceAccount (default: `true`) |
+| `enabled` | `bool` | ❌ | **RESERVED — currently a no-op.** The operator always ensures the backup/restore ServiceAccount exists; only `annotations` is honored. |
 | `annotations` | `map[string]string` | ❌ | Annotations applied to the `neo4j-backup-sa` ServiceAccount on every reconcile. Use this to attach workload-identity annotations. |
 
 The annotations in `autoCreate.annotations` are applied to the `neo4j-backup-sa` ServiceAccount on **every reconcile**, so they stay in sync with the desired state.
@@ -169,19 +170,16 @@ The annotations in `autoCreate.annotations` are applied to the `neo4j-backup-sa`
 ```yaml
 # AWS IRSA
 autoCreate:
-  enabled: true
   annotations:
     eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/neo4j-backup-role
 
 # GKE Workload Identity
 autoCreate:
-  enabled: true
   annotations:
     iam.gke.io/gcp-service-account: neo4j-backup@my-project.iam.gserviceaccount.com
 
 # Azure Workload Identity
 autoCreate:
-  enabled: true
   annotations:
     azure.workload.identity/client-id: 00000000-0000-0000-0000-000000000000
 ```
@@ -202,11 +200,15 @@ Backup retention configuration.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `maxAge` | `string` | ❌ | Maximum age of backups to retain (e.g., `"30d"`, `"4w"`) |
-| `maxCount` | `int32` | ❌ | Maximum number of backups to retain |
-| `deletePolicy` | `string` | ❌ | Action for expired backups: `"Delete"` (default) or `"Archive"` |
+| `maxAge` | `string` | ❌ | Maximum age of artifacts to retain. Accepted units: `d` (days), `h` (hours), `m` (minutes), `s` (seconds) — e.g. `"30d"`, `"168h"`, `"90m"`. `"4w"` is **rejected** by the validator. |
+| `maxCount` | `int32` | ❌ | Maximum number of `.backup` artifacts to retain |
+| `deletePolicy` | `string` | ❌ | `"Delete"` (default). `"Archive"` is **RESERVED — currently a no-op** (no archival logic exists; accepted for backward compatibility). |
 
-> **Cloud storage retention**: For cloud storage targets the operator logs a notice to configure bucket lifecycle rules on the cloud provider side. Automated deletion of cloud objects is not performed by the operator.
+**How retention actually works** (read this before relying on it):
+
+- **Cloud storage (S3/GCS/Azure)**: the operator never deletes cloud objects. Configure **bucket lifecycle rules** on the provider side; `retention` on a cloud-backed CR is advisory only.
+- **PVC storage**: retention is enforced by a cleanup Job that runs **only when the Neo4jBackup CR is deleted** — it is *not* a continuous pruning loop. The Job prunes `*.backup` **files** inside this CR's chain directory (`/backup/<chain-root>/`) only, **oldest-first by file mtime**, and **always keeps the newest artifact** even if it has aged out. Other CRs' chain directories on a shared PVC are never touched.
+- **DIFF-orphaning caveat**: artifact filenames don't encode FULL vs DIFF, so pruning can orphan differential artifacts whose parent FULL ages out (making them unrestorable). The operator emits a `BackupRetentionCaveat` Warning event when retention is configured on a CR that can produce DIFFs. Prefer `options.backupType: FULL` on CRs that use retention, or prune chains with `neo4j-admin backup aggregate`.
 
 ### BackupOptions
 
@@ -215,13 +217,13 @@ Fine-grained backup execution options.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `resources` | [`*corev1.ResourceRequirements`](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) | ❌ | CPU/memory requests + limits on the backup Job's container. When unset, the operator applies a Burstable default (request 100m CPU / 512Mi memory, limit 1 CPU / 2Gi memory) sized for small databases and CI. Tune upward for large production databases. |
-| `compress` | `bool` | ❌ | Compress the backup (default: `true`) |
+| `compress` | `*bool` | ❌ | Compress the backup (default: `true`). Pointer type so an explicit `false` survives updates (a plain bool would silently snap back to the default). |
 | `backupType` | `string` | ❌ | Backup type: `"FULL"`, `"DIFF"`, `"AUTO"` (default) |
 | `preferDiffAsParent` | `bool` | ❌ | Use the latest differential backup as the parent when creating a new differential backup (default: `false`). Maps to `--prefer-diff-as-parent`. **Requires CalVer 2025.04+** — an error is returned at runtime if the target version does not support this flag. |
-| `tempPath` | `string` | ❌ | Local directory path for temporary files during backup. When `tempStorage` is configured, this is set automatically. Only set manually if you are mounting your own volume. Maps to `--temp-path`. |
+| `tempPath` | `string` | ❌ | Local directory path for temporary files during backup. When `tempStorage` is configured, this is set automatically. Only set manually if you are mounting your own volume. Maps to `--temp-path`. Must be an **absolute** path restricted to `A-Z a-z 0-9 . _ / -` (validator-enforced). |
 | `tempStorage` | [`*TempStorageSpec`](#tempstoragespec) | ❌ | Provisions a PVC for temporary staging files during cloud backups. The operator mounts this PVC and passes `--temp-path` automatically. Recommended for large databases to avoid filling ephemeral disk. |
 | `pageCache` | `string` | ❌ | Page cache size hint (e.g., `"4G"`). Must match pattern `^[0-9]+[KMG]?$` |
-| `verify` | `bool` | ❌ | Verify backup integrity after creation |
+| `verify` | `bool` | ❌ | **RESERVED — currently a no-op.** Accepted for backward compatibility but not read by the operator. For real artifact verification use `validate` (below). |
 | `validate` | `*bool` | ❌ | When `true`, runs `neo4j-admin backup validate` against the artifacts **after** the backup succeeds, recording per-shard recoverability into `status.history[].validation`. Appended with `\|\| true` so validate failures don't fail the Job (the backup already succeeded). Pointer type preserves an explicit `true` or `false` across updates; nil (default) skips validate. |
 | `parallelDownload` | `bool` | ❌ | Enable parallel download for remote backups |
 | `remoteAddressResolution` | `*bool` | ❌ | Resolve remote addresses via the cluster discovery service (useful in multi-homed environments). Pointer type: when unset and `target.kind=ShardedDatabase` on Neo4j 2025.09+, the operator defaults this to `true` to match the canonical upstream sharded-backup invocation; otherwise unset. Set explicitly (`true` or `false`) to override in either direction. |
@@ -248,15 +250,30 @@ The `Neo4jBackupStatus` represents the observed state of the backup.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `conditions` | `[]metav1.Condition` | Current backup conditions |
-| `phase` | `string` | Current backup phase |
+| `conditions` | `[]metav1.Condition` | Current backup conditions. The operator maintains a single `Ready` condition derived from `phase` (`Completed` → `True` with reason `BackupSucceeded`; `Failed`/`Suspended`/`Invalid` → `False`; everything else → `Unknown`). |
+| `phase` | `string` | Current backup phase — see [Backup Phases](#backup-phases) |
 | `message` | `string` | Human-readable message about the current state |
 | `observedGeneration` | `int64` | The `.metadata.generation` most recently observed by the controller |
 | `lastRunTime` | `*metav1.Time` | When the last backup Job started |
-| `lastSuccessTime` | `*metav1.Time` | When the last successful backup completed |
+| `lastSuccessTime` | `*metav1.Time` | When a **one-shot** backup completed (set on the `Completed` phase transition). **Never set for scheduled backups** — they don't pass through `Completed`; read `status.history[]` instead. |
 | `nextRunTime` | `*metav1.Time` | When the next scheduled backup will run |
 | `stats` | [`*BackupStats`](#backupstats) | Statistics from the most recent backup run |
-| `history` | [`[]BackupRun`](#backuprun) | History of recent backup runs |
+| `history` | [`[]BackupRun`](#backuprun) | History of recent backup runs. For scheduled backups this is the **authoritative record** of run outcomes. |
+
+### Backup Phases
+
+| Phase | Meaning |
+|-------|---------|
+| `Pending` | A transient precondition isn't met yet — e.g. the `chainFromBackup` parent CR doesn't exist yet, another Job in the same chain is still running, or the sharded-backup preflight couldn't connect to the cluster. The controller requeues and retries. |
+| `Waiting` | The target cluster/standalone CR doesn't exist yet (common with `kubectl apply -f dir/` ordering) or isn't `Ready`. Transient — the controller requeues. |
+| `Scheduled` | A CronJob has been created for `spec.schedule`. **This is the steady state for scheduled backups** — they never transition to `Completed`; per-run outcomes accumulate in `status.history[]`. |
+| `Suspended` | `spec.suspend: true` — the CronJob is suspended and one-shot runs are paused. |
+| `Running` | A one-shot backup Job is executing. |
+| `Completed` | The one-shot backup Job succeeded. Terminal — re-running requires deleting and recreating the CR. |
+| `Failed` | The one-shot backup Job failed terminally (Job `Failed` condition, after retries) or a non-transient error occurred (e.g. chain target/storage mismatch). Terminal for one-shot backups. |
+| `Invalid` | The spec failed validation (clear aggregated message in `status.message`). Recoverable — fixing the spec re-triggers reconcile. |
+
+> **Don't `kubectl wait --for=condition=Ready` on a scheduled backup** — it stays in `Scheduled` (Ready=`Unknown`) forever. Poll `status.history[*].status` for `Succeeded` instead.
 
 ### BackupStats
 
@@ -273,13 +290,13 @@ Represents a single backup Job execution.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `runID` | `string` | Unique identifier for this run, populated from the backing Job's `metadata.uid`. Stable for the lifetime of the Job; a new value for every retry. Used by the operator to dedupe history entries across reconciles and by users to correlate a history entry with the actual Job (and its logs / audit trail). |
+| `runID` | `string` | Unique identifier for this run, populated from the backing Job's **`metadata.name`** (not its opaque UID) — e.g. `<backup>-backup` for one-shots, `<backup>-backup-cron-<unix-seconds>` for CronJob children. Used by the operator to dedupe history entries across reconciles and by users to correlate a history entry with the actual Job (`kubectl logs job/<runID>`). |
 | `startTime` | `metav1.Time` | When the backup run started |
 | `completionTime` | `*metav1.Time` | When the run completed (`nil` if still running) |
 | `status` | `string` | Run status: `"Running"`, `"Succeeded"`, `"Failed"` |
 | `error` | `string` | Error message if the backup failed |
 | `stats` | [`*BackupStats`](#backupstats) | Backup statistics for this run |
-| `backupsPath` | `string` | The shared per-CR directory under `spec.storage.path` where this run wrote its `.backup` artifact. **Same value for every run of one CR** — all runs accumulate in this directory so `neo4j-admin` can chain differential backups off the prior full. Value is the Neo4jBackup CR name (or the `chainFromBackup` chain-root name when set). Use the `runID` field (Job UID) for per-run identity. |
+| `backupsPath` | `string` | The shared per-CR directory under `spec.storage.path` where this run wrote its `.backup` artifact. **Same value for every run of one CR** — all runs accumulate in this directory so `neo4j-admin` can chain differential backups off the prior full. Value is the Neo4jBackup CR name (or the `chainFromBackup` chain-root name when set). Use the `runID` field (Job name) for per-run identity. |
 | `artifactFilename` | `string` | Filename of the `.backup` artifact produced by this standard-DB run (e.g. `"neo4j-2026-06-08T01-18-06.backup"`). Populated by parsing the Job's Pod log after completion; empty when logs couldn't be fetched or the pattern didn't match. Used by the cluster PVC-restore path to build a per-restore seed URL. |
 | `shardArtifacts` | [`[]ShardArtifact`](#shardartifact) | Per-shard `.backup` files produced by a sharded backup run (`target.kind=ShardedDatabase`). Empty for non-sharded runs. |
 | `validation` | [`*BackupValidationResult`](#backupvalidationresult) | Per-shard outcome of the optional `neo4j-admin backup validate` step (only when `options.validate=true` and the operator could parse the output). |
@@ -401,7 +418,6 @@ spec:
     identity:
       provider: aws
       autoCreate:
-        enabled: true
         annotations:
           eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/neo4j-backup-role
   schedule: "0 2 * * *"   # Daily at 2 AM UTC
@@ -527,7 +543,7 @@ spec:
     path: backups/manual/
   options:
     compress: true
-    verify: true
+    validate: true   # runs `neo4j-admin backup validate` after the backup
     backupType: DIFF
 ```
 
@@ -554,13 +570,11 @@ spec:
     identity:
       provider: gcp
       autoCreate:
-        enabled: true
         annotations:
           iam.gke.io/gcp-service-account: neo4j-backup@my-project.iam.gserviceaccount.com
   schedule: "0 3 * * 0"   # Weekly on Sunday at 3 AM
   retention:
     maxCount: 12
-    deletePolicy: Archive
   options:
     backupType: AUTO
     pageCache: "8G"
@@ -620,7 +634,6 @@ spec:
     identity:
       provider: azure
       autoCreate:
-        enabled: true
         annotations:
           azure.workload.identity/client-id: 00000000-0000-0000-0000-000000000000
   schedule: "0 1 * * *"
@@ -680,11 +693,13 @@ kubectl get neo4jbackup daily-cluster-backup -w
 # Check logs from the most recent backup Job
 kubectl logs -n neo4j -l neo4j.com/backup=daily-cluster-backup --tail=100
 
-# Check backup phase
+# Check backup phase (scheduled backups stay in "Scheduled"; only one-shot
+# backups reach "Completed")
 kubectl get neo4jbackup daily-cluster-backup -o jsonpath='{.status.phase}'
 
-# Check last success time
-kubectl get neo4jbackup daily-cluster-backup -o jsonpath='{.status.lastSuccessTime}'
+# Check run outcomes — for scheduled backups, status.history is the record
+# (lastSuccessTime is only set for one-shot backups)
+kubectl get neo4jbackup daily-cluster-backup -o jsonpath='{.status.history[*].status}'
 ```
 
 For more information on backup operations, see the [Backup and Restore Guide](../user_guide/guides/backup_restore.md).

--- a/docs/api_reference/neo4jrestore.md
+++ b/docs/api_reference/neo4jrestore.md
@@ -18,21 +18,33 @@ The operator picks the restore method based on the target kind referenced by `cl
 
 1. Resolves `source.backupRef` (or `source.storage`) into the exact `.backup` **file** URI of the latest successful run, e.g. `s3://bucket/path/<cr-name>/<dbname>-<timestamp>.backup`. Neo4j's `CloudSeedProvider` seeds a single database from one file (a directory URI fails with `Can't open seed file`); when that file is a differential, Neo4j resolves and applies the full + differential chain from the same directory automatically.
    - **Mixed-cadence chains (`spec.chainFromBackup`)**: "latest successful run" is scoped to the **referenced CR**, not the shared chain directory. Reference the **differential** CR to restore the latest state; referencing the parent **full** CR seeds from its latest full snapshot — the newer diffs are *not* applied. Restoring via a chain-parent CR emits a `RestoreFromChainParent` Warning event naming the differential children, so a restore intending "latest" that references the full CR isn't a silent surprise. To pin an arbitrary run, use `source.type: storage` with `backupPath` set to the exact `.backup` file.
-2. Projects cloud credentials onto cluster pods via `spec.extraEnvFrom` (cluster CR) — required so the JVM's AWS/GCP/Azure SDK can authenticate. The operator emits an actionable error if the Secret isn't projected; set the cluster annotation `neo4j.com/auto-inherit-seed-creds=true` to auto-patch.
+   - For **PVC-backed** backups, the operator spawns a `backup-seed-proxy-<restore-name>` Deployment + Service serving the backup PVC read-only over HTTP, plus a **NetworkPolicy restricting proxy ingress to the target cluster's server pods** (effective on enforcing CNIs). The seedURI becomes an `http://` URL at the exact `.backup` filename (`URLConnectionSeedProvider`). The whole proxy stack is **torn down automatically** as soon as the restore reaches `Completed` or `Failed` (and on CR deletion) — it does not linger for the lifetime of the CR.
+2. Projects cloud credentials onto cluster pods via `spec.extraEnvFrom` (cluster CR) — required so the JVM's AWS/GCP/Azure SDK can authenticate. The operator emits an actionable error if the Secret isn't projected; set the cluster annotation `neo4j.com/auto-inherit-seed-creds=true` to auto-patch (triggers a rolling restart, which the restore waits out in `Pending`). With **workload identity** (no `credentialsSecretRef`), the SDK default chain is used — the IAM binding must then be on the **server pods'** ServiceAccount, since the seed fetch runs inside the Neo4j JVM, not in a Job.
 3. Opens a Bolt session and runs `SHOW DATABASES` to detect whether the target database already exists.
-4. Existing database → `CALL dbms.[cluster.]recreateDatabase($db, {seedURI: $uri})`. Preserves user/role privileges, atomically swaps the database on every server, no `DROP` needed.
-5. New database → `CREATE DATABASE $db OPTIONS { seedURI: '<file>' } WAIT`.
-6. `CREATE … WAIT` blocks until online, but `dbms.recreateDatabase` is **asynchronous** — it returns once the recreate is scheduled. The operator therefore polls `SHOW DATABASE` until every allocation reports `online` before marking the restore `Completed`; if the seed fails the restore goes `Failed` with the database's `statusMessage`.
+4. Existing database → `CALL dbms.[cluster.]recreateDatabase($db, {seedURI: $uri})`. **Requires `spec.force: true` or `spec.options.replaceExisting: true`** — recreating wipes and replaces the live contents, so the operator refuses without the explicit opt-in (clear `Failed` message instead of a silent overwrite). Preserves user/role privileges, atomically swaps the database on every server, no `DROP` needed.
+5. New database → `CREATE DATABASE $db OPTIONS { seedURI: '<file>' } WAIT` (no opt-in needed; nothing is overwritten).
+6. `CREATE … WAIT` blocks until online, but `dbms.recreateDatabase` is **asynchronous** — it returns once the recreate is scheduled. The operator therefore polls `SHOW DATABASE` until every allocation reports `online` before marking the restore `Completed`. The poll deadline is **`spec.timeout`** (default **5m** when unset) — raise it for multi-GB stores seeded from object storage; on expiry the restore goes `Failed` with the database's last `statusMessage`.
 
 **`Neo4jEnterpriseStandalone` target** — Kubernetes Job:
 
 1. Spawns a restore Job that runs `neo4j-admin database restore --from-path=$(ls <dir>/<dbname>-*.backup | tail -1) <dbname>`. The shell substitution picks the latest run in the chain by default.
-2. If `stopCluster: true`, the operator scales down the StatefulSet first and mounts `data-{name}-server-0` directly into the Job container for offline access.
+2. If `stopCluster: true`, the operator scales down the StatefulSet first and mounts `data-{name}-server-0` directly into the Job container for offline access. With `stopCluster: false` the operator **refuses to start the Job while any server pod is running** (it never writes into a live data volume) — so in practice standalone restores need `stopCluster: true` unless you have already scaled the instance down yourself.
 3. After the Job succeeds, automatically runs `CREATE DATABASE <dbname>` (new) or `START DATABASE <dbname>` (existed but stopped) via Bolt.
+4. `spec.options.preRestore` / `postRestore` hooks run **only on this path** (never for cluster targets): pre-restore hooks run **before** the instance is stopped (so Cypher like `CALL db.checkpoint()` hits a live Bolt endpoint); post-restore hooks run **after** the restored database is registered and started.
 
 **`Neo4jShardedDatabase` target** — rejected. Sharded restore is owned by the `Neo4jShardedDatabase` CRD; set `spec.replaceExisting: true` + `spec.force: true` on the target sharded DB and reference the backup via `spec.seedBackupRef`. The Neo4jRestore validator emits an actionable error pointing at this flow.
 
-**No manual post-restore Cypher is required** for either path.
+**No manual post-restore Cypher is required** for either path — with one exception: if the backup was taken with `includeMetadata` (users/roles), `neo4j-admin database restore` writes a `restore_metadata.cypher` script next to the restored store, and the operator does **not** run it. Re-creating the database's users/roles is a manual step — run it against the `system` database, e.g.:
+
+```bash
+kubectl exec <instance>-server-0 -c neo4j -- bash -c \
+  'cypher-shell -u neo4j -p "$NEO4J_PASSWORD" -d system \
+     -f /data/scripts/<dbname>/restore_metadata.cypher'
+```
+
+### Retrying a finished restore
+
+`Completed` and `Failed` are terminal **for the current spec generation**, not forever. To re-run a restore, **edit the spec** (any change that bumps `metadata.generation` — typically `source.backupRef` or `databaseName`): the operator clears the previous attempt's one-shot state and issues a fresh restore. Changing `source.backupRef` also invalidates the pinned `status.resolvedSource`, so the new reference is re-resolved rather than silently reusing the old snapshot. Alternatively, delete and recreate the CR.
 
 ## Neo4jRestore Spec
 
@@ -44,9 +56,9 @@ The operator picks the restore method based on the target kind referenced by `cl
 | `source` | [`RestoreSource`](#restoresource) | ✅ | Source of the backup data to restore |
 | `databaseName` | `string` | ✅ | Name of the Neo4j database to restore |
 | `options` | [`RestoreOptionsSpec`](#restoreoptionsspec) | ❌ | Additional restore configuration options |
-| `force` | `bool` | ❌ | Pass `--overwrite-destination` to allow restoring over an existing database (default: `false`) |
-| `stopCluster` | `bool` | ❌ | Scale down the target cluster before restore for an offline/cold restore (default: `false`). When `true`, mounts `data-{cluster}-server-0` PVC into the restore Job. |
-| `timeout` | `string` | ❌ | Timeout for the restore Job (e.g., `"2h"`, `"30m"`) |
+| `force` | `bool` | ❌ | Confirm restoring **over an existing database** (default: `false`). Standalone targets: passes `--overwrite-destination` to `neo4j-admin`. Cluster targets: required (or `options.replaceExisting: true`) before the operator issues the destructive `dbms.recreateDatabase` against an existing database. |
+| `stopCluster` | `bool` | ❌ | **Standalone targets only** (cluster targets restore via Cypher and ignore it). `true` scales the instance down before the restore Job (mounting `data-{name}-server-0` directly) and scales it back up after. With `false`, the operator **refuses** to run the Job while any server pod is running — it never writes into a live data volume. |
+| `timeout` | `string` | ❌ | Go duration (e.g. `"30m"`, `"2h"`). For **cluster** targets this bounds the online-convergence wait after `dbms.recreateDatabase` is issued (default **5m** when unset) — raise it for multi-GB stores seeded from object storage. |
 
 **Target compatibility**: `clusterRef` can reference either:
 
@@ -82,17 +94,21 @@ source:
   type: backup
   backupRef: daily-production-backup
 
-# Restore from an explicit S3 path
+# Restore from an explicit S3 path. backupPath is relative to storage.path and
+# must point at the exact .backup artifact (layout:
+# <chain-root>/<dbname>-YYYY-MM-DDThh-mm-ss.backup — the chain root is the
+# Neo4jBackup CR name; the filename is recorded on
+# Neo4jBackup.status.history[*].artifactFilename).
 source:
   type: storage
   storage:
     type: s3
     bucket: neo4j-backups
-    path: production/
+    path: production
     cloud:
       provider: aws
       credentialsSecretRef: aws-restore-credentials
-  backupPath: /backups/production/backup-20250120-020000
+  backupPath: daily-backup/mydb-2026-06-01T02-00-00.backup
 
 # Point-in-time recovery
 source:
@@ -138,14 +154,14 @@ Additional restore execution options.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `replaceExisting` | `bool` | ❌ | Replace an existing database (default: `false`) |
-| `verifyBackup` | `bool` | ❌ | Verify the backup before attempting restore (default: `false`) |
+| `replaceExisting` | `bool` | ❌ | Replace an existing database (default: `false`). Equivalent confirmation to top-level `force` for cluster restores of an existing database. |
+| `verifyBackup` | `bool` | ❌ | **RESERVED — currently a no-op.** Accepted for backward compatibility but not read by the operator. Verify artifacts at backup time via `Neo4jBackup.spec.options.validate` instead. |
 | `additionalArgs` | `[]string` | ❌ | Additional arguments passed verbatim to `neo4j-admin database restore` |
 | `tempPath` | `string` | ❌ | Local directory for temporary files during restore. When `tempStorage` is configured this is set automatically to the mount path; only set manually if you mount your own volume by other means. |
 | `tempStorage` | [`TempStorageSpec`](#tempstoragespec) | ❌ | Provisions a PVC for temporary staging files during cloud restores. Without it, cloud restores use the container's ephemeral disk (may be too small for large databases). The operator mounts the PVC and passes `--temp-path` automatically. |
 | `resources` | `corev1.ResourceRequirements` | ❌ | CPU/memory requests + limits on the restore Job's container. When unset, the operator applies a Burstable default (request 100m CPU / 512Mi memory, limit 1 CPU / 2Gi memory). **Standalone restores only** — cluster targets use the Cypher path (no Job) and ignore this field. |
-| `preRestore` | [`RestoreHooks`](#restorehooks) | ❌ | Hooks executed before the restore Job starts |
-| `postRestore` | [`RestoreHooks`](#restorehooks) | ❌ | Hooks executed after the restore Job completes successfully |
+| `preRestore` | [`RestoreHooks`](#restorehooks) | ❌ | **Standalone (Job-path) restores only** — never invoked for cluster targets. Executed **before the instance is stopped**, so Cypher hooks (e.g. `CALL db.checkpoint()`) hit a live Bolt endpoint. |
+| `postRestore` | [`RestoreHooks`](#restorehooks) | ❌ | **Standalone (Job-path) restores only.** Executed after the restore Job succeeds **and** the restored database has been registered/started (`CREATE`/`START DATABASE`), so Cypher hooks target a live database. |
 
 ### TempStorageSpec
 
@@ -158,12 +174,12 @@ Provisions a temporary PVC for staging files during cloud restores.
 
 ### RestoreHooks
 
-Hooks to run before or after the restore Job.
+Hooks to run before or after the restore Job. **Hooks run only for `Neo4jEnterpriseStandalone` targets** — the cluster Cypher restore path never invokes them.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `job` | [`RestoreHookJob`](#restorehookjob) | ❌ | Kubernetes Job to run as a hook |
-| `cypherStatements` | `[]string` | ❌ | Cypher statements to execute against the target Neo4j instance |
+| `job` | [`RestoreHookJob`](#restorehookjob) | ❌ | Kubernetes Job to run as a hook. The hook Job runs in its own pod — commands like `cypher-shell` must be pointed at the instance's service explicitly (e.g. `cypher-shell -a neo4j://<standalone>-service:7687 …`), otherwise they dial localhost inside the hook pod. |
+| `cypherStatements` | `[]string` | ❌ | Cypher statements the operator executes over Bolt against the standalone instance (pre-restore: before the instance is stopped; post-restore: after the database is registered/started) |
 
 ### RestoreHookJob
 
@@ -225,15 +241,15 @@ Storage backend configuration (shared with `Neo4jBackup`).
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `provider` | `string` | ✅ | Identity provider: `"aws"`, `"gcp"`, `"azure"` |
-| `serviceAccount` | `string` | ❌ | Existing ServiceAccount to use |
-| `autoCreate` | [`*AutoCreateSpec`](#autocreatespec) | ❌ | Auto-create ServiceAccount with workload-identity annotations |
+| `serviceAccount` | `string` | ❌ | **RESERVED — currently a no-op.** Restore Jobs always run as the operator-managed `neo4j-restore-sa`. Bind your cloud IAM role via `autoCreate.annotations`. |
+| `autoCreate` | [`*AutoCreateSpec`](#autocreatespec) | ❌ | Workload-identity annotations for the operator-managed ServiceAccount |
 
 ### AutoCreateSpec
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `enabled` | `bool` | ❌ | Enable auto-creation of the ServiceAccount (default: `true`) |
-| `annotations` | `map[string]string` | ❌ | Annotations applied to the auto-created ServiceAccount |
+| `enabled` | `bool` | ❌ | **RESERVED — currently a no-op.** The operator always ensures the ServiceAccount exists; only `annotations` is honored. |
+| `annotations` | `map[string]string` | ❌ | Annotations applied to the operator-managed ServiceAccount on every reconcile |
 
 ## Neo4jRestore Status
 
@@ -241,14 +257,25 @@ Storage backend configuration (shared with `Neo4jBackup`).
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `conditions` | `[]metav1.Condition` | Current conditions of the restore resource |
+| `conditions` | `[]metav1.Condition` | Current conditions of the restore resource — see [Condition Types](#condition-types) |
 | `phase` | `string` | Current phase of the restore operation |
 | `message` | `string` | Human-readable message about the current state |
 | `startTime` | `*metav1.Time` | When the restore operation started |
 | `completionTime` | `*metav1.Time` | When the restore operation completed |
 | `stats` | [`RestoreStats`](#restorestats) | Restore operation statistics |
 | `backupInfo` | [`RestoreBackupInfo`](#restorebackupinfo) | Information about the backup that was restored |
+| `resolvedSource` | [`ResolvedRestoreSource`](#resolvedrestoresource) | The concrete backup location this restore pinned the first time it resolved `source.backupRef`. From then on the restore reads this snapshot, so deleting the `Neo4jBackup` CR mid-restore doesn't break it. Cleared automatically if `spec.source.backupRef` changes (the new reference is re-resolved). |
 | `observedGeneration` | `int64` | Generation of the most recently observed `Neo4jRestore` spec |
+
+### ResolvedRestoreSource
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `backupRef` | `string` | The `Neo4jBackup` name this source was resolved from (provenance) |
+| `storage` | [`StorageLocation`](#storagelocation) | Concrete storage location (PVC or cloud, credentials reference folded in) of the resolved backup |
+| `backupPath` | `string` | The per-CR shared chain directory of the resolved most-recent Succeeded run |
+| `artifactFilename` | `string` | Exact `.backup` filename of the resolved run — required by the cluster Cypher paths (cloud seedURI + PVC proxy), which seed from a single file |
+| `resolvedAt` | `*metav1.Time` | When the `backupRef` was first dereferenced |
 
 ### RestoreStats
 
@@ -274,62 +301,40 @@ Storage backend configuration (shared with `Neo4jBackup`).
 
 | Phase | Description |
 |-------|-------------|
-| `Pending` | Restore is queued but not yet started |
-| `Running` | Restore Job is in progress |
-| `Completed` | Restore completed successfully; database has been created or started |
-| `Failed` | Restore Job or post-restore database bring-up failed |
+| `Pending` | A transient precondition isn't met yet — the target cluster/standalone CR doesn't exist yet, the referenced backup has no Succeeded run, or (cluster restores) the seed-credentials rollout / seed proxy is still in progress. The controller requeues and retries automatically. |
+| `Running` | The restore Job (standalone) is executing, or the cluster Cypher recreate has been issued and the operator is polling for online convergence. |
+| `Completed` | Restore completed successfully; the database is online. Terminal for the current spec generation — see [Retrying a finished restore](#retrying-a-finished-restore). |
+| `Failed` | The restore failed (validation, Job failure, seed failure, or convergence timeout). Terminal for the current spec generation — bump the spec or recreate the CR to retry. |
 
 ### Condition Types
 
-| Type | Description |
-|------|-------------|
-| `Ready` | Whether the restore resource is in a terminal successful state |
-| `JobCreated` | Whether the restore Job was created successfully |
-| `ClusterStopped` | Whether the target cluster was scaled down for offline restore |
-| `BackupVerified` | Whether the backup was verified before restore |
+The operator maintains a single **`Ready`** condition, derived from `phase`: `Completed` → `True`; `Failed` → `False` (reason `Failed`); `Pending`/`Running` → `Unknown`. No other condition types are set.
 
-## Post-Restore Database Bring-Up
+## Post-Restore Database Bring-Up (standalone Job path)
 
-After the restore Job completes successfully, the operator automatically issues a Cypher command to make the database available:
+After the restore Job completes successfully on a **standalone** target, the operator automatically issues a Cypher command to make the database available:
 
 - **New database** (did not exist before): `CREATE DATABASE <dbname>`
 - **Existing database** (was stopped for restore): `START DATABASE <dbname>`
 
-This means the restore workflow is fully automated — you do not need to manually start the database after restore completes. The `status.phase` transitions to `Completed` only after the database bring-up command succeeds.
+This means the restore workflow is fully automated — you do not need to manually start the database after restore completes. The `status.phase` transitions to `Completed` only after the database bring-up (and any post-restore hooks) succeed.
 
-### Multi-Server Cluster Re-Seed
+Cluster targets don't have a separate bring-up step: the Cypher restore (`CREATE DATABASE … OPTIONS { seedURI } WAIT` / `dbms.recreateDatabase`) brings the database online as part of the restore itself, and the operator marks `Completed` only after every allocation reports `online`.
 
-For clusters where `spec.topology.servers >= 2`, the operator additionally calls Neo4j's recreate procedure after the bring-up step:
+> **Note on the legacy multi-server re-seed**: older operator releases ran the restore Job against `data-{cluster}-server-0` on multi-server clusters and then called `dbms.[cluster.]recreateDatabase($db, {seedingServers: [server0]})` to force every server to re-seed from server-0. On current releases, **cluster targets never take the Job path** — they restore via the seedURI Cypher path, where every server seeds from the backup artifact in parallel and no re-seed step is needed. The re-seed code remains only as a non-fatal safety net on the Job path (which is now reachable only for standalone/single-server targets, where it is skipped).
 
-```cypher
-CALL dbms.cluster.recreateDatabase($db, {seedingServers: [$server0Id]})  -- Neo4j 5.24+ / 2025.02–2025.03
-CALL dbms.recreateDatabase($db, {seedingServers: [$server0Id]})           -- Neo4j 2025.04+ / 2026.x+
-```
+## `stopCluster` and Offline Restore (standalone targets)
 
-This step exists because the restore Job only writes to `data-{cluster}-server-0`'s PVC, but the database's primary placement after the cluster's restart is non-deterministic. Without re-seeding, a server with stale data can win consensus and overwrite the restored data on re-sync.
-
-The procedure is invoked with **server-0 as the explicit seed**, so the cluster reconciles every server's store to server-0's restored data. Server-0 is resolved at runtime via `SHOW SERVERS` (matched by `address`, which contains the Pod hostname); if the lookup can't find server-0, the operator falls back to Neo4j's auto-select mode (empty `seedingServers` list).
-
-**Version requirement**: the recreate procedure is available in Neo4j 5.24+ (incl. 5.26 LTS) and Neo4j 2025.02+. On unsupported versions the step is skipped silently with an informational log; multi-server cluster restores on those versions are best-effort and may need manual re-seeding via Neo4j tools.
-
-**Required Neo4j privileges**: `CREATE DATABASE` + `DROP DATABASE` (per the [Neo4j recreate-database docs](https://neo4j.com/docs/operations-manual/current/database-administration/standard-databases/recreate-database/)). The operator's admin secret has both.
-
-**Failure handling**: the recreate step is non-fatal — if it fails (network blip, permission issue, procedure unavailable), the restore still transitions to `Completed` and the failure is surfaced via an operator Event of type `Warning` with reason `DatabaseCreateFailed`. Re-run the procedure manually against the system database if needed.
-
-## `stopCluster` and Offline Restore
+`spec.stopCluster` applies only to **standalone** targets — cluster targets restore online via Cypher and ignore it.
 
 When `spec.stopCluster: true`:
 
-1. The operator scales the target StatefulSet down to 0 replicas.
-2. The restore Job is created with the actual server data PVC (`data-{cluster}-server-0`) mounted into the container, enabling direct offline file-level restore.
-3. After the restore Job succeeds, the StatefulSet is scaled back up.
+1. The operator scales the target StatefulSet down to 0 replicas (recording the original replica count so re-entries don't lose it).
+2. The restore Job is created with the actual server data PVC (`data-{name}-server-0`) mounted into the container, enabling direct offline file-level restore.
+3. After the restore Job succeeds, the StatefulSet is scaled back up. If the restore fails after the scale-down (hook failure, Job-create failure), the operator scales the instance back up rather than leaving it stranded at 0 replicas.
 4. The operator then issues `CREATE DATABASE` or `START DATABASE` as described above.
 
-Use `stopCluster: true` when:
-
-- The database is too large for an online restore
-- You need to restore at the storage level rather than via `neo4j-admin`
-- The cluster is in an inconsistent state that prevents online operations
+When `spec.stopCluster: false`, the operator treats the instance as **already quiesced** and **refuses to start the Job while any server pod is running** — restoring into a live data volume is invisible data loss. Use `stopCluster: true` unless you have scaled the instance down yourself.
 
 ## Examples
 
@@ -342,20 +347,17 @@ metadata:
   name: simple-backup-restore
   namespace: neo4j
 spec:
-  clusterRef: test-cluster   # Neo4jEnterpriseCluster or Neo4jEnterpriseStandalone
+  clusterRef: test-cluster   # Neo4jEnterpriseCluster (Cypher path — no Job)
   databaseName: testdb
   source:
     type: backup
     backupRef: daily-test-backup   # References a Neo4jBackup resource
   options:
-    verifyBackup: true
-    replaceExisting: true
-  force: false
-  stopCluster: false
-  timeout: "1h"
+    replaceExisting: true   # required if "testdb" already exists on the cluster
+  timeout: "30m"   # online-convergence budget for the cluster restore (default 5m)
 ```
 
-### Restore from S3 (Static Credentials)
+### Restore from S3 (Static Credentials, Standalone)
 
 ```yaml
 apiVersion: neo4j.neo4j.com/v1beta1
@@ -364,31 +366,31 @@ metadata:
   name: dev-s3-restore
   namespace: development
 spec:
-  clusterRef: dev-standalone   # Neo4jEnterpriseStandalone
+  clusterRef: dev-standalone   # Neo4jEnterpriseStandalone (Job path — hooks run here)
   databaseName: dev-app
   source:
     type: storage
     storage:
       type: s3
       bucket: dev-neo4j-backups
-      path: snapshots/
+      path: snapshots
       cloud:
         provider: aws
         credentialsSecretRef: aws-restore-credentials
-    backupPath: /backups/dev-app/backup-20250120-103000
+    # Exact artifact: <chain-root>/<dbname>-<timestamp>.backup
+    backupPath: dev-backup/dev-app-2026-06-01T10-30-00.backup
   options:
-    verifyBackup: false
     replaceExisting: true
-    postRestore:
+    postRestore:   # hooks run only on standalone targets
       cypherStatements:
         - "CALL db.awaitIndexes(60)"
         - "CREATE (:TestNode {restored: datetime()})"
   force: true
-  stopCluster: false
+  stopCluster: true   # standalone Job restores need the instance stopped
   timeout: "30m"
 ```
 
-### Restore from GCS (Static Credentials)
+### Restore from GCS (Static Credentials, Cluster)
 
 ```yaml
 apiVersion: neo4j.neo4j.com/v1beta1
@@ -397,27 +399,31 @@ metadata:
   name: gcs-restore
   namespace: neo4j
 spec:
-  clusterRef: analytics-cluster
+  clusterRef: analytics-cluster   # Neo4jEnterpriseCluster (Cypher path)
   databaseName: analytics-db
   source:
     type: storage
     storage:
       type: gcs
       bucket: neo4j-analytics-backups
-      path: weekly/
+      path: weekly
       cloud:
         provider: gcp
         credentialsSecretRef: gcs-restore-credentials
-    backupPath: /backups/analytics-db/backup-20250120-030000
+    # Cluster targets REQUIRE the exact .backup file (CloudSeedProvider seeds
+    # a single database from one file — a directory path fails):
+    backupPath: weekly-backup/analytics-db-2026-06-01T03-00-00.backup
   options:
-    verifyBackup: true
-    replaceExisting: true
+    replaceExisting: true   # required: analytics-db already exists
   force: true
-  stopCluster: true
-  timeout: "2h"
+  timeout: "2h"   # online-convergence budget — raise for large stores
 ```
 
-### Restore from Azure Blob Storage
+> For the cluster Cypher path the credentials Secret must also be projected onto the **server pods** via the cluster's `spec.extraEnvFrom` (or annotate the cluster with `neo4j.com/auto-inherit-seed-creds: "true"` and let the operator patch it).
+
+### Restore from Azure Blob Storage (Cluster)
+
+Cluster targets restore via Cypher — hooks, `additionalArgs` and `stopCluster` belong to the standalone Job path and are intentionally absent here.
 
 ```yaml
 apiVersion: neo4j.neo4j.com/v1beta1
@@ -429,45 +435,23 @@ metadata:
     compliance: required
     environment: production
 spec:
-  clusterRef: enterprise-cluster
+  clusterRef: enterprise-cluster   # Neo4jEnterpriseCluster (Cypher path)
   databaseName: customer-data
   source:
     type: storage
     storage:
       type: azure
       bucket: enterprise-backups   # Azure container name
-      path: production/
+      path: production
       cloud:
         provider: azure
         credentialsSecretRef: azure-restore-credentials
-    backupPath: /backups/customer-data/backup-20250120-020000.backup
+    # Exact .backup file, required for cluster targets:
+    backupPath: nightly-backup/customer-data-2026-06-01T02-00-00.backup
   options:
-    verifyBackup: true
-    replaceExisting: true
-    preRestore:
-      cypherStatements:
-        - "CALL db.checkpoint()"
-    postRestore:
-      cypherStatements:
-        - "CALL db.awaitIndexes()"
-        - "CALL dbms.security.clearAuthCache()"
-      job:
-        template:
-          container:
-            image: enterprise-compliance-checker:latest
-            command: ["/scripts/compliance-check.sh"]
-            env:
-              - name: NEO4J_URI
-                value: "neo4j://enterprise-cluster-client:7687"
-              - name: COMPLIANCE_LEVEL
-                value: "GDPR,HIPAA"
-        timeout: "60m"
-    additionalArgs:
-      - "--check-consistency"
-      - "--verbose"
+    replaceExisting: true   # required: customer-data already exists
   force: true
-  stopCluster: true
-  timeout: "6h"
+  timeout: "6h"   # large store — generous online-convergence budget
 ```
 
 ### Point-in-Time Recovery (PITR)
@@ -481,7 +465,7 @@ metadata:
   name: production-pitr-restore
   namespace: neo4j
 spec:
-  clusterRef: recovery-cluster
+  clusterRef: recovery-standalone   # Neo4jEnterpriseStandalone (PITR is standalone-only)
   databaseName: production-db
   source:
     type: pitr
@@ -493,17 +477,16 @@ spec:
       logStorage:
         type: s3
         bucket: neo4j-transaction-logs
-        path: production/logs/
+        path: production/logs
         cloud:
           provider: aws
           credentialsSecretRef: aws-restore-credentials
   options:
-    verifyBackup: true
     replaceExisting: true
-    preRestore:
+    preRestore:     # hooks run only on standalone targets, BEFORE the stop
       cypherStatements:
         - "CALL db.checkpoint()"
-    postRestore:
+    postRestore:    # AFTER the restored database is registered/started
       cypherStatements:
         - "CALL db.awaitIndexes(600)"
         - "CALL dbms.security.clearAuthCache()"
@@ -512,9 +495,9 @@ spec:
   timeout: "4h"
 ```
 
-### Offline Restore via stopCluster
+### Offline Restore via stopCluster (Standalone)
 
-When `stopCluster: true`, the operator mounts the server data PVC (`data-{cluster}-server-0`) directly into the restore Job for a cold/offline restore.
+`stopCluster` applies to **standalone** targets only — cluster targets restore online via Cypher and ignore it. When `stopCluster: true`, the operator scales the standalone to 0 and mounts its data PVC (`data-{name}-server-0`) directly into the restore Job for a cold/offline restore.
 
 ```yaml
 apiVersion: neo4j.neo4j.com/v1beta1
@@ -523,20 +506,20 @@ metadata:
   name: offline-restore
   namespace: neo4j
 spec:
-  clusterRef: production-cluster
+  clusterRef: reporting-standalone   # Neo4jEnterpriseStandalone
   databaseName: large-graph
   source:
     type: storage
     storage:
       type: s3
       bucket: neo4j-backups
-      path: large-graph/
+      path: large-graph
       cloud:
         provider: aws
         credentialsSecretRef: aws-restore-credentials
-    backupPath: /backups/large-graph/backup-20250120-020000
+    backupPath: nightly-backup/large-graph-2026-06-01T02-00-00.backup
   force: true
-  stopCluster: true   # Scales cluster to 0; mounts data-production-cluster-server-0 PVC
+  stopCluster: true   # Scales the standalone to 0; mounts data-reporting-standalone-server-0
   timeout: "8h"
 ```
 
@@ -558,13 +541,12 @@ spec:
     backupRef: dev-daily-backup
   options:
     replaceExisting: true
-    verifyBackup: false
   force: true
-  stopCluster: false   # Standalone does not require scaling down
+  stopCluster: true   # required: with false the operator refuses while pods are running
   timeout: "30m"
 ```
 
-### Cross-Cloud Disaster Recovery
+### Cross-Cloud Disaster Recovery (Cluster)
 
 ```yaml
 apiVersion: neo4j.neo4j.com/v1beta1
@@ -573,39 +555,22 @@ metadata:
   name: cross-cloud-dr-restore
   namespace: disaster-recovery
 spec:
-  clusterRef: dr-cluster
+  clusterRef: dr-cluster   # Neo4jEnterpriseCluster (Cypher path — no hooks, no Job)
   databaseName: critical-app
   source:
     type: storage
     storage:
       type: gcs
       bucket: primary-site-backups
-      path: disaster-recovery/
+      path: disaster-recovery
       cloud:
         provider: gcp
         credentialsSecretRef: gcs-dr-credentials
-    backupPath: /backups/critical-app/latest.backup
+    # Exact .backup file, required for cluster targets:
+    backupPath: dr-backup/critical-app-2026-06-01T02-00-00.backup
   options:
-    verifyBackup: true
     replaceExisting: true
-    preRestore:
-      cypherStatements:
-        - "CALL db.checkpoint()"
-    postRestore:
-      cypherStatements:
-        - "CALL db.awaitIndexes()"
-        - "CALL dbms.security.clearAuthCache()"
-      job:
-        template:
-          container:
-            image: dr-validation-tool:latest
-            command: ["/scripts/dr-validation.sh"]
-            env:
-              - name: NEO4J_URI
-                value: "neo4j://dr-cluster-client:7687"
-        timeout: "45m"
   force: true
-  stopCluster: true
   timeout: "3h"
 ```
 
@@ -627,7 +592,8 @@ kubectl get neo4jrestore production-pitr-restore -o jsonpath='{.status.phase}'
 # Check restore statistics
 kubectl get neo4jrestore production-pitr-restore -o jsonpath='{.status.stats}'
 
-# Monitor restore Job logs
+# Monitor restore Job logs (standalone targets only — cluster targets restore
+# via Cypher and create no Job; follow the operator log instead)
 kubectl logs -n neo4j job/production-pitr-restore-restore --follow
 
 # Check completion time

--- a/docs/user_guide/guides/backup_restore.md
+++ b/docs/user_guide/guides/backup_restore.md
@@ -34,17 +34,19 @@ Backup Jobs run as the auto-created `neo4j-backup-sa` ServiceAccount in the same
 
 | `target.kind` | `target.name` | `target.clusterRef` | Backs up |
 |---|---|---|---|
-| `Cluster` | the **instance** name — a `Neo4jEnterpriseCluster` **or** `Neo4jEnterpriseStandalone` (auto-detected) | *(unused — leave unset)* | every database on the instance |
+| `Cluster` | the **instance** name — a `Neo4jEnterpriseCluster` **or** `Neo4jEnterpriseStandalone` (auto-detected) | *(unused — leave unset)* | every database on the instance (`neo4j-admin database backup "*"` — one `.backup` artifact per database) |
 | `Database` | the **database** name (e.g. `neo4j`) | the owning instance name | a single database |
 | `ShardedDatabase` | the logical sharded-DB name (e.g. `products`) | the owning cluster | all shards in one `neo4j-admin` run |
 
 There is **no `kind: Standalone`** — a standalone is just an instance. To back one up, use `kind: Cluster` with `name: <standalone-name>` (whole instance), or `kind: Database` with `name: <database>` + `clusterRef: <standalone-name>` (one database). Key gotcha: for `kind: Cluster`, `name` is the **instance** name and `clusterRef` is unused; for `kind: Database`/`ShardedDatabase`, `name` is the **database** and `clusterRef` is the instance that owns it.
 
+**Restore is single-database** even when the backup was cluster-wide: a `kind: Cluster` backup leaves one artifact per database in the chain directory, and you create one `Neo4jRestore` per database you want back (the standalone restore Job's filename glob, and the cluster seedURI, naturally select the requested database's artifact). An all-databases restore mode is tracked in [#222](https://github.com/neo4j-partners/neo4j-kubernetes-operator/issues/222).
+
 ### Storage Layout
 
 All runs of a single `Neo4jBackup` CR write to the **same directory**: `<storage.path>/<cr-name>/`. This is what `neo4j-admin` requires for differential backup chaining — every diff run reads the prior full from the same directory to compute the delta. Per-run identity is preserved by the timestamp `neo4j-admin` embeds in each artifact filename (`<dbname>-YYYY-MM-DDThh-mm-ss.backup`).
 
-Each scheduled run appends to `status.history[]` with a unique `runID` (Job UID) and the captured artifact filename. To list runs:
+Each scheduled run appends to `status.history[]` with a unique `runID` (the Job **name**, e.g. `daily-backup-backup-cron-1764806400` — handy for `kubectl logs job/<runID>`) and the captured artifact filename. To list runs:
 
 ```bash
 kubectl get neo4jbackup daily-backup -o jsonpath='{.status.history[*].runID}'
@@ -89,7 +91,16 @@ Cloud backup Jobs need permission to write to your bucket. The operator supports
 | On-prem Kubernetes (no cloud IAM) | Explicit credentials via `credentialsSecretRef` |
 | Compliance requires no long-lived keys | Workload Identity |
 
-**Security recommendation**: Prefer Workload Identity in production. Explicit credentials work everywhere and are simpler to set up initially, but rotate them regularly and store them only in Kubernetes Secrets.
+**Recommendation: use pod identity (IRSA / GKE Workload Identity / Azure Workload Identity) wherever your platform supports it.** Leaving `credentialsSecretRef` empty (or omitting the whole `cloud` credentials block) means the cloud SDK's **default credential chain** is used — which picks up the pod identity automatically. No long-lived keys, nothing to rotate. Explicit credentials work everywhere and are simpler to set up initially, but rotate them regularly and store them only in Kubernetes Secrets.
+
+**Which ServiceAccount needs the IAM binding?** It depends on *where* the cloud access happens:
+
+| Operation | Runs on | Bind the IAM role to |
+|---|---|---|
+| `Neo4jBackup` / standalone `Neo4jRestore` (Job paths) | a backup/restore **Job pod** | the operator-managed `neo4j-backup-sa` / `neo4j-restore-sa` — via `cloud.identity.autoCreate.annotations` on the CR |
+| Cluster `Neo4jRestore` (Cypher path), `Neo4jDatabase` `seedURI`, sharded `seedBackupRef` seeding | the Neo4j **server pods** (the JVM fetches the seed itself) | the **cluster's server pods' ServiceAccount** — the Job SA annotation does nothing here |
+
+With **static credentials** the equivalent split applies: Job paths read the Secret referenced by `credentialsSecretRef`; the seedURI paths need the same Secret projected onto the server pods via the cluster/standalone CR's `spec.extraEnvFrom` (the operator checks this and emits a copy-pasteable fix, or auto-patches under the `neo4j.com/auto-inherit-seed-creds: "true"` annotation).
 
 ---
 
@@ -235,7 +246,15 @@ kubectl run minio-client --rm -it --restart=Never \
 | Path-style not working | `forcePathStyle` missing | Confirm `forcePathStyle: true` in spec |
 | `SSL handshake failed` | TLS mismatch | Use `http://` for in-cluster; mount CA for self-signed certs |
 
-> **Restoring from MinIO / S3-compatible storage uses the same two fields.** Set `endpointURL` and `forcePathStyle` on the `Neo4jRestore` `spec.source.storage.cloud` block (and they apply equally to `Neo4jDatabase` `seedURI` seeding) — the operator injects `AWS_ENDPOINT_URL_S3` and the path-style JVM flag into the restore Job and the seeding pods exactly as it does for backup.
+> **Restoring from MinIO / S3-compatible storage uses the same two fields — but only on Job paths.** Set `endpointURL` and `forcePathStyle` on the `Neo4jRestore` `spec.source.storage.cloud` block: the operator injects `AWS_ENDPOINT_URL_S3` and the path-style JVM flag into backup and **standalone restore Job pods** only. They are **not** injected into the Neo4j server pods — so for the cluster Cypher restore path and `Neo4jDatabase`/`Neo4jShardedDatabase` `seedURI` seeding (where the server JVM fetches the seed itself), add `AWS_ENDPOINT_URL_S3` as an extra key in the credentials Secret you project via the cluster's `spec.extraEnvFrom`:
+>
+> ```bash
+> kubectl create secret generic minio-backup-credentials \
+>   --from-literal=AWS_ACCESS_KEY_ID=minioadmin \
+>   --from-literal=AWS_SECRET_ACCESS_KEY=minioadmin \
+>   --from-literal=AWS_REGION=us-east-1 \
+>   --from-literal=AWS_ENDPOINT_URL_S3=http://minio.minio.svc:9000
+> ```
 
 Full examples with scheduled incremental backups: [`examples/backup-restore/backup-minio.yaml`](https://github.com/neo4j-partners/neo4j-kubernetes-operator/blob/main/examples/backup-restore/backup-minio.yaml).
 
@@ -696,13 +715,16 @@ spec:
     deletePolicy: Delete
 ```
 
-**Schedule:** Daily at 2 AM UTC — adjust as needed. Retention keeps 7 days' worth of backups.
+**Schedule:** Daily at 2 AM UTC — adjust as needed. The schedule must be plain 5-field UTC cron — `TZ=`/`CRON_TZ=` prefixes are rejected (Kubernetes refuses timezone-embedded CronJob schedules). Scheduled backup names are limited to 40 characters.
 
-> **Cloud storage retention note**: The `retention` settings above control how many backup records the operator tracks and attempts to clean up in PVC storage. For cloud storage (S3, GCS, Azure), **retention cleanup is handled by your bucket's lifecycle rules**, not the operator. The operator logs a notice when PVC retention cleanup is skipped for cloud-backed backups. Configure lifecycle rules directly in your cloud provider:
+> **What `retention` actually does** — read this before relying on it:
 >
-> - **S3**: [S3 Lifecycle Rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lifecycle-mgmt.html)
-> - **GCS**: [Object Lifecycle Management](https://cloud.google.com/storage/docs/lifecycle)
-> - **Azure**: [Blob Lifecycle Management](https://learn.microsoft.com/en-us/azure/storage/blobs/lifecycle-management-overview)
+> - **Cloud storage (S3, GCS, Azure)**: the operator never deletes cloud objects. **Retention cleanup is handled by your bucket's lifecycle rules**, not the operator (which logs a notice to that effect). Configure lifecycle rules directly in your cloud provider:
+>   - **S3**: [S3 Lifecycle Rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lifecycle-mgmt.html)
+>   - **GCS**: [Object Lifecycle Management](https://cloud.google.com/storage/docs/lifecycle)
+>   - **Azure**: [Blob Lifecycle Management](https://learn.microsoft.com/en-us/azure/storage/blobs/lifecycle-management-overview)
+> - **PVC storage**: retention is enforced by a cleanup Job that runs **only when the Neo4jBackup CR is deleted** — it is *not* a continuous pruning loop. The Job prunes `*.backup` **files** in this CR's chain directory only, oldest-first by mtime, and **always keeps the newest artifact**. `maxAge` accepts `d`/`h`/`m`/`s` units (`"4w"` is rejected). `deletePolicy: Archive` is a reserved no-op.
+> - **DIFF caveat**: filenames don't encode FULL vs DIFF, so pruning can orphan diffs whose parent FULL ages out — the operator emits a `BackupRetentionCaveat` warning event when this applies. Prefer `backupType: FULL` on CRs that use retention.
 
 #### Weekly Backup with Long Retention
 
@@ -735,14 +757,13 @@ spec:
   retention:
     maxAge: "90d"
     maxCount: 12
-    deletePolicy: Archive
 ```
 
-**Best for:** Enterprise compliance, long-term archival. Configure GCS Lifecycle Management to expire objects after 90 days.
+**Best for:** Enterprise compliance, long-term archival. For cloud storage the `retention` block is advisory — configure GCS Lifecycle Management to expire (or transition to archival storage classes) objects after 90 days. There is no operator-side archive action (`deletePolicy: Archive` is a reserved no-op).
 
 ### Suspended Backups
 
-Temporarily pause a scheduled backup without deleting the resource:
+Temporarily pause a scheduled backup without deleting the resource. The operator propagates `suspend: true` to the CronJob's own `spec.suspend`, so Kubernetes stops firing scheduled Jobs entirely; flipping it back to `false` resumes the schedule. `suspend: true` also pauses a one-shot backup that hasn't run yet. (Separately: removing `spec.schedule` from a CR deletes its CronJob — the CR becomes a one-shot backup.)
 
 ```yaml
 apiVersion: neo4j.neo4j.com/v1beta1
@@ -781,17 +802,27 @@ The operator picks the right restore method based on the target kind. The Neo4j 
 **Cluster path (Cypher)** — works with both cloud and PVC backups:
 
 - **Cloud-backed backup** (S3 / GCS / Azure): the operator passes the exact `.backup` **file** URI of the latest successful run (`s3://bucket/<path>/<backup-cr-name>/<dbname>-<timestamp>.backup`) as `seedURI` — `CloudSeedProvider` seeds a single database from one file, not a directory. When that file is a differential, Neo4j resolves and applies the full + differential chain from the same directory automatically. The cluster's pods must have the cloud credentials Secret projected via `spec.extraEnvFrom` — the operator emits an actionable error if they don't, or auto-patches under annotation `neo4j.com/auto-inherit-seed-creds=true`.
-- **PVC-backed backup**: the operator spawns an in-cluster busybox httpd proxy (`backup-seed-proxy-<restore-name>`) mounting the backup PVC RO at `/backup`, then passes the per-run `.backup` file URL as `seedURI` (`http://backup-seed-proxy-<restore-name>:8080/<backup-cr-name>/<filename>`). Neo4j's `URLConnectionSeedProvider` fetches it. The proxy Deployment + Service are owned by the `Neo4jRestore` CR and GC'd when it's deleted. No credentials required.
+- **PVC-backed backup**: the operator spawns an in-cluster busybox httpd proxy (`backup-seed-proxy-<restore-name>`) mounting the backup PVC RO at `/backup`, then passes the per-run `.backup` file URL as `seedURI` (`http://backup-seed-proxy-<restore-name>:8080/<backup-cr-name>/<filename>`). Neo4j's `URLConnectionSeedProvider` fetches it. The operator also creates a **NetworkPolicy restricting the proxy's ingress to the target cluster's server pods** (effective on enforcing CNIs), and **tears the whole proxy stack down automatically** (Deployment + Service + NetworkPolicy) as soon as the restore reaches `Completed` or `Failed` — it doesn't keep serving the backup PVC for the lifetime of the CR. No credentials required.
+- Restoring over an **existing** database requires the explicit opt-in `spec.force: true` (or `spec.options.replaceExisting: true`) — recreate wipes and replaces the live contents, so the operator refuses without it.
 - `dbms.recreateDatabase` preserves user/role privileges on the existing database; no `DROP DATABASE` needed.
 - For new databases, the operator emits `CREATE DATABASE … OPTIONS { seedURI: '…' } WAIT`.
-- Both forms block until the new state is online — when the restore returns, the database is ready.
+- Both forms finish with the database online. For the recreate path the operator polls until every allocation reports `online`, bounded by **`spec.timeout`** (default 5m) — raise it for multi-GB stores seeded from object storage.
 
 **Standalone path (Job)**:
 
 - The operator spawns a Kubernetes Job that mounts the backup PVC (or streams from cloud storage), runs `neo4j-admin database restore --from-path=<latest-file>`, then automatically runs `CREATE DATABASE` or `START DATABASE` over Bolt.
 - The `<latest-file>` is resolved at Pod startup via shell substitution (`ls <dir>/<dbname>-*.backup | tail -1`), so the most recent run in the chain wins by default.
+- Use `stopCluster: true`: the operator scales the instance down for the offline restore and back up afterwards. With `stopCluster: false` it **refuses to start the Job while any server pod is running** (it never writes into a live data volume).
 
-**No manual post-restore Cypher is required** for either path.
+**No manual post-restore Cypher is required** for either path — with one exception: if the backup included users/roles metadata (`includeMetadata`), `neo4j-admin database restore` writes a `restore_metadata.cypher` script under the data directory (`/data/scripts/<dbname>/restore_metadata.cypher`) and the operator does **not** run it. Re-apply users/roles manually:
+
+```bash
+kubectl exec <instance>-server-0 -c neo4j -- bash -c \
+  'cypher-shell -u neo4j -p "$NEO4J_PASSWORD" -d system \
+     -f /data/scripts/<dbname>/restore_metadata.cypher'
+```
+
+**Retrying a finished restore**: `Completed`/`Failed` are terminal for the current spec generation. Edit the spec (any change that bumps the generation — typically `source.backupRef`) to issue a fresh attempt; changing `backupRef` re-resolves the pinned `status.resolvedSource` instead of reusing the old snapshot. Or delete and recreate the CR.
 
 ### Simple Restore Examples
 
@@ -809,13 +840,11 @@ spec:
     type: backup
     backupRef: daily-backup
   options:
-    verifyBackup: true
-    replaceExisting: true
-  force: false
-  stopCluster: true
+    replaceExisting: true   # required — "neo4j" already exists on the cluster
+  timeout: "30m"            # cluster online-convergence budget (default 5m)
 ```
 
-After the Job completes, the operator automatically runs `START DATABASE neo4j` (or `CREATE DATABASE neo4j` if it was a new database). **You do not need to run any Cypher manually.**
+On a cluster target this runs entirely over Cypher (no Job, `stopCluster` is ignored) and finishes with the database online. On a standalone target the operator runs the restore Job and then automatically issues `START DATABASE neo4j` (or `CREATE DATABASE neo4j` for a new database). **You do not need to run any Cypher manually.**
 
 **Best for:** Quick recovery from an existing `Neo4jBackup` resource.
 
@@ -847,12 +876,11 @@ spec:
     # latest file via `ls … | tail -1`.
     backupPath: daily-backup/myapp-db-2025-06-01T02-00-00.backup
   options:
-    verifyBackup: true
     replaceExisting: true
     tempStorage:
       size: "50Gi"
   force: true
-  stopCluster: true   # ignored on cluster targets (Cypher path); honored on standalone
+  stopCluster: true   # ignored on cluster targets (Cypher path); required on standalone
 ```
 
 **Best for:** Cross-cluster recovery, disaster recovery from a known directory in storage (no `Neo4jBackup` CR available in this namespace).
@@ -881,9 +909,8 @@ spec:
     type: backup
     backupRef: standalone-backup
   options:
-    verifyBackup: true
     replaceExisting: true
-  stopCluster: true
+  stopCluster: true   # required: with false the operator refuses while pods are running
 ```
 
 ---
@@ -902,7 +929,7 @@ kind: Neo4jRestore
 metadata:
   name: pitr-restore
 spec:
-  clusterRef: recovery-cluster
+  clusterRef: recovery-standalone   # Neo4jEnterpriseStandalone (PITR is standalone-only)
   databaseName: production-db
   source:
     type: pitr
@@ -919,7 +946,6 @@ spec:
           provider: aws
           credentialsSecretRef: aws-backup-creds
   options:
-    verifyBackup: true
     replaceExisting: true
   force: true
   stopCluster: true
@@ -936,7 +962,7 @@ kind: Neo4jRestore
 metadata:
   name: pitr-storage-restore
 spec:
-  clusterRef: disaster-recovery
+  clusterRef: dr-standalone   # Neo4jEnterpriseStandalone (PITR is standalone-only)
   databaseName: critical-app
   source:
     type: pitr
@@ -960,7 +986,7 @@ spec:
           provider: gcp
           credentialsSecretRef: gcs-backup-creds
   options:
-    verifyBackup: true
+    replaceExisting: true
   force: true
   stopCluster: true
 ```
@@ -971,6 +997,13 @@ spec:
 
 Pre and post-restore hooks execute custom operations at key points in the restore lifecycle.
 
+**Hooks run only for `Neo4jEnterpriseStandalone` targets** (the Job-based restore path) — cluster targets restore via Cypher and never invoke hooks. The ordering is:
+
+1. **preRestore** hooks — run **before the instance is stopped**, so Cypher hooks like `CALL db.checkpoint()` hit a live Bolt endpoint.
+2. Instance scale-down (`stopCluster: true`), restore Job, scale-up.
+3. Automatic `CREATE DATABASE` / `START DATABASE`.
+4. **postRestore** hooks — run **after the restored database is registered and started**, so Cypher hooks like `CALL db.awaitIndexes()` target a live database.
+
 #### Restore with Cypher Hooks
 
 ```yaml
@@ -979,13 +1012,12 @@ kind: Neo4jRestore
 metadata:
   name: restore-with-hooks
 spec:
-  clusterRef: my-cluster
+  clusterRef: my-standalone   # Neo4jEnterpriseStandalone — hooks are standalone-only
   databaseName: myapp
   source:
     type: backup
     backupRef: production-backup
   options:
-    verifyBackup: true
     replaceExisting: true
     preRestore:
       cypherStatements:
@@ -998,9 +1030,9 @@ spec:
   stopCluster: true
 ```
 
-Note: The operator still automatically runs `CREATE DATABASE` or `START DATABASE` after the restore Job and post-restore hooks complete.
-
 #### Restore with Job Hooks
+
+Hook Jobs run in their own pods — anything that talks to Neo4j (e.g. `cypher-shell`) must address the instance's service explicitly (`-a neo4j://<standalone>-service:7687`), or it will try to connect to localhost inside the hook pod.
 
 ```yaml
 apiVersion: neo4j.neo4j.com/v1beta1
@@ -1008,13 +1040,12 @@ kind: Neo4jRestore
 metadata:
   name: restore-with-job-hooks
 spec:
-  clusterRef: staging-cluster
+  clusterRef: staging-standalone   # Neo4jEnterpriseStandalone — hooks are standalone-only
   databaseName: app-data
   source:
     type: backup
     backupRef: staging-backup
   options:
-    verifyBackup: true
     preRestore:
       job:
         template:
@@ -1023,8 +1054,8 @@ spec:
             command: ["/bin/sh"]
             args: ["-c", "/scripts/pre-restore.sh"]
             env:
-              - name: CLUSTER_NAME
-                value: staging-cluster
+              - name: INSTANCE_NAME
+                value: staging-standalone
               - name: DATABASE_NAME
                 value: app-data
         timeout: "10m"
@@ -1037,7 +1068,7 @@ spec:
             args: ["-c", "/scripts/validate-restore.sh"]
             env:
               - name: NEO4J_URI
-                value: "neo4j://staging-cluster:7687"
+                value: "neo4j://staging-standalone-service:7687"
               - name: NEO4J_PASSWORD
                 valueFrom:
                   secretKeyRef:
@@ -1060,10 +1091,13 @@ kubectl get neo4jbackups
 # Get detailed backup status
 kubectl describe neo4jbackup daily-backup
 
-# View backup history
+# View backup history — for SCHEDULED backups this is the authoritative record:
+# they stay in phase "Scheduled" (never "Completed") and don't set
+# status.lastSuccessTime; each run appends here instead.
 kubectl get neo4jbackup daily-backup -o jsonpath='{.status.history}'
 
-# Check backup job logs
+# Check backup job logs (one-shot: <name>-backup; scheduled runs: use the
+# history entry's runID, which is the Job name)
 kubectl logs job/daily-backup-backup
 ```
 

--- a/docs/user_guide/guides/seed-uri.md
+++ b/docs/user_guide/guides/seed-uri.md
@@ -77,13 +77,21 @@ spec:
 
 ### PVC-backed seeds
 
-When a seed source resolves to a backup stored on a PVC, the operator spawns a short-lived `backup-seed-proxy-<owner>` Deployment + Service that mounts the backup PVC read-only and serves the `.backup` files over HTTP. Neo4j then fetches each file via `URLConnectionSeedProvider` at the exact `.backup` filename. The proxy is owner-referenced to the consuming CR and garbage-collected when that CR is deleted.
+When a seed source resolves to a backup stored on a PVC, the operator spawns a short-lived `backup-seed-proxy-<owner>` Deployment + Service that mounts the backup PVC read-only and serves the `.backup` files over HTTP. Neo4j then fetches each file via `URLConnectionSeedProvider` at the exact `.backup` filename.
+
+Lifecycle and hardening:
+
+- A **NetworkPolicy** restricts the proxy's ingress to the target cluster's server pods (effective on enforcing CNIs; a no-op elsewhere).
+- The proxy stack (Deployment + Service + NetworkPolicy) is **torn down automatically as soon as the seed completes**: when a `Neo4jRestore` reaches `Completed`/`Failed`, or when the `Neo4jShardedDatabase` becomes `Ready`. It does not keep serving the backup PVC for the lifetime of the owning CR.
+- The proxy is also owner-referenced to the consuming CR, so deleting the CR removes any leftovers.
 
 ## Authentication Methods
 
 ### 1. System-Wide Authentication (Recommended)
 
-Use cloud-native authentication mechanisms that don't require explicit credentials:
+Use cloud-native authentication mechanisms that don't require explicit credentials.
+
+> **Where the identity must be bound:** `CREATE DATABASE … OPTIONS { seedURI }` runs inside the Neo4j JVM **on the server pods** — not in a backup/restore Job. Under pod identity (IRSA / GKE Workload Identity / Azure Workload Identity) the IAM binding therefore goes on the **server pods' ServiceAccount**, not on the `neo4j-backup-sa` used by backup Jobs (`Neo4jBackup`'s `cloud.identity.autoCreate.annotations` only annotates the Job SA and has no effect on seeding).
 
 **AWS S3:**
 
@@ -155,6 +163,7 @@ spec:
 
 - `AWS_SESSION_TOKEN` (for temporary credentials)
 - `AWS_REGION`
+- `AWS_ENDPOINT_URL_S3` — required for **MinIO / S3-compatible** stores. The `endpointURL`/`forcePathStyle` fields on `Neo4jBackup`/`Neo4jRestore` only affect their **Job pods**; the server pods doing seedURI fetches read the SDK's standard env vars, so put the endpoint in the Secret you project via `spec.extraEnvFrom`.
 
 ### Google Cloud Storage
 **Required:**

--- a/docs/user_guide/troubleshooting/backup_restore.md
+++ b/docs/user_guide/troubleshooting/backup_restore.md
@@ -14,25 +14,26 @@ kubectl get jobs -l app.kubernetes.io/component=backup
 
 **Diagnosis:**
 ```bash
-# Check backup resource status
+# Check backup resource status — status.phase tells you which stage it's in:
+#   Invalid   → spec failed validation (message has the details)
+#   Waiting   → target cluster missing or not Ready yet (transient)
+#   Pending   → transient precondition (chain parent missing, chain busy,
+#               sharded preflight couldn't connect) — retried automatically
+#   Failed    → terminal for one-shot backups
 kubectl get neo4jbackup
 kubectl describe neo4jbackup production-backup
 
 # Check operator logs for backup controller errors
 kubectl logs -n neo4j-operator-system deployment/neo4j-operator-controller-manager | grep -i backup
-
-# Verify RBAC permissions (default backup job service account)
-kubectl auth can-i create pods/exec --as=system:serviceaccount:<namespace>:neo4j-backup-sa
 ```
 
 **Common Causes & Solutions:**
 
-1. **Missing RBAC Permissions**:
+1. **Missing ServiceAccount**:
    ```bash
-# The operator automatically creates RBAC - check if it exists
+# The operator automatically creates the backup ServiceAccount — check it exists.
+# (No Role/RoleBinding is created: the backup Job needs no Kubernetes API access.)
 kubectl get serviceaccount neo4j-backup-sa
-kubectl get role neo4j-backup-role
-kubectl get rolebinding neo4j-backup-rolebinding
 
 # If missing, trigger operator reconciliation with a no-op annotation change
 kubectl annotate neo4jenterprisecluster production-cluster troubleshooting.neo4j.com/reconcile="$(date +%s)" --overwrite
@@ -80,7 +81,7 @@ kubectl logs <cluster>-server-0 -c neo4j | grep -i backup
    # `kubectl exec` into any server pod to inspect the bound PVC.
    kubectl exec <cluster>-server-0 -c neo4j -- df -h /data
    ```
-   Increase `Neo4jBackup.spec.storage.pvc.size` (only effective when the operator provisions the PVC — see [bring-your-own PVC](../guides/backup_restore.md#pvc-ownership-auto-provision-vs-bring-your-own) otherwise) or set `retention.maxCount` / `retention.maxAge` to prune old runs.
+   Increase `Neo4jBackup.spec.storage.pvc.size` (only effective when the operator provisions the PVC — see [bring-your-own PVC](../guides/backup_restore.md#pvc-ownership-auto-provision-vs-bring-your-own) otherwise). Note that `retention.maxCount` / `retention.maxAge` do **not** prune continuously — PVC retention runs only when the Neo4jBackup CR is deleted, so a long-lived scheduled CR accumulates artifacts until then. Prune manually (or via a recurring `neo4j-admin backup aggregate`) if the volume fills.
 
 2. **Database Lock Issues**:
    ```bash
@@ -92,7 +93,7 @@ kubectl logs <cluster>-server-0 -c neo4j | grep -i backup
    ```
 
 3. **Memory Issues in Backup Process**:
-   Backup pod resources are fixed by the operator. Prefer off-peak scheduling, smaller backup scope, or larger cluster nodes.
+   Backup pod resources default to a Burstable profile (request 100m CPU / 512Mi, limit 1 CPU / 2Gi) but **are tunable** via `spec.options.resources` (standard `requests`/`limits`). Raise them for large databases; `spec.options.pageCache` controls the page-cache hint passed to `neo4j-admin`.
 
 ### Cloud Storage Issues
 
@@ -111,15 +112,16 @@ kubectl run backup-auth-check --rm -it --image=amazon/aws-cli --serviceaccount=<
 
 1. **IAM Role Issues**:
    ```yaml
-   # Use IAM roles for service accounts (IRSA) on the Neo4jBackup CR
+   # Use IAM roles for service accounts (IRSA) on the Neo4jBackup CR.
+   # The annotations land on the operator-managed neo4j-backup-sa.
    apiVersion: neo4j.neo4j.com/v1beta1
    kind: Neo4jBackup
    spec:
      cloud:
        provider: aws
        identity:
+         provider: aws
          autoCreate:
-           enabled: true
            annotations:
              eks.amazonaws.com/role-arn: "arn:aws:iam::123456789:role/Neo4jBackupRole"
    ```
@@ -163,14 +165,15 @@ kubectl run backup-auth-check --rm -it --image=google/cloud-sdk:slim --serviceac
 **Solutions:**
 ```yaml
 # Use Workload Identity on the Neo4jBackup CR
+# (annotations land on the operator-managed neo4j-backup-sa)
 apiVersion: neo4j.neo4j.com/v1beta1
 kind: Neo4jBackup
 spec:
   cloud:
     provider: gcp
     identity:
+      provider: gcp
       autoCreate:
-        enabled: true
         annotations:
           iam.gke.io/gcp-service-account: "neo4j-backup@project.iam.gserviceaccount.com"
 ```
@@ -211,10 +214,10 @@ kubectl get neo4jbackup production-backup -o yaml | grep -A 10 schedule
    ```
 
 2. **Timezone Issues**:
+   Schedules run in **UTC** — there is no `spec.timezone` field, and `TZ=`/`CRON_TZ=` prefixes in the schedule string are **rejected by the validator** (Kubernetes refuses timezone-embedded CronJob schedules). Convert your local time to UTC:
    ```yaml
    spec:
-     schedule: "0 2 * * *"
-     timezone: "UTC"          # Explicitly set timezone
+     schedule: "0 2 * * *"    # 02:00 UTC — adjust the hour for your timezone
    ```
 
 3. **Backup Window Conflicts**:
@@ -246,9 +249,13 @@ kubectl logs -n neo4j-operator-system deployment/neo4j-operator-controller-manag
    # Verify backup exists
    kubectl get neo4jbackup production-backup
 
-   # Check backup completion status
+   # Check backup completion status. One-shot backups reach phase "Completed";
+   # scheduled backups stay in "Scheduled" — check status.history for a
+   # Succeeded run instead.
    kubectl get neo4jbackup production-backup -o jsonpath='{.status.phase}'
+   kubectl get neo4jbackup production-backup -o jsonpath='{.status.history[*].status}'
    ```
+   A restore whose referenced backup has no Succeeded run yet sits in `Pending` ("Waiting for backup to complete") and retries automatically — that is not an error.
 
 2. **Target Cluster Issues**:
    ```bash
@@ -453,24 +460,26 @@ kubectl top pod production-cluster-server-0
 
 ### Backup Health Monitoring
 
-**Prometheus Metrics:**
+**Prometheus Metrics** (exported by the operator):
 ```yaml
-# Monitor backup success rate
-neo4j_backup_success_total
-neo4j_backup_failure_total
-neo4j_backup_duration_seconds
+# Backup attempts, labelled by result ("success"/"failure")
+neo4j_operator_backup_total{cluster_name, namespace, result}
+# Backup duration histogram
+neo4j_operator_backup_duration_seconds{cluster_name, namespace}
+# Size of the latest backup in bytes
+neo4j_operator_backup_size_bytes{cluster_name, namespace}
 
 # Alert rules
 groups:
 - name: neo4j-backup
   rules:
   - alert: BackupFailure
-    expr: increase(neo4j_backup_failure_total[24h]) > 0
+    expr: increase(neo4j_operator_backup_total{result="failure"}[24h]) > 0
     labels:
       severity: critical
     annotations:
       summary: "Neo4j backup failed"
-      description: "Backup for cluster {{ $labels.cluster }} failed"
+      description: "Backup for cluster {{ $labels.cluster_name }} failed"
 ```
 
 **Log Monitoring:**
@@ -498,18 +507,26 @@ BACKUP_NAME="production-backup"
 NAMESPACE="default"
 
 validate_backup() {
+  # One-shot backups reach phase "Completed". Scheduled backups stay in
+  # "Scheduled" forever — check status.history for a Succeeded run instead.
   local backup_status=$(kubectl get neo4jbackup $BACKUP_NAME -n $NAMESPACE -o jsonpath='{.status.phase}')
 
-  if [ "$backup_status" != "Succeeded" ]; then
+  if [ "$backup_status" = "Scheduled" ]; then
+    local last_run=$(kubectl get neo4jbackup $BACKUP_NAME -n $NAMESPACE \
+      -o jsonpath='{.status.history[-1].status}')
+    if [ "$last_run" != "Succeeded" ]; then
+      echo "❌ Last scheduled run not successful: ${last_run:-no runs yet}"
+      return 1
+    fi
+  elif [ "$backup_status" != "Completed" ]; then
     echo "❌ Backup failed or incomplete: $backup_status"
     return 1
   fi
 
-  # Check backup size
-  local backup_size=$(kubectl get neo4jbackup $BACKUP_NAME -n $NAMESPACE -o jsonpath='{.status.backupSize}')
-  if [ "$backup_size" -lt 1000000 ]; then  # Less than 1MB
-    echo "⚠️  Backup size suspiciously small: $backup_size bytes"
-  fi
+  # Check backup size (human-readable string such as "2.5GB", parsed by
+  # neo4j-admin output; empty if the Pod log couldn't be read)
+  local backup_size=$(kubectl get neo4jbackup $BACKUP_NAME -n $NAMESPACE -o jsonpath='{.status.stats.size}')
+  echo "ℹ️  Latest backup size: ${backup_size:-unknown}"
 
   echo "✅ Backup validation passed"
   return 0

--- a/examples/backup-restore/README.md
+++ b/examples/backup-restore/README.md
@@ -27,7 +27,7 @@ kubectl apply -f backup-pvc-simple.yaml
 kubectl get neo4jbackup simple-backup -w
 ```
 
-**🎯 Success:** Status shows `Completed` with `BackupSuccessful` condition.
+**🎯 Success:** Status shows phase `Completed`, with the `Ready` condition `True` (reason `BackupSucceeded`). Note this applies to **one-shot** backups only — scheduled backups stay in phase `Scheduled` and record their runs in `status.history[]` instead.
 
 ### Choose Your Path:
 - **🟢 New to backups?** Continue with [PVC examples](#basic-backups) below
@@ -58,10 +58,8 @@ kubectl get neo4jbackup simple-backup -w
 
 ### 1. PVC Backup Example
 ```bash
-# Create storage class if needed
-kubectl apply -f storage-class-fast.yaml
-
-# Run PVC backup
+# Run PVC backup (the operator provisions the PVC using your cluster's
+# default StorageClass — see the comments in the example to pin one)
 kubectl apply -f backup-pvc-simple.yaml
 
 # Monitor progress
@@ -71,10 +69,12 @@ kubectl describe neo4jbackup simple-backup
 
 ### 2. S3 Backup Example
 ```bash
-# Create AWS credentials secret
-kubectl create secret generic aws-credentials \
+# Create AWS credentials secret — all three keys are required (the backup Job
+# reads AWS_REGION as a non-optional env var)
+kubectl create secret generic aws-backup-credentials \
   --from-literal=AWS_ACCESS_KEY_ID=your-access-key \
-  --from-literal=AWS_SECRET_ACCESS_KEY=your-secret-key
+  --from-literal=AWS_SECRET_ACCESS_KEY=your-secret-key \
+  --from-literal=AWS_REGION=us-east-1
 
 # Run S3 backup
 kubectl apply -f backup-s3-basic.yaml
@@ -100,8 +100,14 @@ kubectl get neo4jbackup daily-backup -o jsonpath='{.status.history}'
 # Set up complete PITR environment
 kubectl apply -f pitr-setup-complete.yaml
 
-# Wait for base backup to complete
-kubectl wait --for=condition=Ready neo4jbackup/pitr-base-backup --timeout=600s
+# Wait for the first scheduled run to succeed. Do NOT use
+# `kubectl wait --for=condition=Ready` here — scheduled backups never leave
+# phase Scheduled (only one-shot backups reach Completed/Ready), so that wait
+# hangs forever. Poll status.history instead:
+until kubectl get neo4jbackup pitr-base-backup \
+    -o jsonpath='{.status.history[*].status}' | grep -q Succeeded; do
+  sleep 10
+done
 
 # Perform PITR restore
 kubectl apply -f restore-pitr-basic.yaml
@@ -113,22 +119,42 @@ kubectl get neo4jrestore pitr-restore -w
 ## Storage Configuration
 
 ### AWS S3
-```bash
-# Using IAM roles (recommended)
-kubectl annotate serviceaccount neo4j-operator \
-  eks.amazonaws.com/role-arn=arn:aws:iam::ACCOUNT:role/neo4j-backup-role
 
-# Using access keys
-kubectl create secret generic aws-credentials \
+**Using IAM roles / IRSA (recommended).** Backup and restore Jobs run as the
+operator-managed `neo4j-backup-sa` / `neo4j-restore-sa` ServiceAccounts — *not*
+the operator's own SA. Don't `kubectl annotate` anything manually; declare the
+role binding in the backup spec and the operator applies it to `neo4j-backup-sa`
+on every reconcile:
+
+```yaml
+spec:
+  storage:
+    type: s3
+    bucket: my-neo4j-backups
+    cloud:
+      provider: aws
+      identity:
+        provider: aws
+        autoCreate:
+          annotations:
+            eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT:role/neo4j-backup-role
+```
+
+```bash
+# Using access keys (all three keys required)
+kubectl create secret generic aws-backup-credentials \
   --from-literal=AWS_ACCESS_KEY_ID=your-key \
-  --from-literal=AWS_SECRET_ACCESS_KEY=your-secret
+  --from-literal=AWS_SECRET_ACCESS_KEY=your-secret \
+  --from-literal=AWS_REGION=us-east-1
 ```
 
 ### Google Cloud Storage
 ```bash
-# Create service account key secret
+# Create service account key secret — the key MUST be named
+# GOOGLE_APPLICATION_CREDENTIALS_JSON and contain the JSON as a string value
+# (not a file path):
 kubectl create secret generic gcs-credentials \
-  --from-file=service-account.json=path/to/service-account.json
+  --from-literal=GOOGLE_APPLICATION_CREDENTIALS_JSON="$(cat path/to/service-account.json)"
 ```
 
 ### Azure Blob Storage
@@ -205,7 +231,7 @@ az storage blob delete-batch --source your-container --pattern "neo4j-backups/*"
 
 1. **Test Regularly**: Test backup and restore procedures in non-production environments
 2. **Monitor Storage**: Set up monitoring for storage usage and backup completion
-3. **Verify Backups**: Enable backup verification to ensure data integrity
+3. **Validate Backups**: Set `spec.options.validate: true` to run `neo4j-admin backup validate` after each backup (result recorded on `status.history[].validation`)
 4. **Secure Credentials**: Use proper secret management for cloud credentials
 5. **Plan Retention**: Implement appropriate retention policies for your use case
 6. **Document Procedures**: Document your backup and restore procedures
@@ -214,7 +240,7 @@ az storage blob delete-batch --source your-container --pattern "neo4j-backups/*"
 ## Troubleshooting
 
 For detailed troubleshooting information, see:
-- [Backup and Restore Troubleshooting Guide](../../docs/user_guide/guides/troubleshooting_backup_restore.md)
+- [Backup and Restore Troubleshooting Guide](../../docs/user_guide/troubleshooting/backup_restore.md)
 - [Backup and Restore User Guide](../../docs/user_guide/guides/backup_restore.md)
 
 ## Support

--- a/examples/backup-restore/backup-incremental.yaml
+++ b/examples/backup-restore/backup-incremental.yaml
@@ -37,7 +37,7 @@ spec:
     path: incremental/orders      # Path/prefix within the bucket
     cloud:
       provider: aws
-      credentialsSecretRef: aws-backup-credentials  # Secret with AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
+      credentialsSecretRef: aws-backup-credentials  # Secret with AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_REGION
   retention:
     maxAge: "3d"
     maxCount: 12  # Keep last 12 incremental backups

--- a/examples/backup-restore/backup-s3-basic.yaml
+++ b/examples/backup-restore/backup-s3-basic.yaml
@@ -2,10 +2,13 @@
 # S3 Backup — Variant 1: Explicit AWS credentials via Secret
 # ============================================================
 #
-# Create the AWS credentials secret first:
+# Create the AWS credentials secret first (all three keys are required —
+# the backup Job reads AWS_REGION as a non-optional env var, so omitting it
+# fails the pod with CreateContainerConfigError):
 #   kubectl create secret generic aws-backup-credentials \
 #     --from-literal=AWS_ACCESS_KEY_ID=<your-access-key-id> \
-#     --from-literal=AWS_SECRET_ACCESS_KEY=<your-secret-access-key>
+#     --from-literal=AWS_SECRET_ACCESS_KEY=<your-secret-access-key> \
+#     --from-literal=AWS_REGION=us-east-1
 #
 apiVersion: neo4j.neo4j.com/v1beta1
 kind: Neo4jBackup
@@ -24,7 +27,7 @@ spec:
     path: cluster-backups              # Path/prefix within the bucket
     cloud:
       provider: aws
-      credentialsSecretRef: aws-backup-credentials  # Secret with AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
+      credentialsSecretRef: aws-backup-credentials  # Secret with AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_REGION
   options:
     compress: true
     backupType: FULL
@@ -41,8 +44,11 @@ spec:
 #
 #   kubectl create secret generic aws-backup-credentials \
 #     --from-literal=AWS_ACCESS_KEY_ID='<your-access-key-id>' \
-#     --from-literal=AWS_SECRET_ACCESS_KEY='<your-secret-access-key>'
+#     --from-literal=AWS_SECRET_ACCESS_KEY='<your-secret-access-key>' \
+#     --from-literal=AWS_REGION='us-east-1'
 #
+# AWS_REGION is required: the backup Job reads it from this Secret (the operator
+# wires it as a non-optional env var), so omit it and the Job pod won't start.
 # Referenced via spec.storage.cloud.credentialsSecretRef: aws-backup-credentials
 
 ---

--- a/examples/backup-restore/backup-scheduled-daily.yaml
+++ b/examples/backup-restore/backup-scheduled-daily.yaml
@@ -1,10 +1,13 @@
 # ============================================================
 # Scheduled Daily Backup to S3 — explicit credentials
 #
-# Create the AWS credentials secret first:
+# Create the AWS credentials secret first (all three keys are required —
+# the backup Job reads AWS_REGION as a non-optional env var, so omitting it
+# fails the pod with CreateContainerConfigError):
 #   kubectl create secret generic aws-backup-credentials \
 #     --from-literal=AWS_ACCESS_KEY_ID=<your-access-key-id> \
-#     --from-literal=AWS_SECRET_ACCESS_KEY=<your-secret-access-key>
+#     --from-literal=AWS_SECRET_ACCESS_KEY=<your-secret-access-key> \
+#     --from-literal=AWS_REGION=us-east-1
 # ============================================================
 apiVersion: neo4j.neo4j.com/v1beta1
 kind: Neo4jBackup
@@ -26,7 +29,10 @@ spec:
     path: daily-backups
     cloud:
       provider: aws
-      credentialsSecretRef: aws-backup-credentials  # Secret with AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
+      credentialsSecretRef: aws-backup-credentials  # Secret with AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_REGION
+  # NOTE: for cloud storage (s3/gcs/azure) the operator does NOT prune objects —
+  # configure bucket lifecycle rules instead. retention is applied only for
+  # type=pvc storage, and only when the Neo4jBackup CR is deleted.
   retention:
     maxAge: "7d"
     maxCount: 7
@@ -34,7 +40,9 @@ spec:
     compress: true
     backupType: AUTO   # FULL on first run, DIFF afterwards
     tempPath: /tmp/neo4j-backup-temp
-  # Set suspend: true to temporarily pause this scheduled backup
+  # Set suspend: true to temporarily pause this scheduled backup. The operator
+  # propagates it to the underlying CronJob (no scheduled Jobs fire while
+  # suspended); removing spec.schedule entirely deletes the CronJob.
   suspend: false
 
 # ── AWS backup credentials Secret (create this BEFORE you apply this manifest) ─
@@ -44,8 +52,11 @@ spec:
 #
 #   kubectl create secret generic aws-backup-credentials \
 #     --from-literal=AWS_ACCESS_KEY_ID='<your-access-key-id>' \
-#     --from-literal=AWS_SECRET_ACCESS_KEY='<your-secret-access-key>'
+#     --from-literal=AWS_SECRET_ACCESS_KEY='<your-secret-access-key>' \
+#     --from-literal=AWS_REGION='us-east-1'
 #
+# AWS_REGION is required: the backup Job reads it from this Secret (the operator
+# wires it as a non-optional env var), so omit it and the Job pod won't start.
 # Referenced via spec.storage.cloud.credentialsSecretRef: aws-backup-credentials
 
 ---

--- a/examples/backup-restore/pitr-setup-complete.yaml
+++ b/examples/backup-restore/pitr-setup-complete.yaml
@@ -33,13 +33,18 @@ spec:
     cloud:
       provider: aws
       credentialsSecretRef: pitr-aws-credentials
+  # NOTE: for cloud storage (s3) the operator does NOT prune objects — these
+  # retention settings are advisory; configure S3 lifecycle rules instead.
   retention:
     maxAge: "30d"
     maxCount: 30
     deletePolicy: Delete
   options:
     compress: true
-    verify: true
+    # validate runs `neo4j-admin backup validate` after the backup and records
+    # the result on status.history[].validation. (options.verify is a RESERVED
+    # no-op — don't use it.)
+    validate: true
     # Include users/roles metadata in the backup (all|none|users|roles).
     includeMetadata: all
     # Multi-threaded transaction application during backup.
@@ -98,8 +103,10 @@ spec:
         cloud:
           provider: aws
   options:
-    verifyBackup: true
     replaceExisting: true
+    # Hooks run only on standalone targets (this example). preRestore Cypher
+    # hooks run BEFORE the instance is stopped; postRestore hooks run AFTER
+    # the restored database is registered/started.
     preRestore:
       cypherStatements:
         - "CALL db.checkpoint()"
@@ -136,9 +143,13 @@ spec:
               - "-c"
               - |
                 echo "=== PITR Post-Restore Validation ==="
-                cypher-shell -u neo4j -p $NEO4J_PASSWORD -d production-db \
+                # -a points cypher-shell at the standalone's service — the hook
+                # Job runs in its own pod, so omitting it dials localhost.
+                cypher-shell -a neo4j://recovery-standalone-service:7687 \
+                  -u neo4j -p "$NEO4J_PASSWORD" -d production-db \
                   "CALL db.ping() YIELD success RETURN success"
-                cypher-shell -u neo4j -p $NEO4J_PASSWORD -d production-db \
+                cypher-shell -a neo4j://recovery-standalone-service:7687 \
+                  -u neo4j -p "$NEO4J_PASSWORD" -d production-db \
                   "MATCH (n) RETURN labels(n)[0] as label, count(n) as count ORDER BY label"
                 echo "PITR validation completed successfully"
             env:
@@ -163,43 +174,19 @@ spec:
 #
 # Referenced via the postRestore job's NEO4J_PASSWORD secretKeyRef.
 
----
-# Service account for PITR operations with appropriate permissions
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: pitr-service-account
-  annotations:
-    # AWS IAM role for S3 access (if using IAM roles instead of access keys)
-    eks.amazonaws.com/role-arn: arn:aws:iam::YOUR-ACCOUNT:role/neo4j-pitr-role
-
----
-# RBAC for PITR operations
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: pitr-operator-role
-rules:
-  - apiGroups: ["neo4j.neo4j.com"]
-    resources: ["neo4jbackups", "neo4jrestores", "neo4jenterpriseclusters"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  - apiGroups: ["batch"]
-    resources: ["jobs", "cronjobs"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  - apiGroups: [""]
-    resources: ["secrets", "configmaps", "persistentvolumeclaims"]
-    verbs: ["get", "list", "watch"]
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: pitr-operator-binding
-subjects:
-  - kind: ServiceAccount
-    name: pitr-service-account
-    namespace: default
-roleRef:
-  kind: ClusterRole
-  name: pitr-operator-role
-  apiGroup: rbac.authorization.k8s.io
+# ── No extra ServiceAccount or RBAC is needed ──────────────────────────────────
+# The operator runs backup Jobs as the operator-managed `neo4j-backup-sa` and
+# restore Jobs as `neo4j-restore-sa` (both auto-created in the CR's namespace;
+# they need no Kubernetes API access, so no Role/RoleBinding is created).
+# To use IAM roles (IRSA) instead of the static-credentials Secret above,
+# bind the role on the operator-managed SA via the Neo4jBackup spec:
+#
+#   spec:
+#     storage:
+#       cloud:
+#         provider: aws
+#         identity:
+#           provider: aws
+#           autoCreate:
+#             annotations:
+#               eks.amazonaws.com/role-arn: arn:aws:iam::YOUR-ACCOUNT:role/neo4j-pitr-role

--- a/examples/backup-restore/restore-from-backup.yaml
+++ b/examples/backup-restore/restore-from-backup.yaml
@@ -1,3 +1,13 @@
+# ============================================================
+# Restore from a Neo4jBackup reference.
+#
+# NOTE on hooks: spec.options.{preRestore,postRestore} hooks run ONLY when
+# clusterRef targets a Neo4jEnterpriseStandalone (the Job-based restore path).
+# Cluster targets restore via Cypher (seedURI) and never invoke hooks.
+#   - preRestore Cypher hooks run BEFORE the instance is stopped
+#     (so statements like CALL db.checkpoint() hit a live Bolt endpoint).
+#   - postRestore hooks run AFTER the restored database is registered/started.
+# ============================================================
 apiVersion: neo4j.neo4j.com/v1beta1
 kind: Neo4jRestore
 metadata:
@@ -6,27 +16,30 @@ metadata:
     environment: development
     restore-type: backup-reference
 spec:
-  clusterRef: single-node-cluster
+  clusterRef: single-node-standalone   # Neo4jEnterpriseStandalone (hooks are standalone-only)
   databaseName: neo4j
   source:
     type: backup
     backupRef: simple-backup  # Reference to the backup resource
   options:
-    verifyBackup: true
     replaceExisting: true
     preRestore:
       cypherStatements:
-        - "CALL dbms.backup.prepare()"
+        - "CALL db.checkpoint()"   # flush pending writes before the instance stops
     postRestore:
       cypherStatements:
         - "CALL db.awaitIndexes()"
         - "CALL dbms.security.clearAuthCache()"
   force: false
+  # stopCluster: true scales the standalone down for an offline restore and
+  # brings it back up afterwards. With stopCluster: false the operator REFUSES
+  # to restore while server pods are running (it never writes into a live PVC).
   stopCluster: true
   timeout: "1h"
 
 ---
-# More complex restore with job hooks
+# More complex restore with job hooks (standalone target — job hooks, like all
+# hooks, only run on the standalone Job-based restore path).
 apiVersion: neo4j.neo4j.com/v1beta1
 kind: Neo4jRestore
 metadata:
@@ -35,13 +48,12 @@ metadata:
     environment: staging
     restore-type: with-hooks
 spec:
-  clusterRef: staging-cluster
+  clusterRef: staging-standalone   # Neo4jEnterpriseStandalone
   databaseName: myapp
   source:
     type: backup
     backupRef: daily-backup
   options:
-    verifyBackup: true
     replaceExisting: true
     postRestore:
       job:
@@ -53,7 +65,11 @@ spec:
               - "-c"
               - |
                 echo "Validating restored database..."
-                cypher-shell -u neo4j -p $NEO4J_PASSWORD -d myapp \
+                # -a is required: the hook Job runs in its own pod, so
+                # cypher-shell must be pointed at the instance's service
+                # (<standalone-name>-service) — without it, it dials localhost.
+                cypher-shell -a neo4j://staging-standalone-service:7687 \
+                  -u neo4j -p "$NEO4J_PASSWORD" -d myapp \
                   "MATCH (n) RETURN count(n) as nodeCount"
                 echo "Database validation completed"
             env:

--- a/examples/backup-restore/restore-overwrite.yaml
+++ b/examples/backup-restore/restore-overwrite.yaml
@@ -1,14 +1,19 @@
 # ============================================================
 # Destructive restore: overwrite an EXISTING database from a backup.
 #
-#   - force: true            overwrites the existing database (drop + recreate)
-#   - replaceExisting: true  replace rather than fail if the database exists
+#   - force: true            confirms overwriting the existing database
+#   - replaceExisting: true  equivalent option-level confirmation
 #   - source.type: backup    pulls from a Neo4jBackup CR's latest successful run
 #
+# On a CLUSTER target the operator restores via Cypher
+# (dbms.recreateDatabase with a seedURI — no Job, no downtime for other
+# databases). Restoring over an EXISTING database REQUIRES force: true or
+# options.replaceExisting: true — without either the restore fails with an
+# actionable message instead of silently wiping the database.
+#
+# Hooks (spec.options.{preRestore,postRestore}) run ONLY on standalone
+# targets (the Job-based path) — they are intentionally absent here.
 # For point-in-time recovery, see restore-pitr-basic.yaml.
-# Hooks live under spec.options.{preRestore,postRestore} and accept either
-# `cypherStatements:` (run via Bolt) or a `job:` template — there is no
-# free-form `type: script` hook.
 # ============================================================
 apiVersion: neo4j.neo4j.com/v1beta1
 kind: Neo4jRestore
@@ -18,17 +23,15 @@ metadata:
 spec:
   clusterRef: my-neo4j-cluster
   databaseName: orders
-  # Force restore over an existing database
+  # Confirm the destructive overwrite of the existing database
   force: true
   source:
     type: backup
     backupRef: full-backup
   options:
-    # Verify the backup before applying it
-    verifyBackup: true
     # Replace the existing database rather than failing if it exists
     replaceExisting: true
-    postRestore:
-      cypherStatements:
-        - "CALL db.awaitIndexes()"
-        - "CALL dbms.security.clearAuthCache()"
+  # spec.timeout bounds how long the operator waits for the re-seeded
+  # database to converge online across the cluster (default 5m — raise it
+  # for multi-GB stores seeded from object storage).
+  timeout: "30m"

--- a/examples/backup-restore/restore-pitr-basic.yaml
+++ b/examples/backup-restore/restore-pitr-basic.yaml
@@ -37,8 +37,10 @@ spec:
         cloud:
           provider: aws
   options:
-    verifyBackup: true
     replaceExisting: true
+    # Hooks run only on standalone targets (this example). preRestore Cypher
+    # hooks run BEFORE the instance is stopped; postRestore hooks run AFTER
+    # the restored database is registered/started.
     preRestore:
       cypherStatements:
         - "CALL db.checkpoint()"
@@ -85,7 +87,6 @@ spec:
         cloud:
           provider: aws
   options:
-    verifyBackup: true
     replaceExisting: true
     preRestore:
       job:
@@ -117,7 +118,10 @@ spec:
               - "-c"
               - |
                 echo "Running post-restore validation..."
-                cypher-shell -u neo4j -p $NEO4J_PASSWORD -d critical-app \
+                # -a points cypher-shell at the standalone's service — the hook
+                # Job runs in its own pod, so omitting it dials localhost.
+                cypher-shell -a neo4j://dr-standalone-service:7687 \
+                  -u neo4j -p "$NEO4J_PASSWORD" -d critical-app \
                   "MATCH (n) RETURN labels(n)[0] as label, count(n) as count ORDER BY label"
                 echo "Validation completed successfully"
             env:


### PR DESCRIPTION
Fourth PR of the audit burndown — the #221 docs sweep. **Stacked on #225 (Wave 3)**; base is `fix/backup-restore-wave3`. 13 files changed; every claim verified against the controller/validator code on this branch (including the wave 1–3 behavior changes).

## Highlights
- **Copy-paste fixes**: `AWS_REGION` added to every S3 secret-creation block (missing key = `CreateContainerConfigError`); nonexistent `CALL dbms.backup.prepare()` replaced with `CALL db.checkpoint()`; job-hook cypher-shell invocations get `-a <address>`; `kubectl wait` on scheduled backups (hangs forever) replaced with history polling; GCS secret key corrected to `GOOGLE_APPLICATION_CREDENTIALS_JSON`; IAM annotations corrected to `cloud.identity.autoCreate.annotations` (not `kubectl annotate` of the operator SA).
- **Reserved no-ops truth-marked** everywhere: `options.verify`/`verifyBackup` (→ `options.validate`), `deletePolicy: Archive`, `identity.serviceAccount`, `autoCreate.enabled`.
- **Restore docs match rule 75/76 reality**: cluster examples use file-exact `.backup` paths; standalone examples use `stopCluster: true` (live-pods refusal documented); legacy cluster-Job sections rescoped; `spec.timeout` (now wired), `status.resolvedSource`, the force/replaceExisting gate, hooks (standalone-only, pre-before-stop / post-after-registration) and fresh-attempt retry semantics all documented.
- **Backup docs**: runID = Job NAME; full phase table incl. the new transient routing (Waiting/Pending); suspend now real; schedule-removal deletes the CronJob; maxAge units; charset validation; scheduled backups never reach Completed (history[] is the record).
- **Retention**: file-level chain-scoped pruning semantics, deletion-time-only on PVC, Archive no-op, DIFF-orphan caveat + `BackupRetentionCaveat` event — overpromises removed.
- **Pod identity (IRSA / Workload Identity / Managed Identity) is now the recommended cloud auth**, with a which-SA-needs-the-binding table: Job paths → `neo4j-backup-sa`/`neo4j-restore-sa`; cluster Cypher restore / seedURI / sharded seeding → the **server pods'** SA (or static creds via `spec.extraEnvFrom`). MinIO guidance fixed: `endpointURL`/`forcePathStyle` are Job-pod-only; server-pod seeding needs `AWS_ENDPOINT_URL_S3` in the projected Secret (exactly the setup used in the live verification).
- **Seed-proxy lifecycle** (NetworkPolicy + auto-teardown) and **cluster-wide backup** (`kind: Cluster` = `"*"`; restore is single-DB, #222 linked) documented; the manual `restore_metadata.cypher` step (users/roles) documented with a runnable command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example YAML/comments only; no controller or CRD logic changes in this diff.
> 
> **Overview**
> This PR is a **documentation-only truth sweep** for backup/restore (#221): API reference, user guides, troubleshooting, seed-uri notes, and `examples/backup-restore/` are rewritten to match current controller behavior (stacked on wave 3).
> 
> **Neo4jBackup docs** now spell out real retention (cloud = lifecycle rules only; PVC prune on CR delete; DIFF orphan caveat), scheduled vs one-shot phases (`Scheduled` never `Completed`; poll `status.history`), `runID` as Job **name**, cron/`suspend`/schedule-removal semantics, charset validation, and reserved no-ops (`verify`, `Archive`, `autoCreate.enabled`). Examples drop misleading `enabled: true` on IRSA and swap `verify` → `validate`.
> 
> **Neo4jRestore docs** split **cluster (Cypher seedURI)** vs **standalone (Job)** paths: `force`/`replaceExisting` gate on recreate, `timeout` for convergence, `status.resolvedSource`, PVC seed-proxy + NetworkPolicy + teardown, hooks standalone-only with correct ordering, `stopCluster` refusal while pods run, retry via spec generation bump, and rescoped legacy cluster Job/re-seed narrative.
> 
> **Cross-cutting fixes**: pod-identity **which SA** table (Job SA vs server pods for seedURI); MinIO `endpointURL` Job-only vs `AWS_ENDPOINT_URL_S3` on server pods; `AWS_REGION` on all S3 secret snippets; GCS `GOOGLE_APPLICATION_CREDENTIALS_JSON`; no backup Role/RBAC; corrected Prometheus metric names; PITR/scheduled wait patterns; hook `cypher-shell -a` addresses; removed bogus `dbms.backup.prepare()` and example ClusterRole/SAs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cfa1fac1f43cc08226f59bd3d46dd0ddc92f496. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->