### PR TITLE
fix(backup/restore): pre-release #227 items — maxAge grammar, stale-artifact guard, restore timestamps

### DIFF
--- a/docs/api_reference/neo4jbackup.md
+++ b/docs/api_reference/neo4jbackup.md
@@ -200,7 +200,7 @@ Backup retention configuration.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `maxAge` | `string` | ❌ | Maximum age of artifacts to retain. Accepted units: `d` (days), `h` (hours), `m` (minutes), `s` (seconds) — e.g. `"30d"`, `"168h"`, `"90m"`. `"4w"` is **rejected** by the validator. |
+| `maxAge` | `string` | ❌ | Maximum age of artifacts to retain. A **single** unit of `d` (days), `h` (hours), `m` (minutes), or `s` (seconds) — e.g. `"30d"`, `"168h"`, `"90m"`. Compound values (`"1h30m"`) and `"4w"` are **rejected** by the validator (the runtime applies exactly what validates). |
 | `maxCount` | `int32` | ❌ | Maximum number of `.backup` artifacts to retain |
 | `deletePolicy` | `string` | ❌ | `"Delete"` (default). `"Archive"` is **RESERVED — currently a no-op** (no archival logic exists; accepted for backward compatibility). |
 

--- a/docs/user_guide/guides/backup_restore.md
+++ b/docs/user_guide/guides/backup_restore.md
@@ -723,7 +723,7 @@ spec:
 >   - **S3**: [S3 Lifecycle Rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lifecycle-mgmt.html)
 >   - **GCS**: [Object Lifecycle Management](https://cloud.google.com/storage/docs/lifecycle)
 >   - **Azure**: [Blob Lifecycle Management](https://learn.microsoft.com/en-us/azure/storage/blobs/lifecycle-management-overview)
-> - **PVC storage**: retention is enforced by a cleanup Job that runs **only when the Neo4jBackup CR is deleted** — it is *not* a continuous pruning loop. The Job prunes `*.backup` **files** in this CR's chain directory only, oldest-first by mtime, and **always keeps the newest artifact**. `maxAge` accepts `d`/`h`/`m`/`s` units (`"4w"` is rejected). `deletePolicy: Archive` is a reserved no-op.
+> - **PVC storage**: retention is enforced by a cleanup Job that runs **only when the Neo4jBackup CR is deleted** — it is *not* a continuous pruning loop. The Job prunes `*.backup` **files** in this CR's chain directory only, oldest-first by mtime, and **always keeps the newest artifact**. `maxAge` accepts a **single** `d`/`h`/`m`/`s` unit (`"30d"`, `"24h"`; compound values like `"1h30m"` and `"4w"` are rejected). `deletePolicy: Archive` is a reserved no-op.
 > - **DIFF caveat**: filenames don't encode FULL vs DIFF, so pruning can orphan diffs whose parent FULL ages out — the operator emits a `BackupRetentionCaveat` warning event when this applies. Prefer `backupType: FULL` on CRs that use retention.
 
 #### Weekly Backup with Long Retention

--- a/internal/controller/neo4jrestore_controller.go
+++ b/internal/controller/neo4jrestore_controller.go
@@ -2913,6 +2913,11 @@ func (r *Neo4jRestoreReconciler) latestSucceededArtifactFilename(ctx context.Con
 			if fn := backup.Status.History[i].ArtifactFilename; fn != "" {
 				return fn, nil
 			}
+			// The NEWEST Succeeded run has no captured filename (Pod-log
+			// capture is best-effort, rule 67). Refusing to fall through to
+			// an OLDER run — that would silently restore stale data under a
+			// green status (#227 item 3). Fail actionably instead.
+			return "", fmt.Errorf("the most recent Succeeded run %q of Neo4jBackup %q has no captured ArtifactFilename (Pod-log capture is best-effort and can miss) — restoring an older run silently is refused; restore via type=storage with source.backupPath pointing at the exact .backup file, or re-run the backup", backup.Status.History[i].RunID, backupRef)
 		}
 	}
 	return "", fmt.Errorf("Neo4jBackup %q has no Succeeded run with a captured ArtifactFilename — re-run the backup with a recent operator version (Pod-log capture required for cluster restores), or copy the .backup file to storage and restore via type=storage with source.backupPath pointing at the file", backupRef)
@@ -3105,6 +3110,17 @@ func (r *Neo4jRestoreReconciler) updateRestoreStatus(ctx context.Context, restor
 		latest.Status.Phase = phase
 		latest.Status.Message = message
 		latest.Status.ObservedGeneration = latest.Generation
+		// Carry the caller's timestamps: callers stamp StartTime/CompletionTime
+		// on their (possibly stale) in-memory object before funneling through
+		// this writer, which refetches — without this copy the stamps were
+		// silently dropped on the cluster Cypher path (#227 item 4). Earlier
+		// persisted values win so a requeue can't move a timestamp.
+		if restore.Status.StartTime != nil && latest.Status.StartTime == nil {
+			latest.Status.StartTime = restore.Status.StartTime
+		}
+		if restore.Status.CompletionTime != nil && latest.Status.CompletionTime == nil {
+			latest.Status.CompletionTime = restore.Status.CompletionTime
+		}
 		condStatus, condReason := PhaseToConditionStatus(phase)
 		SetReadyCondition(&latest.Status.Conditions, latest.Generation, condStatus, condReason, message)
 		return r.Status().Update(ctx, latest)

--- a/internal/controller/neo4jrestore_resolvedsource_test.go
+++ b/internal/controller/neo4jrestore_resolvedsource_test.go
@@ -216,3 +216,77 @@ func TestValidateRestore_MissingCRWithoutSnapshotPointsAtStorage(t *testing.T) {
 	require.Error(t, err)
 	assert.True(t, strings.Contains(err.Error(), "source.type=storage"))
 }
+
+// --- #227 pre-release items 3 + 4 ---
+
+// TestLatestSucceededArtifactFilename_NewestRunWithoutFilenameIsRefused pins
+// #227 item 3: when the MOST RECENT Succeeded run has no captured
+// ArtifactFilename, the resolver must error actionably instead of silently
+// falling through to an OLDER Succeeded run (which would restore stale data
+// under a green status).
+func TestLatestSucceededArtifactFilename_NewestRunWithoutFilenameIsRefused(t *testing.T) {
+	backup := backupCRForRestore("nightly", "default", false)
+	backup.Status.History = []neo4jv1beta1.BackupRun{
+		{RunID: "nightly-backup-new", Status: "Succeeded", ArtifactFilename: ""}, // newest — capture missed
+		{RunID: "nightly-backup-old", Status: "Succeeded", ArtifactFilename: "neo4j-2026-06-10T10-00-00.backup"},
+	}
+	r := newResolvedSourceReconciler(t, backup)
+
+	_, err := r.latestSucceededArtifactFilename(context.Background(), "nightly", "default")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nightly-backup-new", "error must name the run whose filename capture missed")
+	assert.Contains(t, err.Error(), "type=storage", "error must point at the explicit-path escape hatch")
+	assert.NotContains(t, err.Error(), "2026-06-10", "must not leak/choose the older artifact")
+}
+
+// TestLatestSucceededArtifactFilename_NewestSucceededWins pins the happy path:
+// the newest Succeeded run's filename is returned even when older runs exist,
+// and Failed runs ahead of it are skipped.
+func TestLatestSucceededArtifactFilename_NewestSucceededWins(t *testing.T) {
+	backup := backupCRForRestore("nightly", "default", false)
+	backup.Status.History = []neo4jv1beta1.BackupRun{
+		{RunID: "nightly-backup-failed", Status: "Failed"},
+		{RunID: "nightly-backup-new", Status: "Succeeded", ArtifactFilename: "neo4j-2026-06-11T10-00-00.backup"},
+		{RunID: "nightly-backup-old", Status: "Succeeded", ArtifactFilename: "neo4j-2026-06-10T10-00-00.backup"},
+	}
+	r := newResolvedSourceReconciler(t, backup)
+
+	fn, err := r.latestSucceededArtifactFilename(context.Background(), "nightly", "default")
+	require.NoError(t, err)
+	assert.Equal(t, "neo4j-2026-06-11T10-00-00.backup", fn)
+}
+
+// TestUpdateRestoreStatus_PersistsCallerTimestamps pins #227 item 4: the
+// status writer refetches the CR, so StartTime/CompletionTime stamped on the
+// caller's in-memory object were silently dropped. They must be carried over —
+// and an already-persisted value must not be moved by a later requeue.
+func TestUpdateRestoreStatus_PersistsCallerTimestamps(t *testing.T) {
+	restore := restoreWithBackupRef("r1", "default", "nightly")
+	r := newResolvedSourceReconciler(t, restore)
+	ctx := context.Background()
+
+	start := metav1.NewTime(time.Now().Add(-2 * time.Minute).Truncate(time.Second))
+	completion := metav1.NewTime(time.Now().Truncate(time.Second))
+	restore.Status.StartTime = &start
+	restore.Status.CompletionTime = &completion
+
+	r.updateRestoreStatus(ctx, restore, StatusCompleted, "done")
+
+	persisted := &neo4jv1beta1.Neo4jRestore{}
+	require.NoError(t, r.Get(ctx, client.ObjectKeyFromObject(restore), persisted))
+	require.NotNil(t, persisted.Status.StartTime, "StartTime must survive the refetch-based status writer")
+	require.NotNil(t, persisted.Status.CompletionTime, "CompletionTime must survive the refetch-based status writer")
+	assert.True(t, persisted.Status.StartTime.Equal(&start))
+	assert.True(t, persisted.Status.CompletionTime.Equal(&completion))
+
+	// A second write with different in-memory stamps must NOT move the
+	// persisted timestamps (earlier persisted values win).
+	later := metav1.NewTime(time.Now().Add(time.Hour))
+	restore.Status.StartTime = &later
+	restore.Status.CompletionTime = &later
+	r.updateRestoreStatus(ctx, restore, StatusCompleted, "done again")
+
+	require.NoError(t, r.Get(ctx, client.ObjectKeyFromObject(restore), persisted))
+	assert.True(t, persisted.Status.StartTime.Equal(&start), "persisted StartTime must not be moved by a requeue")
+	assert.True(t, persisted.Status.CompletionTime.Equal(&completion), "persisted CompletionTime must not be moved by a requeue")
+}

--- a/internal/validation/backup_validator.go
+++ b/internal/validation/backup_validator.go
@@ -21,7 +21,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"time"
 
 	cron "github.com/robfig/cron/v3"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
@@ -64,14 +63,13 @@ func ValidateScheduledBackupName(name string) error {
 var maxAgeShorthand = regexp.MustCompile(`^[1-9][0-9]*[dhms]$`)
 
 // isValidMaxAge reports whether a retention maxAge is one the operator can
-// actually apply: either the "<n>{d|h|m|s}" shorthand or a value Go's
-// time.ParseDuration accepts. (time.ParseDuration alone rejects "7d"/"30d".)
+// actually apply: exactly the "<n>{d|h|m|s}" single-unit shorthand that
+// parseFindTimeArg understands. Compound Go durations like "1h30m" used to be
+// accepted here (via time.ParseDuration) but the runtime parser can't read
+// them and silently fell back to 7 days — a validated value MUST be applied
+// as written (#227 item 8).
 func isValidMaxAge(maxAge string) bool {
-	if maxAgeShorthand.MatchString(maxAge) {
-		return true
-	}
-	_, err := time.ParseDuration(maxAge)
-	return err == nil
+	return maxAgeShorthand.MatchString(maxAge)
 }
 
 // BackupValidator validates Neo4j backup configuration for Neo4j 5.26+ compatibility
@@ -502,16 +500,16 @@ func (v *BackupValidator) validateRetentionPolicy(retention *neo4jv1beta1.Retent
 	retentionPath := field.NewPath("spec", "retention")
 
 	// Validate max age format if specified. The runtime (parseFindTimeArg in
-	// the backup controller) accepts a day/hour/minute/second shorthand like
-	// "7d", "30d", "24h" — which Go's time.ParseDuration rejects (no "d"
-	// unit). Accept the shorthand the runtime understands, and also tolerate
-	// any value time.ParseDuration accepts, so the validator never rejects a
-	// maxAge the operator can actually apply.
+	// the backup controller) understands a SINGLE-unit day/hour/minute/second
+	// shorthand like "7d", "30d", "24h". Compound Go durations ("1h30m") are
+	// rejected here: the runtime can't apply them and used to fall back
+	// silently to 7 days — anything the validator passes must be applied
+	// exactly as written.
 	if retention.MaxAge != "" && !isValidMaxAge(retention.MaxAge) {
 		allErrs = append(allErrs, field.Invalid(
 			retentionPath.Child("maxAge"),
 			retention.MaxAge,
-			"invalid duration format. Use a value like '7d', '30d', '24h', or '90m'",
+			"must be a single-unit duration like '7d', '30d', '24h', '90m', or '45s' (compound values such as '1h30m' are not supported)",
 		))
 	}
 

--- a/internal/validation/backup_validator_test.go
+++ b/internal/validation/backup_validator_test.go
@@ -599,7 +599,8 @@ func TestIsValidMaxAge(t *testing.T) {
 		{"24h", true},
 		{"90m", true},
 		{"45s", true},
-		{"1h30m", true}, // valid Go duration
+		{"1h30m", false}, // compound durations rejected — parseFindTimeArg can't apply them (#227 item 8)
+		{"1.5h", false},  // fractional Go duration — same reason
 		{"7days", false},
 		{"0d", false},
 		{"abc", false},


### PR DESCRIPTION
Pulls three of the nine deferred #227 items forward into the v1.12.0 release (analysis re-verified all nine against current main today; the rest stay deferred):

- **Item 8 — `maxAge` validator/runtime gap (tightening → belongs in a release):** `'1h30m'` passed validation via `time.ParseDuration` but `parseFindTimeArg` silently fell back to **7 days**. The validator now accepts exactly the single-unit `[dhms]` grammar the runtime applies.
- **Item 3 — silent stale-data restore:** the artifact resolver skipped Succeeded runs with an empty `ArtifactFilename` (capture is best-effort Pod-log parsing) and fell through to an **older** run — restoring stale data under a green status. Newest Succeeded run now wins or the restore fails actionably (names the run, points at `type=storage` + explicit path).
- **Item 4 — restore timestamps dropped:** `updateRestoreStatus` refetches and wrote only phase/message/conditions, so `StartTime`/`CompletionTime` stamped by the cluster Cypher path never persisted. Carried over now; earlier persisted values win.

NOT included (per scope decision): item 2 (convergence-handshake guard) and the rest of #227 stay deferred.

Verification: full `make test-unit` green (0 failures); new pinning tests `TestIsValidMaxAge` (flipped `1h30m` case + `1.5h`), `TestLatestSucceededArtifactFilename_NewestRunWithoutFilenameIsRefused` / `_NewestSucceededWins`, `TestUpdateRestoreStatus_PersistsCallerTimestamps` (incl. requeue-can't-move-timestamps). `maxAge` docs updated in the guide + API reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes restore artifact selection and admission rules for `maxAge`; misconfigured restores fail loudly instead of picking older backups, and compound `maxAge` values that previously validated will now be rejected.
> 
> **Overview**
> Addresses three **#227** pre-release fixes across backup validation, restore artifact selection, and restore status persistence.
> 
> **`retention.maxAge` (item 8):** Validation now only allows single-unit `d`/`h`/`m`/`s` values that `parseFindTimeArg` can apply. Compound Go durations (e.g. `"1h30m"`) are rejected at admission instead of passing validation and silently defaulting to 7 days at runtime. User guide and API reference document the stricter grammar.
> 
> **Restore from `backupRef` (item 3):** If the newest `Succeeded` backup run has an empty `artifactFilename` (best-effort pod-log capture), the operator **errors** with run ID and a `type=storage` workaround instead of using an older succeeded run—which could restore stale data while status looks healthy.
> 
> **Restore status timestamps (item 4):** `updateRestoreStatus` now copies `StartTime` and `CompletionTime` from the caller’s in-memory object after its refetch; already-persisted timestamps are not overwritten on requeue.
> 
> New unit tests cover `maxAge` rejection, artifact resolution, and timestamp persistence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9724e35df81508f05b417dfec31758a7eefbc5fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->