### PR TITLE
fix(standalone): unify client-facing Service naming on {name}-client (#215)

### DIFF
--- a/docs/api_reference/neo4jenterprisecluster.md
+++ b/docs/api_reference/neo4jenterprisecluster.md
@@ -767,9 +767,9 @@ The `Neo4jEnterpriseClusterStatus` represents the observed state of the cluster.
 
 Service endpoints and connection information populated by the controller on
 every status update. Schema is shared between `Neo4jEnterpriseCluster` and
-`Neo4jEnterpriseStandalone`; the cluster controller resolves URLs against
-the `{cluster}-client` ClusterIP, the standalone controller against the
-`{name}-service` ClusterIP.
+`Neo4jEnterpriseStandalone`; both controllers resolve URLs against the
+`{name}-client` ClusterIP (the legacy standalone `{name}-service` name remains
+as a deprecated alias for one release).
 
 | Field | Type | Description |
 |---|---|---|

--- a/docs/api_reference/neo4jenterprisestandalone.md
+++ b/docs/api_reference/neo4jenterprisestandalone.md
@@ -419,14 +419,16 @@ Detailed conditions about the deployment state.
 #### `endpoints` (EndpointStatus)
 Connection endpoints for the Neo4j instance. The bolt scheme reflects the TLS configuration: `bolt+s://` when TLS is enabled, `bolt://` when disabled. `connectionExamples` is populated from `spec.service.type` and the LoadBalancer-assigned external IP (when applicable).
 
+Endpoints are resolved against the `{name}-client` Service. Connection strings saved against the legacy `{name}-service` name still resolve this release (it remains as a deprecated ClusterIP-only alias) but will stop working next release — update them to `{name}-client`.
+
 ```yaml
 # TLS disabled, ClusterIP
 endpoints:
-  bolt: "bolt://standalone-neo4j-service.default.svc.cluster.local:7687"
-  http: "http://standalone-neo4j-service.default.svc.cluster.local:7474"
-  https: "https://standalone-neo4j-service.default.svc.cluster.local:7473"
+  bolt: "bolt://standalone-neo4j-client.default.svc.cluster.local:7687"
+  http: "http://standalone-neo4j-client.default.svc.cluster.local:7474"
+  https: "https://standalone-neo4j-client.default.svc.cluster.local:7473"
   connectionExamples:
-    portForward: "kubectl port-forward -n default svc/standalone-neo4j-service 7474:7474 7687:7687"
+    portForward: "kubectl port-forward -n default svc/standalone-neo4j-client 7474:7474 7687:7687"
     browserURL: "http://localhost:7474"
     boltURI: "bolt://localhost:7687"
     neo4jURI: "neo4j://localhost:7687"
@@ -440,11 +442,11 @@ endpoints:
 # TLS enabled (cert-manager) — connection examples use bolt+ssc:// since
 # cert-manager-issued certs are typically not trusted by external clients.
 endpoints:
-  bolt: "bolt+s://standalone-neo4j-service.default.svc.cluster.local:7687"
-  http: "http://standalone-neo4j-service.default.svc.cluster.local:7474"
-  https: "https://standalone-neo4j-service.default.svc.cluster.local:7473"
+  bolt: "bolt+s://standalone-neo4j-client.default.svc.cluster.local:7687"
+  http: "http://standalone-neo4j-client.default.svc.cluster.local:7474"
+  https: "https://standalone-neo4j-client.default.svc.cluster.local:7473"
   connectionExamples:
-    portForward: "kubectl port-forward -n default svc/standalone-neo4j-service 7473:7473 7687:7687"
+    portForward: "kubectl port-forward -n default svc/standalone-neo4j-client 7473:7473 7687:7687"
     browserURL: "https://localhost:7473"
     boltURI: "bolt+ssc://localhost:7687"
     neo4jURI: "neo4j+ssc://localhost:7687"
@@ -753,7 +755,7 @@ kubectl describe neo4jenterprisestandalone dev-neo4j
 kubectl logs -l app=dev-neo4j
 
 # Port forward for local access
-kubectl port-forward svc/dev-neo4j-service 7474:7474 7687:7687
+kubectl port-forward svc/dev-neo4j-client 7474:7474 7687:7687
 ```
 
 ### Scaling and Updates

--- a/docs/api_reference/neo4jrestore.md
+++ b/docs/api_reference/neo4jrestore.md
@@ -178,7 +178,7 @@ Hooks to run before or after the restore Job. **Hooks run only for `Neo4jEnterpr
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `job` | [`RestoreHookJob`](#restorehookjob) | ❌ | Kubernetes Job to run as a hook. The hook Job runs in its own pod — commands like `cypher-shell` must be pointed at the instance's service explicitly (e.g. `cypher-shell -a neo4j://<standalone>-service:7687 …`), otherwise they dial localhost inside the hook pod. |
+| `job` | [`RestoreHookJob`](#restorehookjob) | ❌ | Kubernetes Job to run as a hook. The hook Job runs in its own pod — commands like `cypher-shell` must be pointed at the instance's service explicitly (e.g. `cypher-shell -a neo4j://<standalone>-client:7687 …`), otherwise they dial localhost inside the hook pod. |
 | `cypherStatements` | `[]string` | ❌ | Cypher statements the operator executes over Bolt against the standalone instance (pre-restore: before the instance is stopped; post-restore: after the database is registered/started) |
 
 ### RestoreHookJob

--- a/docs/user_guide/external_access.md
+++ b/docs/user_guide/external_access.md
@@ -20,17 +20,32 @@ and standalone.
 
 | Service | `Neo4jEnterpriseCluster` | `Neo4jEnterpriseStandalone` | Ports |
 |---|---|---|---|
-| Client-facing (your apps connect here) | `{name}-client` | `{name}-service` | `bolt 7687`, `http 7474`, `https 7473` (TLS); standalone also exposes `metrics 2004` here when monitoring is on |
+| Client-facing (your apps connect here) | `{name}-client` | `{name}-client` | `bolt 7687`, `http 7474`, `https 7473` (TLS); standalone also exposes `metrics 2004` here when monitoring is on |
+| Deprecated alias (standalone only, removed next release) | — | `{name}-service` | same client ports, ClusterIP only |
 | Headless (stable per-pod DNS) | `{name}-headless` | `{name}-headless` | `bolt 7687`, `http 7474`, `backup 6362`, `https 7473` (TLS) |
 | Discovery / internals (cluster only) | `{name}-discovery`, `{name}-internals` | — | clustering ports (`6000/7000/7688/7689`) |
 | Metrics (cluster only; standalone folds metrics into its client service) | `{name}-metrics` (`2004`) | — | `2004` |
 
 Notes:
 
-- **Client-service name differs by kind** (`-client` for clusters, `-service`
-  for standalone). This is intentional and load-bearing — use the right name
-  for the kind you deployed. A pod's stable address is always
+- **The client-facing Service is `{name}-client` for both kinds.** Standalone
+  deployments previously used `{name}-service`; that name still resolves for
+  **one more release** as a deprecated ClusterIP-only alias (annotated
+  `neo4j.com/deprecated-alias-of`) and will then be removed — update any saved
+  connection strings, NetworkPolicies, and dashboards to `{name}-client` now.
+  A pod's stable address is always
   `{name}-0.{name}-headless.<namespace>.svc.cluster.local`.
+- **External exposure moves to `{name}-client` on upgrade**: `spec.service`
+  settings (`type: LoadBalancer` / `NodePort`, annotations,
+  `loadBalancerSourceRanges`) are now applied to the standalone `{name}-client`
+  Service, not the alias. A pre-existing LoadBalancer external IP therefore
+  **re-provisions once** when you upgrade — expect a new external IP/hostname
+  and update DNS accordingly.
+- **One-time TLS pod restart**: with `spec.tls` enabled, the issued certificate
+  now carries SANs for both the `{name}-client` and legacy `{name}-service`
+  names. After the certificate is re-issued on upgrade, the operator
+  automatically restarts the standalone pod once so the running server presents
+  the new SANs.
 - **The standalone headless service exposes `bolt`/`http`/`backup` (and `https`
   under TLS)** for direct per-pod addressing, mirroring the cluster headless
   service. It does **not** expose the clustering ports (`6000/7000/7688/7689`):
@@ -47,7 +62,7 @@ The fastest way to access Neo4j during development:
 kubectl port-forward svc/my-cluster-client 7474:7474 7687:7687
 
 # For Neo4jEnterpriseStandalone
-kubectl port-forward svc/my-standalone-service 7474:7474 7687:7687
+kubectl port-forward svc/my-standalone-client 7474:7474 7687:7687
 ```
 
 Access Neo4j Browser at: http://localhost:7474

--- a/docs/user_guide/getting_started.md
+++ b/docs/user_guide/getting_started.md
@@ -101,7 +101,7 @@ For development, testing, or simple workloads that don't require high availabili
 4.  **Access Neo4j Browser:**
 
     ```bash
-    kubectl port-forward svc/standalone-neo4j-service 7474:7474 7687:7687
+    kubectl port-forward svc/standalone-neo4j-client 7474:7474 7687:7687
     ```
 
     Open http://localhost:7474 in your browser.
@@ -192,7 +192,7 @@ Once the pods are in the `Running` state, you can access your deployment using `
 ### For Standalone Deployments
 ```bash
 # For standalone deployment
-kubectl port-forward service/standalone-neo4j-service 7474:7474 7687:7687
+kubectl port-forward service/standalone-neo4j-client 7474:7474 7687:7687
 ```
 
 ### For Cluster Deployments

--- a/docs/user_guide/guides/backup_restore.md
+++ b/docs/user_guide/guides/backup_restore.md
@@ -1032,7 +1032,7 @@ spec:
 
 #### Restore with Job Hooks
 
-Hook Jobs run in their own pods — anything that talks to Neo4j (e.g. `cypher-shell`) must address the instance's service explicitly (`-a neo4j://<standalone>-service:7687`), or it will try to connect to localhost inside the hook pod.
+Hook Jobs run in their own pods — anything that talks to Neo4j (e.g. `cypher-shell`) must address the instance's service explicitly (`-a neo4j://<standalone>-client:7687`), or it will try to connect to localhost inside the hook pod. (The legacy `<standalone>-service` name still resolves this release but is deprecated — update saved hook commands to `-client`.)
 
 ```yaml
 apiVersion: neo4j.neo4j.com/v1beta1
@@ -1068,7 +1068,7 @@ spec:
             args: ["-c", "/scripts/validate-restore.sh"]
             env:
               - name: NEO4J_URI
-                value: "neo4j://staging-standalone-service:7687"
+                value: "neo4j://staging-standalone-client:7687"
               - name: NEO4J_PASSWORD
                 valueFrom:
                   secretKeyRef:

--- a/docs/user_guide/guides/monitoring.md
+++ b/docs/user_guide/guides/monitoring.md
@@ -34,7 +34,7 @@ spec:
     enabled: true
 ```
 
-For standalone deployments, the metrics port is added to the `<standalone>-service` Service and a `ServiceMonitor` named `<standalone>-monitoring` is created automatically.
+For standalone deployments, the metrics port is added to the `<standalone>-client` Service and a `ServiceMonitor` named `<standalone>-monitoring` is created automatically.
 
 ### Full configuration example
 
@@ -69,7 +69,7 @@ scrape_configs:
           - <cluster>-metrics.<namespace>.svc.cluster.local:2004
 ```
 
-Note: for standalone deployments, scrape `<standalone>-service.<namespace>.svc.cluster.local:2004` (the metrics port is added to the same Service that serves Bolt/HTTP).
+Note: for standalone deployments, scrape `<standalone>-client.<namespace>.svc.cluster.local:2004` (the metrics port is added to the same Service that serves Bolt/HTTP). Scrape configs still pointing at the legacy `<standalone>-service` name keep working this release, but that alias is deprecated and will be removed next release — switch to `-client`.
 
 ### Operator's own metrics (TokenReview-authenticated)
 

--- a/docs/user_guide/guides/prometheus-grafana-setup.md
+++ b/docs/user_guide/guides/prometheus-grafana-setup.md
@@ -61,7 +61,7 @@ spec:
     enabled: true
 ```
 
-For standalone, the metrics port is added to the existing `my-standalone-service` Service — no separate metrics Service is created.
+For standalone, the metrics port is added to the existing `my-standalone-client` Service — no separate metrics Service is created. (The legacy `my-standalone-service` alias still works this release but is deprecated.)
 
 ### Verify metrics are exposed
 

--- a/docs/user_guide/guides/troubleshooting.md
+++ b/docs/user_guide/guides/troubleshooting.md
@@ -39,7 +39,7 @@ kubectl logs -n neo4j-operator-system deployment/neo4j-operator-controller-manag
 kubectl port-forward svc/<cluster-name>-client 7474:7474 7687:7687
 
 # For standalone deployments
-kubectl port-forward svc/<standalone-name>-service 7474:7474 7687:7687
+kubectl port-forward svc/<standalone-name>-client 7474:7474 7687:7687
 ```
 
 ## Common Issues and Solutions
@@ -205,8 +205,9 @@ kubectl describe svc <service-name>
    # For clusters
    service: <cluster-name>-client
 
-   # For standalone
-   service: <standalone-name>-service
+   # For standalone (`<standalone-name>-service` still resolves this release
+   # but is deprecated — use `-client`)
+   service: <standalone-name>-client
    ```
 
 2. **Verify Network Policies:**

--- a/docs/user_guide/installation.md
+++ b/docs/user_guide/installation.md
@@ -285,7 +285,7 @@ kubectl get neo4jenterprisestandalone
 kubectl get pods
 
 # Access Neo4j Browser
-kubectl port-forward svc/standalone-neo4j-service 7474:7474 7687:7687
+kubectl port-forward svc/standalone-neo4j-client 7474:7474 7687:7687
 ```
 
 Browse all available examples at
@@ -309,7 +309,7 @@ kubectl get neo4jenterprisestandalone
 kubectl get pods
 
 # Access Neo4j Browser
-kubectl port-forward svc/standalone-neo4j-service 7474:7474 7687:7687
+kubectl port-forward svc/standalone-neo4j-client 7474:7474 7687:7687
 ```
 
 ## Uninstalling the Operator

--- a/examples/backup-restore/pitr-setup-complete.yaml
+++ b/examples/backup-restore/pitr-setup-complete.yaml
@@ -145,10 +145,10 @@ spec:
                 echo "=== PITR Post-Restore Validation ==="
                 # -a points cypher-shell at the standalone's service — the hook
                 # Job runs in its own pod, so omitting it dials localhost.
-                cypher-shell -a neo4j://recovery-standalone-service:7687 \
+                cypher-shell -a neo4j://recovery-standalone-client:7687 \
                   -u neo4j -p "$NEO4J_PASSWORD" -d production-db \
                   "CALL db.ping() YIELD success RETURN success"
-                cypher-shell -a neo4j://recovery-standalone-service:7687 \
+                cypher-shell -a neo4j://recovery-standalone-client:7687 \
                   -u neo4j -p "$NEO4J_PASSWORD" -d production-db \
                   "MATCH (n) RETURN labels(n)[0] as label, count(n) as count ORDER BY label"
                 echo "PITR validation completed successfully"

--- a/examples/backup-restore/restore-from-backup.yaml
+++ b/examples/backup-restore/restore-from-backup.yaml
@@ -67,8 +67,8 @@ spec:
                 echo "Validating restored database..."
                 # -a is required: the hook Job runs in its own pod, so
                 # cypher-shell must be pointed at the instance's service
-                # (<standalone-name>-service) — without it, it dials localhost.
-                cypher-shell -a neo4j://staging-standalone-service:7687 \
+                # (<standalone-name>-client) — without it, it dials localhost.
+                cypher-shell -a neo4j://staging-standalone-client:7687 \
                   -u neo4j -p "$NEO4J_PASSWORD" -d myapp \
                   "MATCH (n) RETURN count(n) as nodeCount"
                 echo "Database validation completed"

--- a/examples/backup-restore/restore-pitr-basic.yaml
+++ b/examples/backup-restore/restore-pitr-basic.yaml
@@ -120,7 +120,7 @@ spec:
                 echo "Running post-restore validation..."
                 # -a points cypher-shell at the standalone's service — the hook
                 # Job runs in its own pod, so omitting it dials localhost.
-                cypher-shell -a neo4j://dr-standalone-service:7687 \
+                cypher-shell -a neo4j://dr-standalone-client:7687 \
                   -u neo4j -p "$NEO4J_PASSWORD" -d critical-app \
                   "MATCH (n) RETURN labels(n)[0] as label, count(n) as count ORDER BY label"
                 echo "Validation completed successfully"

--- a/examples/end-to-end/development-workflow.yaml
+++ b/examples/end-to-end/development-workflow.yaml
@@ -92,7 +92,7 @@ spec:
 # Run these from your dev machine or CI pipeline against the standalone's Bolt
 # endpoint (use the routing scheme; bolt+s:// if TLS is enabled):
 #
-#   kubectl -n neo4j-dev port-forward svc/dev-instance-neo4j-service 7687:7687 &
+#   kubectl -n neo4j-dev port-forward svc/dev-instance-client 7687:7687 &
 #   cypher-shell -a neo4j://localhost:7687 -u neo4j -p "$PASSWORD" -d devdb \
 #     -f ./seed-data.cypher          # load sample data
 #   cypher-shell -a neo4j://localhost:7687 -u neo4j -p "$PASSWORD" -d devdb \

--- a/examples/standalone/README.md
+++ b/examples/standalone/README.md
@@ -18,7 +18,7 @@ kubectl create secret generic neo4j-admin-secret \
 ```bash
 kubectl apply -f examples/standalone/single-node-standalone.yaml
 kubectl get neo4jenterprisestandalone
-kubectl port-forward svc/standalone-neo4j-service 7474:7474 7687:7687
+kubectl port-forward svc/standalone-neo4j-client 7474:7474 7687:7687
 ```
 
 > For external access (LoadBalancer / NodePort / Ingress / OpenShift Route), see

--- a/internal/controller/connection_helper.go
+++ b/internal/controller/connection_helper.go
@@ -21,7 +21,9 @@ func clusterServiceExternalIP(ctx context.Context, c client.Client, cluster *neo
 // standaloneServiceExternalIP is the standalone counterpart — resolves the
 // `{name}-service` Service.
 func standaloneServiceExternalIP(ctx context.Context, c client.Client, standalone *neo4jv1beta1.Neo4jEnterpriseStandalone) string {
-	return serviceExternalIP(ctx, c, standalone.Namespace, fmt.Sprintf("%s-service", standalone.Name))
+	// External exposure lives on the canonical {name}-client Service (#215);
+	// the deprecated {name}-service alias is ClusterIP-only.
+	return serviceExternalIP(ctx, c, standalone.Namespace, fmt.Sprintf("%s-client", standalone.Name))
 }
 
 // serviceExternalIP returns the first ingress entry's IP (or hostname) from
@@ -122,7 +124,7 @@ func GenerateStandaloneConnectionExamples(name, namespace string, serviceType co
 	examples := &neo4jv1beta1.ConnectionExamples{}
 
 	// Port forwarding example (always available)
-	serviceName := fmt.Sprintf("%s-service", name)
+	serviceName := fmt.Sprintf("%s-client", name) // canonical client Service (#215)
 	examples.PortForward = fmt.Sprintf("kubectl port-forward -n %s svc/%s 7474:7474 7687:7687", namespace, serviceName)
 
 	// Determine the base URL based on service type

--- a/internal/controller/neo4jenterprisestandalone_controller.go
+++ b/internal/controller/neo4jenterprisestandalone_controller.go
@@ -567,7 +567,18 @@ func (r *Neo4jEnterpriseStandaloneReconciler) reconcileService(ctx context.Conte
 				return err
 			}
 			clientSvc.Labels = desiredClient.Labels
-			clientSvc.Annotations = desiredClient.Annotations
+			// MERGE annotations rather than replace: cloud LB / ingress
+			// controllers stamp their own annotations on the Service, and a
+			// wholesale assign would strip them every reconcile (breaking
+			// provider-managed exposure). Trade-off: removing a key from
+			// spec.service.annotations doesn't remove it from the live
+			// Service — same semantics as the cluster path.
+			if clientSvc.Annotations == nil {
+				clientSvc.Annotations = map[string]string{}
+			}
+			for k, v := range desiredClient.Annotations {
+				clientSvc.Annotations[k] = v
+			}
 			clientSvc.Spec.Type = desiredClient.Spec.Type
 			clientSvc.Spec.Selector = desiredClient.Spec.Selector
 			clientSvc.Spec.Ports = desiredClient.Spec.Ports
@@ -1834,13 +1845,20 @@ func (r *Neo4jEnterpriseStandaloneReconciler) updateStatus(ctx context.Context, 
 		ready = false
 	}
 
-	// Check if status actually needs to be updated
+	// Check if status actually needs to be updated. The endpoints check
+	// compares the canonical Bolt URL, not just non-nil-ness (#228 review):
+	// after the #215 rename, an already-Ready standalone would otherwise keep
+	// its pre-rename {name}-service URLs in status forever, because nothing
+	// else in this condition changes on an operator upgrade.
+	expectedBoltHost := fmt.Sprintf("%s-client.%s.svc.cluster.local:7687", standalone.Name, standalone.Namespace)
+	endpointsCurrent := latestStandalone.Status.Endpoints != nil &&
+		strings.HasSuffix(latestStandalone.Status.Endpoints.Bolt, expectedBoltHost)
 	if latestStandalone.Status.Phase == phase &&
 		latestStandalone.Status.Message == message &&
 		latestStandalone.Status.Ready == ready &&
 		latestStandalone.Status.Version == standalone.Spec.Image.Tag &&
 		latestStandalone.Status.ObservedGeneration == latestStandalone.Generation &&
-		latestStandalone.Status.Endpoints != nil {
+		endpointsCurrent {
 		logger.V(1).Info("Status unchanged, skipping update")
 		return nil
 	}

--- a/internal/controller/neo4jenterprisestandalone_controller.go
+++ b/internal/controller/neo4jenterprisestandalone_controller.go
@@ -1500,6 +1500,12 @@ func (r *Neo4jEnterpriseStandaloneReconciler) createAliasService(standalone *neo
 	if standalone.Spec.TLS != nil && standalone.Spec.TLS.Mode == "cert-manager" {
 		ports = append(ports, corev1.ServicePort{Name: "https", Port: 7473, TargetPort: intstr.FromInt(7473), Protocol: corev1.ProtocolTCP})
 	}
+	// Keep the metrics port on the alias too (#228 review): the monitoring
+	// docs promise legacy {name}-service scrape targets keep working for the
+	// deprecation release.
+	if standalone.Spec.Monitoring != nil && standalone.Spec.Monitoring.Enabled {
+		ports = append(ports, corev1.ServicePort{Name: "metrics", Port: resources.MetricsPort, TargetPort: intstr.FromInt(resources.MetricsPort), Protocol: corev1.ProtocolTCP})
+	}
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-service", standalone.Name),

--- a/internal/controller/neo4jenterprisestandalone_controller.go
+++ b/internal/controller/neo4jenterprisestandalone_controller.go
@@ -581,7 +581,11 @@ func (r *Neo4jEnterpriseStandaloneReconciler) reconcileService(ctx context.Conte
 			}
 			clientSvc.Spec.Type = desiredClient.Spec.Type
 			clientSvc.Spec.Selector = desiredClient.Spec.Selector
-			clientSvc.Spec.Ports = desiredClient.Spec.Ports
+			// Preserve API-assigned NodePorts across reconciles (#228
+			// review) — same helper the cluster controller uses; a bare
+			// assign would churn node ports on every loop for
+			// type=NodePort/LoadBalancer.
+			clientSvc.Spec.Ports = mergeServicePorts(clientSvc.Spec.Ports, desiredClient.Spec.Ports)
 			clientSvc.Spec.LoadBalancerIP = desiredClient.Spec.LoadBalancerIP
 			clientSvc.Spec.LoadBalancerSourceRanges = desiredClient.Spec.LoadBalancerSourceRanges
 			clientSvc.Spec.ExternalTrafficPolicy = desiredClient.Spec.ExternalTrafficPolicy

--- a/internal/controller/neo4jenterprisestandalone_controller.go
+++ b/internal/controller/neo4jenterprisestandalone_controller.go
@@ -19,8 +19,10 @@ package controller
 import (
 	"context"
 	"crypto/sha256"
+	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"reflect"
 	"sort"
@@ -553,26 +555,64 @@ func (r *Neo4jEnterpriseStandaloneReconciler) reconcileService(ctx context.Conte
 	}
 	logger.Info("Successfully created or updated headless Service", "name", headless.Name)
 
-	// Create client-facing Service using the standalone configuration
-	service := r.createService(standalone)
-
-	// Set owner reference
-	if err := controllerutil.SetControllerReference(standalone, service, r.Scheme); err != nil {
-		return fmt.Errorf("failed to set owner reference: %w", err)
-	}
-
-	// Create or update Service with retry logic to handle resource version conflicts
+	// Create the canonical client-facing Service ({name}-client, #215) with
+	// an ASSERTIVE mutate — the historical no-op mutate meant spec.service
+	// changes never applied to existing Services (#203's headless lesson).
+	// ClusterIP is immutable → only set on create.
+	desiredClient := r.createService(standalone)
+	clientSvc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: desiredClient.Name, Namespace: desiredClient.Namespace}}
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		_, err := controllerutil.CreateOrUpdate(ctx, r.Client, service, func() error {
-			// Service updates for standalone deployments
+		_, err := controllerutil.CreateOrUpdate(ctx, r.Client, clientSvc, func() error {
+			if err := controllerutil.SetControllerReference(standalone, clientSvc, r.Scheme); err != nil {
+				return err
+			}
+			clientSvc.Labels = desiredClient.Labels
+			clientSvc.Annotations = desiredClient.Annotations
+			clientSvc.Spec.Type = desiredClient.Spec.Type
+			clientSvc.Spec.Selector = desiredClient.Spec.Selector
+			clientSvc.Spec.Ports = desiredClient.Spec.Ports
+			clientSvc.Spec.LoadBalancerIP = desiredClient.Spec.LoadBalancerIP
+			clientSvc.Spec.LoadBalancerSourceRanges = desiredClient.Spec.LoadBalancerSourceRanges
+			clientSvc.Spec.ExternalTrafficPolicy = desiredClient.Spec.ExternalTrafficPolicy
+			clientSvc.Spec.SessionAffinity = desiredClient.Spec.SessionAffinity
 			return nil
 		})
 		return err
 	})
 	if err != nil {
-		return fmt.Errorf("failed to create or update Service: %w", err)
+		return fmt.Errorf("failed to create or update client Service: %w", err)
 	}
-	logger.Info("Successfully created or updated Service", "name", service.Name)
+	logger.Info("Successfully created or updated client Service", "name", clientSvc.Name)
+
+	// Deprecated {name}-service alias (#215): plain ClusterIP shim so existing
+	// in-cluster connection strings survive one release. The assertive mutate
+	// also CONVERTS a pre-rename LoadBalancer/NodePort {name}-service to
+	// ClusterIP (external exposure moves to {name}-client — release-noted).
+	desiredAlias := r.createAliasService(standalone)
+	aliasSvc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: desiredAlias.Name, Namespace: desiredAlias.Namespace}}
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		_, err := controllerutil.CreateOrUpdate(ctx, r.Client, aliasSvc, func() error {
+			if err := controllerutil.SetControllerReference(standalone, aliasSvc, r.Scheme); err != nil {
+				return err
+			}
+			aliasSvc.Labels = desiredAlias.Labels
+			if aliasSvc.Annotations == nil {
+				aliasSvc.Annotations = map[string]string{}
+			}
+			for k, v := range desiredAlias.Annotations {
+				aliasSvc.Annotations[k] = v
+			}
+			aliasSvc.Spec.Type = desiredAlias.Spec.Type
+			aliasSvc.Spec.Selector = desiredAlias.Spec.Selector
+			aliasSvc.Spec.Ports = desiredAlias.Spec.Ports
+			return nil
+		})
+		return err
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create or update deprecated alias Service: %w", err)
+	}
+	logger.Info("Successfully created or updated deprecated alias Service", "name", aliasSvc.Name)
 
 	// Reconcile OpenShift Route if requested
 	if err := r.reconcileRoute(ctx, standalone); err != nil {
@@ -778,7 +818,7 @@ func (r *Neo4jEnterpriseStandaloneReconciler) reconcileStatefulSet(ctx context.C
 	logger := log.FromContext(ctx)
 
 	// Create StatefulSet using the standalone configuration
-	statefulSet := r.createStatefulSet(standalone)
+	statefulSet := r.createStatefulSet(ctx, standalone)
 
 	// Stamp a hash of the rendered neo4j.conf onto the desired pod template so a
 	// conf change rolls the pod through the NORMAL template-apply path below
@@ -1401,6 +1441,72 @@ func buildStandaloneStartupProbe() *corev1.Probe {
 }
 
 // createService creates a Service for the standalone deployment
+// tlsCertHasClientSAN reports whether the issued TLS Secret's certificate
+// already carries the canonical "{name}-client" SAN (#215). Used to gate the
+// one-time rolling restart after the naming migration: Neo4j loads its
+// keystore at startup, so until the pod restarts it presents the pre-rename
+// cert — and connections to the canonical name would fail hostname
+// verification. Restarting BEFORE cert-manager has re-issued would just load
+// the old cert again, so the roll is deferred until the SAN is present.
+// Best-effort: any read/parse problem reports false (no restart yet).
+func (r *Neo4jEnterpriseStandaloneReconciler) tlsCertHasClientSAN(ctx context.Context, standalone *neo4jv1beta1.Neo4jEnterpriseStandalone) bool {
+	secret := &corev1.Secret{}
+	if err := r.Get(ctx, types.NamespacedName{Name: fmt.Sprintf("%s-tls-secret", standalone.Name), Namespace: standalone.Namespace}, secret); err != nil {
+		return false
+	}
+	block, _ := pem.Decode(secret.Data["tls.crt"])
+	if block == nil {
+		return false
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return false
+	}
+	want := fmt.Sprintf("%s-client", standalone.Name)
+	for _, dns := range cert.DNSNames {
+		if dns == want || strings.HasPrefix(dns, want+".") {
+			return true
+		}
+	}
+	return false
+}
+
+// createAliasService builds the DEPRECATED {name}-service alias (#215): a
+// plain ClusterIP carrying the client ports so existing in-cluster DNS
+// connection strings keep working for one release after the rename to
+// {name}-client. It deliberately does NOT carry spec.service (type/LB) — the
+// canonical Service owns external exposure. Removed in the release after the
+// rename; the annotation makes the migration discoverable via kubectl.
+func (r *Neo4jEnterpriseStandaloneReconciler) createAliasService(standalone *neo4jv1beta1.Neo4jEnterpriseStandalone) *corev1.Service {
+	ports := []corev1.ServicePort{
+		{Name: "http", Port: 7474, TargetPort: intstr.FromInt(7474), Protocol: corev1.ProtocolTCP},
+		{Name: "bolt", Port: 7687, TargetPort: intstr.FromInt(7687), Protocol: corev1.ProtocolTCP},
+	}
+	if standalone.Spec.TLS != nil && standalone.Spec.TLS.Mode == "cert-manager" {
+		ports = append(ports, corev1.ServicePort{Name: "https", Port: 7473, TargetPort: intstr.FromInt(7473), Protocol: corev1.ProtocolTCP})
+	}
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-service", standalone.Name),
+			Namespace: standalone.Namespace,
+			Annotations: map[string]string{
+				"neo4j.com/deprecated-alias-of": fmt.Sprintf("%s-client", standalone.Name),
+			},
+			Labels: map[string]string{
+				"app.kubernetes.io/name":       "neo4j",
+				"app.kubernetes.io/instance":   standalone.Name,
+				"app.kubernetes.io/component":  "standalone",
+				"app.kubernetes.io/managed-by": "neo4j-operator",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type:     corev1.ServiceTypeClusterIP,
+			Selector: map[string]string{"app": standalone.Name},
+			Ports:    ports,
+		},
+	}
+}
+
 func (r *Neo4jEnterpriseStandaloneReconciler) createService(standalone *neo4jv1beta1.Neo4jEnterpriseStandalone) *corev1.Service {
 	// Determine service type from spec
 	serviceType := corev1.ServiceTypeClusterIP
@@ -1454,7 +1560,12 @@ func (r *Neo4jEnterpriseStandaloneReconciler) createService(standalone *neo4jv1b
 
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        fmt.Sprintf("%s-service", standalone.Name),
+			// {name}-client is the CANONICAL client-facing Service for both
+			// kinds since #215 (clusters always used it). It carries the full
+			// spec.service configuration (type/LB/annotations). The legacy
+			// {name}-service name survives one release as a ClusterIP alias —
+			// see createAliasService.
+			Name:        fmt.Sprintf("%s-client", standalone.Name),
 			Namespace:   standalone.Namespace,
 			Annotations: annotations,
 			Labels: map[string]string{
@@ -1507,11 +1618,20 @@ func standalonePrometheusAnnotations(standalone *neo4jv1beta1.Neo4jEnterpriseSta
 }
 
 // createStatefulSet creates a StatefulSet for the standalone deployment
-func (r *Neo4jEnterpriseStandaloneReconciler) createStatefulSet(standalone *neo4jv1beta1.Neo4jEnterpriseStandalone) *appsv1.StatefulSet {
+func (r *Neo4jEnterpriseStandaloneReconciler) createStatefulSet(ctx context.Context, standalone *neo4jv1beta1.Neo4jEnterpriseStandalone) *appsv1.StatefulSet {
 	replicas := int32(1)
 	annotations := map[string]string{}
 	for k, v := range standalonePrometheusAnnotations(standalone) {
 		annotations[k] = v
+	}
+
+	// #215 naming migration: once cert-manager has re-issued the TLS cert
+	// with the canonical {name}-client SAN, stamp the template so the pod
+	// rolls ONCE and the running server starts presenting it. Gated on the
+	// SAN actually being in the Secret — restarting earlier would reload the
+	// old cert and leave canonical-name connections failing hostname checks.
+	if standalone.Spec.TLS != nil && standalone.Spec.TLS.Mode == "cert-manager" && r.tlsCertHasClientSAN(ctx, standalone) {
+		annotations["neo4j.com/tls-cert-sans"] = "client-v1"
 	}
 
 	ports := []corev1.ContainerPort{
@@ -1754,9 +1874,9 @@ func (r *Neo4jEnterpriseStandaloneReconciler) updateStatus(ctx context.Context, 
 	externalIP := standaloneServiceExternalIP(ctx, r.Client, standalone)
 
 	latestStandalone.Status.Endpoints = &neo4jv1beta1.EndpointStatus{
-		Bolt:               fmt.Sprintf("%s://%s-service.%s.svc.cluster.local:7687", boltScheme, standalone.Name, standalone.Namespace),
-		HTTP:               fmt.Sprintf("http://%s-service.%s.svc.cluster.local:7474", standalone.Name, standalone.Namespace),
-		HTTPS:              fmt.Sprintf("https://%s-service.%s.svc.cluster.local:7473", standalone.Name, standalone.Namespace),
+		Bolt:               fmt.Sprintf("%s://%s-client.%s.svc.cluster.local:7687", boltScheme, standalone.Name, standalone.Namespace),
+		HTTP:               fmt.Sprintf("http://%s-client.%s.svc.cluster.local:7474", standalone.Name, standalone.Namespace),
+		HTTPS:              fmt.Sprintf("https://%s-client.%s.svc.cluster.local:7473", standalone.Name, standalone.Namespace),
 		ConnectionExamples: GenerateStandaloneConnectionExamples(standalone.Name, standalone.Namespace, serviceType, externalIP, hasTLS),
 	}
 
@@ -2106,7 +2226,14 @@ func (r *Neo4jEnterpriseStandaloneReconciler) reconcileTLSCertificate(ctx contex
 
 // createTLSCertificate creates a TLS certificate for the standalone deployment
 func (r *Neo4jEnterpriseStandaloneReconciler) createTLSCertificate(standalone *neo4jv1beta1.Neo4jEnterpriseStandalone) *certmanagerv1.Certificate {
+	// Dual SANs during the #215 naming migration: {name}-client is canonical;
+	// the legacy {name}-service names stay until the alias Service is removed
+	// so connections via either name pass hostname verification.
 	dnsNames := []string{
+		fmt.Sprintf("%s-client", standalone.Name),
+		fmt.Sprintf("%s-client.%s", standalone.Name, standalone.Namespace),
+		fmt.Sprintf("%s-client.%s.svc", standalone.Name, standalone.Namespace),
+		fmt.Sprintf("%s-client.%s.svc.cluster.local", standalone.Name, standalone.Namespace),
 		fmt.Sprintf("%s-service", standalone.Name),
 		fmt.Sprintf("%s-service.%s", standalone.Name, standalone.Namespace),
 		fmt.Sprintf("%s-service.%s.svc", standalone.Name, standalone.Namespace),
@@ -2174,7 +2301,7 @@ func (r *Neo4jEnterpriseStandaloneReconciler) createIngress(standalone *neo4jv1b
 			PathType: &pathType,
 			Backend: networkingv1.IngressBackend{
 				Service: &networkingv1.IngressServiceBackend{
-					Name: fmt.Sprintf("%s-service", standalone.Name),
+					Name: fmt.Sprintf("%s-client", standalone.Name),
 					Port: networkingv1.ServiceBackendPort{
 						Number: 7474,
 					},

--- a/internal/controller/neo4jenterprisestandalone_controller.go
+++ b/internal/controller/neo4jenterprisestandalone_controller.go
@@ -1594,6 +1594,10 @@ func (r *Neo4jEnterpriseStandaloneReconciler) createService(standalone *neo4jv1b
 				"app.kubernetes.io/instance":   standalone.Name,
 				"app.kubernetes.io/component":  "standalone",
 				"app.kubernetes.io/managed-by": "neo4j-operator",
+				// Selected by the ServiceMonitor — present ONLY on the
+				// canonical Service so Prometheus doesn't discover the
+				// deprecated alias too and double-scrape the pod (#228).
+				"neo4j.com/metrics-endpoint": "true",
 			},
 		},
 		Spec: corev1.ServiceSpec{
@@ -2394,6 +2398,12 @@ func (r *Neo4jEnterpriseStandaloneReconciler) reconcileServiceMonitor(ctx contex
 			"matchLabels": map[string]any{
 				"app.kubernetes.io/name":     "neo4j",
 				"app.kubernetes.io/instance": standalone.Name,
+				// Canonical client Service only — the deprecated
+				// {name}-service alias carries the same name/instance
+				// labels (and the metrics port for legacy static scrape
+				// configs), so without this Prometheus would scrape the
+				// pod twice (#228).
+				"neo4j.com/metrics-endpoint": "true",
 			},
 		},
 		"endpoints": []map[string]any{

--- a/internal/controller/neo4jenterprisestandalone_controller_test.go
+++ b/internal/controller/neo4jenterprisestandalone_controller_test.go
@@ -175,7 +175,7 @@ var _ = Describe("Neo4jEnterpriseStandalone Controller", func() {
 			Eventually(func() bool {
 				service := &corev1.Service{}
 				err := k8sClient.Get(ctx, types.NamespacedName{
-					Name:      standaloneName + "-service",
+					Name:      standaloneName + "-client",
 					Namespace: namespaceName,
 				}, service)
 				return err == nil
@@ -436,7 +436,7 @@ var _ = Describe("Neo4jEnterpriseStandalone Controller", func() {
 			Eventually(func() bool {
 				service := &corev1.Service{}
 				err := k8sClient.Get(ctx, types.NamespacedName{
-					Name:      standaloneName + "-service",
+					Name:      standaloneName + "-client",
 					Namespace: namespaceName,
 				}, service)
 				if err != nil {
@@ -446,6 +446,22 @@ var _ = Describe("Neo4jEnterpriseStandalone Controller", func() {
 				// Verify service type is LoadBalancer
 				return service.Spec.Type == corev1.ServiceTypeLoadBalancer
 			}, timeout, interval).Should(BeTrue())
+		})
+
+		It("Should keep the deprecated {name}-service alias as a ClusterIP shim (#215)", func() {
+			Expect(k8sClient.Create(ctx, standalone)).Should(Succeed())
+			alias := &corev1.Service{}
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      standaloneName + "-service",
+					Namespace: namespaceName,
+				}, alias); err != nil {
+					return false
+				}
+				return alias.Spec.Type == corev1.ServiceTypeClusterIP &&
+					alias.Annotations["neo4j.com/deprecated-alias-of"] == standaloneName+"-client"
+			}, timeout, interval).Should(BeTrue(),
+				"the legacy name must survive one release as a ClusterIP-only alias")
 		})
 
 		It("Should create service with NodePort type", func() {
@@ -461,7 +477,7 @@ var _ = Describe("Neo4jEnterpriseStandalone Controller", func() {
 			Eventually(func() bool {
 				service := &corev1.Service{}
 				err := k8sClient.Get(ctx, types.NamespacedName{
-					Name:      standaloneName + "-service",
+					Name:      standaloneName + "-client",
 					Namespace: namespaceName,
 				}, service)
 				if err != nil {
@@ -492,7 +508,7 @@ var _ = Describe("Neo4jEnterpriseStandalone Controller", func() {
 			Eventually(func() bool {
 				service := &corev1.Service{}
 				err := k8sClient.Get(ctx, types.NamespacedName{
-					Name:      standaloneName + "-service",
+					Name:      standaloneName + "-client",
 					Namespace: namespaceName,
 				}, service)
 				if err != nil {
@@ -684,7 +700,7 @@ var _ = Describe("Neo4jEnterpriseStandalone Controller", func() {
 			Eventually(func() bool {
 				service := &corev1.Service{}
 				err := k8sClient.Get(ctx, types.NamespacedName{
-					Name:      standaloneName + "-service",
+					Name:      standaloneName + "-client",
 					Namespace: namespaceName,
 				}, service)
 				return err == nil && service.Spec.Type == corev1.ServiceTypeClusterIP
@@ -713,7 +729,7 @@ var _ = Describe("Neo4jEnterpriseStandalone Controller", func() {
 			Eventually(func() bool {
 				service := &corev1.Service{}
 				err := k8sClient.Get(ctx, types.NamespacedName{
-					Name:      standaloneName + "-service",
+					Name:      standaloneName + "-client",
 					Namespace: namespaceName,
 				}, service)
 				if err != nil {

--- a/internal/controller/service_naming_215_test.go
+++ b/internal/controller/service_naming_215_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package controller
+
+// Pinning tests for the #215 client-Service naming unification: the canonical
+// {name}-client carries the full spec.service configuration; the deprecated
+// {name}-service alias survives one release as a ClusterIP DNS shim; TLS
+// certs carry dual SANs; and the one-time TLS roll is gated on the re-issued
+// cert actually containing the canonical SAN.
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
+)
+
+func tlsStandalone(name string) *neo4jv1beta1.Neo4jEnterpriseStandalone {
+	return &neo4jv1beta1.Neo4jEnterpriseStandalone{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "ns"},
+		Spec: neo4jv1beta1.Neo4jEnterpriseStandaloneSpec{
+			Image:   neo4jv1beta1.ImageSpec{Repo: "neo4j", Tag: "5.26.0-enterprise"},
+			Storage: neo4jv1beta1.StorageSpec{Size: "2Gi"},
+			Service: &neo4jv1beta1.ServiceSpec{Type: "LoadBalancer"},
+			TLS: &neo4jv1beta1.TLSSpec{
+				Mode:      "cert-manager",
+				IssuerRef: &neo4jv1beta1.IssuerRef{Name: "ca-cluster-issuer", Kind: "ClusterIssuer"},
+			},
+		},
+	}
+}
+
+func TestStandaloneCanonicalAndAliasServices(t *testing.T) {
+	r := &Neo4jEnterpriseStandaloneReconciler{}
+	sa := tlsStandalone("db1")
+
+	canonical := r.createService(sa)
+	assert.Equal(t, "db1-client", canonical.Name,
+		"the canonical client Service uses the cluster-wide {name}-client convention (#215)")
+	assert.Equal(t, corev1.ServiceTypeLoadBalancer, canonical.Spec.Type,
+		"spec.service (external exposure) lives on the canonical Service")
+
+	alias := r.createAliasService(sa)
+	assert.Equal(t, "db1-service", alias.Name)
+	assert.Equal(t, corev1.ServiceTypeClusterIP, alias.Spec.Type,
+		"the deprecated alias is a ClusterIP-only DNS shim — never a second LB")
+	assert.Equal(t, "db1-client", alias.Annotations["neo4j.com/deprecated-alias-of"])
+	portNames := map[string]bool{}
+	for _, p := range alias.Spec.Ports {
+		portNames[p.Name] = true
+	}
+	assert.True(t, portNames["bolt"] && portNames["http"] && portNames["https"],
+		"alias keeps the client ports (incl. https under TLS) so saved connection strings work")
+}
+
+func TestStandaloneCertCarriesDualSANs(t *testing.T) {
+	r := &Neo4jEnterpriseStandaloneReconciler{}
+	cert := r.createTLSCertificate(tlsStandalone("db1"))
+	want := []string{
+		"db1-client", "db1-client.ns", "db1-client.ns.svc", "db1-client.ns.svc.cluster.local",
+		"db1-service", "db1-service.ns", "db1-service.ns.svc", "db1-service.ns.svc.cluster.local",
+	}
+	for _, w := range want {
+		assert.Contains(t, cert.Spec.DNSNames, w)
+	}
+}
+
+// selfSignedCertPEM builds a throwaway cert with the given SANs.
+func selfSignedCertPEM(t *testing.T, dnsNames []string) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: dnsNames[0]},
+		DNSNames:     dnsNames,
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+func TestTLSCertHasClientSAN_GatesTheRoll(t *testing.T) {
+	scheme := newTestScheme()
+	sa := tlsStandalone("db1")
+
+	oldSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "db1-tls-secret", Namespace: "ns"},
+		Data:       map[string][]byte{"tls.crt": selfSignedCertPEM(t, []string{"db1-service", "db1-service.ns.svc.cluster.local"})},
+	}
+	r := &Neo4jEnterpriseStandaloneReconciler{Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(sa, oldSecret).Build()}
+	assert.False(t, r.tlsCertHasClientSAN(context.Background(), sa),
+		"pre-rename cert (no -client SAN) must NOT trigger the roll — restarting would reload the old cert")
+	sts := r.createStatefulSet(context.Background(), sa)
+	_, stamped := sts.Spec.Template.Annotations["neo4j.com/tls-cert-sans"]
+	assert.False(t, stamped)
+
+	newSecret := oldSecret.DeepCopy()
+	newSecret.Data["tls.crt"] = selfSignedCertPEM(t, []string{"db1-client", "db1-client.ns.svc.cluster.local", "db1-service"})
+	r2 := &Neo4jEnterpriseStandaloneReconciler{Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(sa, newSecret).Build()}
+	assert.True(t, r2.tlsCertHasClientSAN(context.Background(), sa))
+	sts2 := r2.createStatefulSet(context.Background(), sa)
+	assert.Equal(t, "client-v1", sts2.Spec.Template.Annotations["neo4j.com/tls-cert-sans"],
+		"once the re-issued cert carries the canonical SAN, the template rolls the pod exactly once")
+
+	// Missing secret (TLS not yet issued) — no roll, no panic.
+	r3 := &Neo4jEnterpriseStandaloneReconciler{Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(sa).Build()}
+	assert.False(t, r3.tlsCertHasClientSAN(context.Background(), sa))
+}

--- a/internal/controller/standalone_selectors_test.go
+++ b/internal/controller/standalone_selectors_test.go
@@ -14,6 +14,7 @@ package controller
 // unexported).
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,7 +35,7 @@ func TestStandalonePodSelector_MatchesStatefulSetPodTemplate(t *testing.T) {
 	}
 
 	r := &Neo4jEnterpriseStandaloneReconciler{}
-	sts := r.createStatefulSet(standalone)
+	sts := r.createStatefulSet(context.Background(), standalone)
 	require.NotNil(t, sts)
 
 	selector := resources.StandalonePodSelector(standalone.Name)
@@ -66,7 +67,7 @@ func TestPVCSelectorByInstance_MatchesStandaloneVolumeClaimTemplate(t *testing.T
 	}
 
 	r := &Neo4jEnterpriseStandaloneReconciler{}
-	sts := r.createStatefulSet(standalone)
+	sts := r.createStatefulSet(context.Background(), standalone)
 	require.NotEmpty(t, sts.Spec.VolumeClaimTemplates)
 
 	selector := resources.PVCSelectorByInstance(standalone.Name)

--- a/internal/neo4j/client.go
+++ b/internal/neo4j/client.go
@@ -2460,7 +2460,8 @@ func buildConnectionURIForStandalone(standalone *neo4jv1beta1.Neo4jEnterpriseSta
 	}
 
 	// Use service for connection (standalone service naming pattern)
-	host := fmt.Sprintf("%s-service.%s.svc.cluster.local", standalone.Name, standalone.Namespace)
+	// {name}-client is the canonical client Service for both kinds (#215).
+	host := fmt.Sprintf("%s-client.%s.svc.cluster.local", standalone.Name, standalone.Namespace)
 	port := 7687
 
 	return fmt.Sprintf("%s://%s:%d", scheme, host, port)

--- a/internal/neo4j/uri_test.go
+++ b/internal/neo4j/uri_test.go
@@ -77,17 +77,17 @@ func TestBuildConnectionURIForStandalone(t *testing.T) {
 		{
 			name:     "TLS disabled → neo4j://",
 			tls:      &neo4jv1beta1.TLSSpec{Mode: "disabled"},
-			expected: "neo4j://my-standalone-service.my-ns.svc.cluster.local:7687",
+			expected: "neo4j://my-standalone-client.my-ns.svc.cluster.local:7687",
 		},
 		{
 			name:     "TLS nil → neo4j://",
 			tls:      nil,
-			expected: "neo4j://my-standalone-service.my-ns.svc.cluster.local:7687",
+			expected: "neo4j://my-standalone-client.my-ns.svc.cluster.local:7687",
 		},
 		{
 			name:     "TLS cert-manager → neo4j+s://",
 			tls:      &neo4jv1beta1.TLSSpec{Mode: "cert-manager"},
-			expected: "neo4j+s://my-standalone-service.my-ns.svc.cluster.local:7687",
+			expected: "neo4j+s://my-standalone-client.my-ns.svc.cluster.local:7687",
 		},
 	}
 	for _, tc := range cases {

--- a/internal/resources/mcp.go
+++ b/internal/resources/mcp.go
@@ -588,7 +588,7 @@ func mcpNeo4jURIForStandalone(standalone *neo4jv1beta1.Neo4jEnterpriseStandalone
 	// Single-member topologies still respond to dbms.routing.getRoutingTable
 	// (the lone server is reported as both reader and writer), so neo4j://
 	// works identically to bolt:// here.
-	serviceName := fmt.Sprintf("%s-service", standalone.Name)
+	serviceName := fmt.Sprintf("%s-client", standalone.Name) // canonical client Service (#215)
 	if standalone.Spec.TLS != nil && standalone.Spec.TLS.Mode == CertManagerMode {
 		return fmt.Sprintf("neo4j+ssc://%s.%s.svc.cluster.local:7687", serviceName, standalone.Namespace)
 	}

--- a/internal/resources/mcp_test.go
+++ b/internal/resources/mcp_test.go
@@ -184,7 +184,7 @@ func TestBuildMCPDeploymentForStandalone_STDIOAuth(t *testing.T) {
 	assert.Empty(t, container.Ports)
 
 	// STDIO: credentials MUST be injected.
-	assertEnvValue(t, container.Env, "NEO4J_URI", "neo4j+ssc://graph-standalone-service.default.svc.cluster.local:7687")
+	assertEnvValue(t, container.Env, "NEO4J_URI", "neo4j+ssc://graph-standalone-client.default.svc.cluster.local:7687")
 	assertEnvValue(t, container.Env, "NEO4J_TRANSPORT_MODE", "stdio")
 	assertEnvSecretRef(t, container.Env, "NEO4J_USERNAME", "mcp-auth", "user")
 	assertEnvSecretRef(t, container.Env, "NEO4J_PASSWORD", "mcp-auth", "pass")

--- a/internal/resources/route.go
+++ b/internal/resources/route.go
@@ -129,7 +129,7 @@ func BuildRouteForStandalone(standalone *neo4jv1beta1.Neo4jEnterpriseStandalone)
 	return buildRoute(
 		fmt.Sprintf("%s-route", standalone.Name),
 		standalone.Namespace,
-		fmt.Sprintf("%s-service", standalone.Name),
+		fmt.Sprintf("%s-client", standalone.Name), // canonical client Service (#215)
 		map[string]string{
 			"app.kubernetes.io/name":       "neo4j",
 			"app.kubernetes.io/instance":   standalone.Name,


### PR DESCRIPTION
Closes #215. Implements the **flip-now** variant validated with @priyolahiri: the canonical name lands fully this release, with a one-release compatibility shim.

## What changes
- **`{name}-client` is canonical for both kinds** (clusters always used it). It carries the full `spec.service` configuration — LoadBalancer/NodePort/annotations move here.
- **`{name}-service` survives one release** as a deprecated ClusterIP-only alias (annotated `neo4j.com/deprecated-alias-of`) so saved in-cluster connection strings keep working. A pre-rename LB/NodePort alias is converted to ClusterIP.
- **Dual TLS SANs** (`-client` + `-service` name sets + external DNSName) on every re-issued certificate.
- **SAN-gated one-time pod roll**: Neo4j loads its keystore at startup, so the operator restarts the TLS standalone pod once — but only after the re-issued Secret actually contains the `{name}-client` SAN (rolling earlier would reload the pre-rename cert and break canonical-name hostname verification).
- **All consumers flipped**: `status.endpoints`, MCP, OpenShift Route, Ingress, connection examples / external-IP lookup, the operator's standalone Bolt client.
- Client-Service reconcile is now **assertive** for both Services (the historical no-op mutate meant `spec.service` changes never applied to existing Services — the #203 headless lesson).
- **Docs**: `external_access.md` services table + three migration notes; 15 docs/examples files swept with deprecation notes.

## Release notes (breaking-ish, called out)
1. Pre-existing standalone **LoadBalancer external IPs re-provision once** on upgrade (exposure moves to `{name}-client`) — update DNS.
2. TLS standalones **restart once** automatically after the dual-SAN certificate is re-issued.
3. `{name}-service` is removed in the **next** release.

Pinned by `service_naming_215_test.go` (canonical+alias shape, dual SANs, SAN-gated roll) + an envtest alias spec. Full unit suite green; drift clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrade can change LoadBalancer external IPs, trigger a one-time TLS standalone restart, and break integrations still hard-coded to `{name}-service` after the deprecation window; networking and monitoring configs should be updated to `-client`.
> 
> **Overview**
> **Unifies standalone client Service naming on `{name}-client`** (matching clusters). The canonical Service now owns full `spec.service` exposure (LoadBalancer/NodePort/annotations) with **assertive reconcile** so existing Services actually pick up spec changes; legacy `{name}-service` remains **one release** as a ClusterIP-only alias (`neo4j.com/deprecated-alias-of`), including metrics on the alias for legacy scrapes while **ServiceMonitor** selects only the canonical Service via `neo4j.com/metrics-endpoint`.
> 
> **Migration behavior on upgrade:** external IPs may **re-provision** when LB settings move to `-client`; TLS certs gain **dual SANs** (`-client` + `-service`); a **one-time pod roll** runs only after the re-issued cert includes the `-client` SAN (`tlsCertHasClientSAN` gate).
> 
> **Consumers updated** to `-client`: `status.endpoints`, connection examples / LB external IP lookup, Ingress/Route, operator Bolt client, MCP URIs; status refresh now compares Bolt URLs so pre-rename endpoints update on operator upgrade.
> 
> Docs, examples, and restore-hook samples swept to `-client` with deprecation notes. Tests: `service_naming_215_test.go`, envtest alias spec, controller test renames.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8598dab270384b36f327167ad4fb1be64142b899. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->