### PR TITLE
fix(plugin): enforce https-only URL scheme for url/custom plugin sources (#208)

### DIFF
--- a/docs/api_reference/neo4jplugin.md
+++ b/docs/api_reference/neo4jplugin.md
@@ -98,7 +98,7 @@ kind: Neo4jPlugin
 | Field | Type | Description |
 |-------|------|-------------|
 | `type` | `string` | Source type: "official", "community", "custom", "url" (default: `official`) |
-| `url` | `string` | Direct URL for "url" source type |
+| `url` | `string` | Direct URL for "url" and "custom" source types. **Must be `https://`** — the controller-side validator rejects `http://`, `file://`, and every other scheme (plugin JARs are downloaded over the network and a non-https scheme has no transport integrity). Host internal plugins on an https mirror, e.g. with a cert-manager certificate. |
 | `checksum` | `string` | Checksum for verification. **Required** by the controller-side validator for `type: url` and `type: custom`. Must match `^(sha256:[a-f0-9]{64}\|sha512:[a-f0-9]{128})$`. SHA1 and MD5 are rejected. See [Supply-chain](#supply-chain). |
 | `authSecret` | `string` | Secret containing auth for private repositories/URLs |
 | `registry` | [`PluginRegistry`](#pluginregistry) | Registry configuration for custom sources |

--- a/internal/validation/plugin_validator.go
+++ b/internal/validation/plugin_validator.go
@@ -18,6 +18,7 @@ package validation
 
 import (
 	"fmt"
+	"net/url"
 	"regexp"
 	"strings"
 
@@ -268,6 +269,36 @@ func (v *PluginValidator) validatePluginSource(source *neo4jv1beta1.PluginSource
 			sourcePath.Child("url"),
 			"URL must be specified for custom and url source types",
 		))
+	}
+
+	// Supply-chain: transport integrity. The JAR is fetched over the network
+	// (Neo4j entrypoint or the VerifiedDownload init container) and the
+	// recorded checksum is not enforced at download time on the entrypoint
+	// path (see below), so cleartext http would leave a network attacker free
+	// to swap the JAR. Only https is accepted — file:/ftp:/etc. give no
+	// transport integrity either and the downloaders don't support them.
+	if (source.Type == "custom" || source.Type == "url") && source.URL != "" {
+		parsed, err := url.Parse(source.URL)
+		switch {
+		case err != nil:
+			allErrs = append(allErrs, field.Invalid(
+				sourcePath.Child("url"),
+				source.URL,
+				fmt.Sprintf("must be a valid URL: %v", err),
+			))
+		case !strings.EqualFold(parsed.Scheme, "https"):
+			allErrs = append(allErrs, field.Invalid(
+				sourcePath.Child("url"),
+				source.URL,
+				"URL scheme must be https — plugin JARs are downloaded over the network and a non-https scheme has no transport integrity. Host the plugin on an https endpoint (an in-cluster mirror with a cert-manager certificate works)",
+			))
+		case parsed.Host == "":
+			allErrs = append(allErrs, field.Invalid(
+				sourcePath.Child("url"),
+				source.URL,
+				"URL must include a host",
+			))
+		}
 	}
 
 	// Supply-chain: any source that fetches a JAR from an arbitrary URL

--- a/internal/validation/plugin_validator_test.go
+++ b/internal/validation/plugin_validator_test.go
@@ -691,3 +691,104 @@ func hasErrContaining(errs field.ErrorList, sub string) bool {
 	}
 	return false
 }
+
+// TestPluginValidator_URLSchemeAllowlist pins the https-only URL scheme rule
+// for url/custom plugin sources (#208, audit P0.3). Plugin JARs are fetched
+// over the network and the recorded checksum is not enforced at download time
+// on the entrypoint path, so a cleartext http URL would let a network attacker
+// swap the JAR with no transport AND no content integrity.
+func TestPluginValidator_URLSchemeAllowlist(t *testing.T) {
+	validator := NewPluginValidator()
+
+	const validSHA256 = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+	base := func(src *neo4jv1beta1.PluginSource) *neo4jv1beta1.Neo4jPlugin {
+		return &neo4jv1beta1.Neo4jPlugin{
+			ObjectMeta: metav1.ObjectMeta{Name: "p"},
+			Spec: neo4jv1beta1.Neo4jPluginSpec{
+				ClusterRef: "c",
+				Name:       "apoc",
+				Version:    "5.26.0",
+				Enabled:    true,
+				Source:     src,
+			},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		source  *neo4jv1beta1.PluginSource
+		wantErr bool
+		errSubs string
+	}{
+		{
+			name:   "https url passes",
+			source: &neo4jv1beta1.PluginSource{Type: "url", URL: "https://repo.example.com/apoc.jar", Checksum: validSHA256},
+		},
+		{
+			name:   "https with port and path passes",
+			source: &neo4jv1beta1.PluginSource{Type: "custom", URL: "https://mirror.internal:8443/plugins/apoc.jar", Checksum: validSHA256},
+		},
+		{
+			name:   "uppercase HTTPS scheme passes",
+			source: &neo4jv1beta1.PluginSource{Type: "url", URL: "HTTPS://repo.example.com/apoc.jar", Checksum: validSHA256},
+		},
+		{
+			name:    "http rejected (cleartext)",
+			source:  &neo4jv1beta1.PluginSource{Type: "url", URL: "http://repo.example.com/apoc.jar", Checksum: validSHA256},
+			wantErr: true, errSubs: "scheme must be https",
+		},
+		{
+			name:    "http rejected for custom type too",
+			source:  &neo4jv1beta1.PluginSource{Type: "custom", URL: "http://repo.example.com/apoc.jar", Checksum: validSHA256},
+			wantErr: true, errSubs: "scheme must be https",
+		},
+		{
+			name:    "file scheme rejected",
+			source:  &neo4jv1beta1.PluginSource{Type: "url", URL: "file:///plugins/apoc.jar", Checksum: validSHA256},
+			wantErr: true, errSubs: "scheme must be https",
+		},
+		{
+			name:    "ftp scheme rejected",
+			source:  &neo4jv1beta1.PluginSource{Type: "url", URL: "ftp://repo.example.com/apoc.jar", Checksum: validSHA256},
+			wantErr: true, errSubs: "scheme must be https",
+		},
+		{
+			name:    "scheme-relative URL rejected",
+			source:  &neo4jv1beta1.PluginSource{Type: "url", URL: "//repo.example.com/apoc.jar", Checksum: validSHA256},
+			wantErr: true, errSubs: "scheme must be https",
+		},
+		{
+			name:    "unparseable URL rejected",
+			source:  &neo4jv1beta1.PluginSource{Type: "url", URL: "https://repo example com/ap oc.jar%zz", Checksum: validSHA256},
+			wantErr: true, errSubs: "must be a valid URL",
+		},
+		{
+			name:    "https with empty host rejected",
+			source:  &neo4jv1beta1.PluginSource{Type: "url", URL: "https:///apoc.jar", Checksum: validSHA256},
+			wantErr: true, errSubs: "must include a host",
+		},
+		{
+			name:   "official source has no URL and is unaffected",
+			source: &neo4jv1beta1.PluginSource{Type: "official"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := validator.Validate(base(tt.source)).Errors
+			if tt.wantErr {
+				if len(errs) == 0 {
+					t.Fatalf("expected an error, got none")
+				}
+				if tt.errSubs != "" && !strings.Contains(errs.ToAggregate().Error(), tt.errSubs) {
+					t.Errorf("expected error to contain %q, got %v", tt.errSubs, errs)
+				}
+				return
+			}
+			if len(errs) > 0 {
+				t.Fatalf("expected no errors, got %v", errs)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #208 (audit P0.3, supply-chain Tier-1).

## Why now
Pre-release is the right time for this: it tightens accepted specs (an `http://` plugin URL that validates today is rejected after this change). Shipping the restriction in the release is hardening; shipping it after would break published behavior.

## What changes
`validatePluginSource` now parses `spec.source.url` for `url`/`custom` sources and rejects any scheme other than `https` (case-insensitive), plus host-less and unparseable URLs, with actionable messages. Rationale: the JAR is fetched over the network (entrypoint or VerifiedDownload init container) and the recorded checksum is **not** verified at download time on the entrypoint path — cleartext http meant no transport and no content integrity.

No opt-out: an in-cluster mirror can serve https with a cert-manager certificate.

## Verification
- `TestPluginValidator_URLSchemeAllowlist` — 11 cases (https/HTTPS/port+path pass; http, file, ftp, scheme-relative, host-less, unparseable rejected; official/community untouched)
- Checksum rules unchanged; full validation package green
- All shipped examples/docs already used https; API reference updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens accepted CR specs (http and other schemes that validated before are rejected), but only affects plugin download URLs—not cluster auth or data paths.
> 
> **Overview**
> **Neo4jPlugin** admission now requires **`spec.source.url`** to use **`https`** (case-insensitive) when `source.type` is **`url`** or **`custom`**. `validatePluginSource` parses the URL and rejects cleartext **`http`**, **`file`**, **`ftp`**, scheme-relative URLs, unparseable values, and **`https`** URLs without a host—checksum rules are unchanged; **`official`** / **`community`** sources are unaffected.
> 
> The **Neo4jPlugin** API reference documents the **`https`** requirement and suggests in-cluster mirrors (e.g. cert-manager). **`TestPluginValidator_URLSchemeAllowlist`** locks in 11 pass/fail cases.
> 
> **Breaking:** any manifest that previously accepted a non-**`https`** plugin URL will fail validation after upgrade.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5e6ad82d160fbd5bc7d76c975add620add41509. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->