### PR TITLE
docs: close the v1.12.0 release docs gaps

### DIFF
--- a/docs/api_reference/neo4jenterprisecluster.md
+++ b/docs/api_reference/neo4jenterprisecluster.md
@@ -119,6 +119,7 @@ Defines the cluster server topology and role constraints.
 | Field | Type | Description |
 |---|---|---|
 | `servers` | `int32` | **Required**. Number of Neo4j servers (minimum: 2, maximum: 100) |
+| `minSystemPrimaries` | `*int32` | System-database primary count written to `dbms.cluster.minimum_initial_system_primaries_count` at cluster formation, and the floor the cluster can later be scaled down to. Default: `min(3, servers)`. Validator: must be ≥ 2 and ≤ `servers`; an even value draws a warning (an even voting set has no clean write-quorum majority — prefer 3, 5, …). Note this is a bootstrap **floor**, not a cap: Neo4j makes **all** initially-joined servers system primaries; the setting only defines how many must be present to bootstrap and the minimum the system database can shrink to |
 | `serverModeConstraint` | `string` | Global server mode constraint: `"NONE"` (default), `"PRIMARY"`, `"SECONDARY"` |
 | `serverRoles` | [`[]ServerRoleHint`](#serverrolehint) | Per-server role constraints (overrides global constraint) |
 | `placement` | [`*PlacementConfig`](#placementconfig) | Advanced placement and scheduling configuration |

--- a/docs/user_guide/clustering.md
+++ b/docs/user_guide/clustering.md
@@ -67,7 +67,7 @@ The operator uses a **ME/OTHER bootstrap strategy** with `Parallel` pod manageme
 ### Key Configuration
 
 - **Bootstrap strategy**: server-0 uses `me` (preferred bootstrapper); all other servers use `other` (join when ready)
-- **Minimum primaries**: Set to `TOTAL_SERVERS` on initial formation — all servers must mutually discover each other before RAFT elects a leader, preventing premature solo bootstrap
+- **Minimum primaries**: Set to `min(3, servers)` on initial formation (override with `spec.topology.minSystemPrimaries`) — that many servers must mutually discover each other before RAFT elects a leader, preventing premature solo bootstrap. Note it's a bootstrap **floor**, not a cap: all initially-joined servers become system primaries
 - **On restart** (data already exists): minimum primaries check is skipped so servers rejoin immediately without blocking StatefulSet rolling updates
 - **Pod Management**: `Parallel` — all pods start simultaneously
 
@@ -76,13 +76,13 @@ The operator uses a **ME/OTHER bootstrap strategy** with `Parallel` pod manageme
 1. **All server pods start in parallel** — Single StatefulSet with `Parallel` pod management
 2. **Servers discover each other** — Via static pod FQDNs in the LIST endpoint list (port 6000)
 3. **RAFT coordination** — server-0's `me` hint makes it the preferred bootstrapper; others wait with `other` hint
-4. **All N servers must see each other** — `dbms.cluster.minimum_initial_system_primaries_count=N` prevents any single node from forming a solo cluster (split-brain)
+4. **A quorum of servers must see each other** — `dbms.cluster.minimum_initial_system_primaries_count` (default `min(3, servers)`, override via `spec.topology.minSystemPrimaries`) prevents any single node from forming a solo cluster (split-brain)
 5. **Cluster forms once quorum reached** — RAFT elects server-0 as bootstrap leader; others join
 6. **Servers self-organize** — Neo4j automatically assigns primary and secondary roles per database
 
 ### Benefits
 
-- **Split-brain prevention** — All servers must be mutually visible before formation completes
+- **Split-brain prevention** — A quorum of servers must be mutually visible before formation completes
 - **Reliable formation** — Deterministic peer addresses (one FQDN per pod) unlike K8S ClusterIP which returns a single VIP
 - **Fast restarts** — Minimum primaries check skipped on pod restarts so rolling updates aren't blocked
 

--- a/docs/user_guide/guides/backup_restore.md
+++ b/docs/user_guide/guides/backup_restore.md
@@ -895,7 +895,22 @@ spec:
 
 #### Restore to a Standalone Instance
 
-`clusterRef` can reference a `Neo4jEnterpriseStandalone` as well as a `Neo4jEnterpriseCluster`:
+`clusterRef` can reference a `Neo4jEnterpriseStandalone` as well as a
+`Neo4jEnterpriseCluster` — the operator auto-detects the kind and routes to the
+standalone path. Unlike the cluster path (Cypher `seedURI`, no downtime), a
+standalone restore is **Job-based and takes the instance offline**:
+
+1. The operator scales the standalone StatefulSet to 0 (`stopCluster: true` is
+   required — with `false` it refuses while pods are running).
+2. A restore Job mounts the data PVC and the backup source and runs
+   `neo4j-admin database restore`. From a chain directory it picks the
+   **latest** `.backup` file automatically; from a read-only backup PVC it
+   extracts via a temp dir (`--temp-path`) since the source mount is RO.
+3. The StatefulSet is scaled back up, and once the instance is `Ready` the
+   operator brings the database online (`CREATE DATABASE`/`START DATABASE`).
+
+Pre/post restore hooks (`spec.hooks`) run only on this standalone path — see
+[Restore with Hooks](#restore-with-hooks).
 
 ```yaml
 apiVersion: neo4j.neo4j.com/v1beta1

--- a/docs/user_guide/guides/upgrades.md
+++ b/docs/user_guide/guides/upgrades.md
@@ -33,6 +33,42 @@ kubectl get neo4jenterprisecluster <name> -o jsonpath='{.status.upgradeStatus}'
 kubectl logs -n neo4j-operator deployment/neo4j-operator-controller-manager -f | grep -i upgrade
 ```
 
+### Upgrade phases and resumability
+
+The upgrade runs as a requeue-driven state machine whose state is persisted in
+`status.upgradeStatus`, so you can follow it with `kubectl` and it survives
+operator restarts:
+
+| Phase | What's happening |
+|---|---|
+| `Staging` | Pre-upgrade health check, version-compatibility check, StatefulSet frozen (partition = replica count), new image applied to the template |
+| `Rolling` | Pods restart one at a time, highest ordinal first; after each pod, Kubernetes readiness **and** Neo4j cluster membership (`SHOW SERVERS`) are verified before the partition is lowered |
+| `Stabilizing` | All pods updated; the operator waits for consistently stable cluster health and consensus |
+| `Verifying` | Every server's reported version is checked against the target before the upgrade is declared done |
+| `Completed` / `Failed` / `Paused` | Terminal. `Paused` means a health check failed with `autoPauseOnFailure: true` — the cluster is left as-is for you to investigate |
+
+Two status fields drive the machine and are useful when watching a long
+upgrade: `currentPartition` (which StatefulSet partition step the rollout is
+on — counts down toward 0) and `stepStartTime` (when the current step began;
+each per-pod step is bounded by `upgradeTimeout`/`healthCheckTimeout`).
+
+**Resumability.** Because the phase and partition are persisted in status, an
+operator restart (or leader change) mid-upgrade resumes exactly where it left
+off — already-rolled pods are not rolled again. Upgrades that were interrupted
+under an older operator version (`phase: InProgress`) are adopted and resumed
+automatically.
+
+**Changing the target mid-upgrade.** If you patch `spec.image.tag` again while
+an upgrade is running, the state machine retargets to the new image: pods not
+yet rolled go straight to the new version, and pods already rolled to the
+intermediate version are rolled again. You don't need to wait for the first
+upgrade to finish.
+
+**Version verification across SemVer/CalVer.** The `Verifying` phase compares
+each server's `SHOW SERVERS` version against the image tag, normalizing
+Neo4j's kernel alias (the `2025.01.x` CalVer releases report kernel `5.27.x` —
+both are accepted as the same version).
+
 ### First upgrade after operator deployment
 
 If `status.version` is not yet set on the cluster resource (e.g. immediately after the operator is first deployed against an existing cluster), the version-compatibility check is skipped and the upgrade proceeds. Downgrade protection is applied on all subsequent upgrades.

--- a/docs/user_guide/migration_guide.md
+++ b/docs/user_guide/migration_guide.md
@@ -59,6 +59,81 @@ Remove or correct any flagged keys. (The operator's own rendered config is fully
 > **Single-node Cluster CRDs**: removed in v1.6-alpha. If you still have a `Neo4jEnterpriseCluster` with `topology.servers: 1`, migrate to `Neo4jEnterpriseStandalone` — same data via a backup/restore round-trip. For step-by-step alpha-era guidance, see the [v1.6-alpha migration section](#upgrading-to-v160-alpha-api-stabilization) below or the older versions of this doc in git history.
 
 
+## Upgrading from v1.11.x to v1.12.0
+
+### 0. Refresh CRDs before upgrading the operator (always required)
+
+Helm installs CRDs from the chart's `crds/` directory **once** and never
+upgrades them. Before `helm upgrade`, apply the new release's CRDs:
+
+```bash
+kubectl apply --server-side -f \
+  https://github.com/neo4j-partners/neo4j-kubernetes-operator/releases/download/v1.12.0/neo4j-kubernetes-operator.yaml
+```
+
+`--server-side` is required — the larger CRDs exceed the client-side-apply
+annotation limit. See [Installation → Upgrading](installation.md) for the full
+procedure and the documented uninstall order.
+
+### 1. Standalone client Service renamed: `{name}-service` → `{name}-client`
+
+**What changed.** Standalone instances historically exposed their client
+Service as `{name}-service` while clusters used `{name}-client`. v1.12 unifies
+on **`{name}-client` for both kinds**. The canonical Service now carries your
+full `spec.service` configuration (type, NodePort, annotations).
+
+**Compatibility shim (one release only).** `{name}-service` is kept as a
+**ClusterIP-only** alias annotated `neo4j.com/deprecated-alias-of`, so saved
+in-cluster connection strings keep working. **It is removed in the next
+release** — update clients, dashboards, NetworkPolicies, and automation to
+`{name}-client` during this cycle.
+
+**One-time effects on upgrade:**
+
+- If your standalone used `spec.service.type: LoadBalancer` or `NodePort`, that
+  exposure **moves to `{name}-client`** — the LoadBalancer is re-provisioned
+  once and its **external IP may change**. Update DNS records accordingly.
+- TLS standalones get a re-issued certificate carrying **both** name sets as
+  SANs, and the pod **restarts once** (automatically, only after the new
+  certificate is in place) so Neo4j loads the new keystore.
+- `status.endpoints` now reports `{name}-client` hostnames.
+
+See [External Access](external_access.md) for the services table and migration
+notes.
+
+### 2. Plugin `url`/`custom` sources must be `https://`
+
+**What changed.** The validator now rejects any `Neo4jPlugin`
+`spec.source.url` whose scheme isn't `https` (`http://`, `file://`, `ftp://`
+etc. all fail with `field.Invalid`). Plugin JARs are downloaded over the
+network and the recorded checksum is not enforced at download time on the
+entrypoint path, so a cleartext URL had neither transport nor content
+integrity.
+
+**Who is affected.** Existing `Neo4jPlugin` CRs with an `http://` source URL —
+they will fail validation (and stop reconciling) after the operator upgrade.
+
+**Action required.** Audit plugin CRs before upgrading:
+
+```bash
+kubectl get neo4jplugins -A -o json | \
+  jq -r '.items[] | select(.spec.source.url // "" | startswith("http://")) | "\(.metadata.namespace)/\(.metadata.name): \(.spec.source.url)"'
+```
+
+Re-host flagged JARs on an https endpoint (an in-cluster mirror with a
+cert-manager certificate works) or switch to `installMode: PreBaked` with the
+JAR baked into a custom image.
+
+### 3. Rolling upgrades now run as a resumable state machine
+
+Not a breaking change, but visible: during a Neo4j version upgrade,
+`status.upgradeStatus.phase` now progresses through
+`Staging → Rolling → Stabilizing → Verifying → Completed`, and the upgrade
+**survives operator restarts** (it resumes where it left off instead of
+starting over). An upgrade interrupted under v1.11 (`InProgress`) is adopted
+and resumed automatically. See the [Upgrade guide](guides/upgrades.md) for
+phase semantics and monitoring.
+
 ## Upgrading from v1.10.x to v1.11.x
 
 This section covers the breaking and behavioural changes landing in v1.11.x (since `v1.10.0`).


### PR DESCRIPTION
Pre-release docs audit (3 parallel sweeps over everything merged since v1.11.2) found four HIGH gaps plus one stale claim — all fixed here:

1. **Migration guide had no v1.11.x → v1.12.0 section** — and the release-notes template literally directs users to it. Now covers: mandatory CRD refresh before `helm upgrade`, the standalone `{name}-service` → `{name}-client` rename with its one-time effects (LB re-provision, TLS pod roll) and the one-release alias window, the new https-only plugin URL rule (with a `jq` one-liner to audit existing CRs), and the resumable upgrade state machine.
2. **Upgrade phases were invisible** — users watching `status.upgradeStatus` would see `Staging`/`Rolling`/`Stabilizing`/`Verifying` with no documentation. Added the phase table, `currentPartition`/`stepStartTime` semantics, restart resumability, and mid-flight retarget behavior to `guides/upgrades.md`.
3. **`minSystemPrimaries` was missing from the API reference** — added to the TopologyConfiguration table with default (`min(3, servers)`), validator rules (≥2, ≤servers, even-value warning) and the bootstrap-floor-not-cap semantics.
4. **Standalone-target restore was one bare YAML** — expanded with the Job-path mechanics (offline scale-down, latest-in-chain artifact pick, RO-PVC temp path, automatic bring-up, hooks standalone-only).
5. **Stale fact in clustering.md**: claimed `minimum_initial_system_primaries_count` is set to TOTAL_SERVERS; it's been `min(3, servers)` with a spec override since #173.

Remaining MED/LOW audit findings (scale-down troubleshooting entries, standalone probe parameters, README version-support cross-link) are deliberately left out to keep this reviewable pre-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only changes; no runtime or schema impact.
> 
> **Overview**
> Documentation-only PR that closes v1.12.0 release gaps: no operator or CRD behavior changes.
> 
> **Migration guide** adds **v1.11.x → v1.12.0**: mandatory server-side CRD apply before Helm upgrade, standalone `{name}-service` → `{name}-client` (one-release alias, LB/TLS one-time effects), **https-only** `Neo4jPlugin` URLs with an audit `jq` one-liner, and a pointer to the resumable upgrade state machine.
> 
> **Upgrades guide** documents **`status.upgradeStatus` phases** (`Staging` → `Rolling` → `Stabilizing` → `Verifying` → terminal), **`currentPartition`** / **`stepStartTime`**, restart resumability (including legacy `InProgress`), mid-upgrade image retargeting, and SemVer/CalVer version verification.
> 
> **API reference** documents **`spec.topology.minSystemPrimaries`** (default `min(3, servers)`, validator rules, bootstrap floor vs cap).
> 
> **Backup/restore guide** expands **standalone-target restore** (offline scale-down Job path, latest-in-chain pick, RO PVC temp path, bring-up, hooks standalone-only).
> 
> **Clustering guide** corrects stale copy: minimum system primaries default is **`min(3, servers)`** with optional override—not “all servers must see each other” / `TOTAL_SERVERS`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9878d63db0c01fea187074b2dce1012dd5571d34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->