### PR TITLE
docs(dev): document the install-confidence gate and per-PR chart checks

### DIFF
--- a/docs/developer_guide/ci_and_workflows.md
+++ b/docs/developer_guide/ci_and_workflows.md
@@ -22,8 +22,13 @@ gate that blocks merge. Jobs:
 
 1. **Generated Artifacts In Sync (`check-drift`)** — runs `make check-drift`
    (`sync-all` + `bundle`, then `git diff --exit-code`). Fails if any committed
-   CRD, RBAC, deepcopy, Helm CRD, or OLM bundle file is stale. Fix locally with
-   `make sync-all` and commit the result.
+   CRD, RBAC, deepcopy, Helm CRD, or OLM bundle file is stale (untracked
+   generated files fail it too). Fix locally with `make sync-all` and commit
+   the result. The same job then runs `make helm-lint` and
+   `make check-csv-coverage` — both used to be ship-prep-only, which let a
+   chart template error or a CSV missing a new CRD hide until release time.
+   Static and seconds-fast; the failure summary distinguishes drift failures
+   from lint/coverage failures.
 2. **Unit Tests** — `make test-unit` (race-enabled, envtest-backed controller
    suite + plain unit tests). No external cluster required. The job runs the
    suite through [gotestsum](makefile_reference.md#make-gotestsum)
@@ -183,17 +188,53 @@ so there's no single shared variable):
 
 Bump both in the same PR — the bump is itself a tested change.
 
+## Install Confidence
+
+**`scripts/install-confidence.sh` — the install/upgrade/uninstall matrix on a
+throwaway Kind cluster.** Run locally with `make install-confidence` (~10–15
+min; needs kind, helm, kubectl, docker), or dispatch
+**`install-confidence.yml`** manually. It builds the operator image from the
+working tree, loads it into a fresh Kind cluster, and walks five legs:
+
+1. **Helm install, cluster mode** — default values, then a smoke
+   `Neo4jEnterpriseStandalone` CR proving the operator actually reconciles
+   (StatefulSet appears).
+2. **Helm install, namespaces mode + `rbac.perNamespaceRoles`** — asserts the
+   manager permissions land as a namespaced `Role` in the watched namespace and
+   NO manager ClusterRole is created.
+3. **Helm upgrade from the previously published chart** — installs the latest
+   released chart, applies the new CRDs with
+   `kubectl apply --server-side -f config/crd/bases/` (the step real users must
+   run — Helm never upgrades `crds/`), upgrades to the working-tree chart, and
+   probes a new-in-this-release CRD field to prove the refresh took.
+   `PREV_CHART_VERSION=<x.y.z>` pins the starting chart (empty = latest
+   published).
+4. **Documented-order uninstall with a live CR** — CRs first (finalizers need
+   the running operator), then `helm uninstall`, then CRDs; asserts nothing
+   wedges.
+5. **kubectl server-side apply path** — install, re-apply (idempotence), and
+   ordered teardown of the non-Helm manifests.
+
+The same matrix runs as a **blocking job in `release.yml`** — a release tag
+cannot publish an image or chart if any leg fails. Use the local run (or the
+dispatch workflow) to catch problems before tagging instead of failing the tag.
+
 ## Release
 
 **`release.yml` — tag-driven release pipeline.** Push a `vX.Y.Z` tag (or dispatch
 with a tag input). Jobs:
 
 1. **determine-tag / validate-release** — resolve the tag and run build/test
-   validation.
-2. **build-and-push** — multi-arch (`linux/amd64,linux/arm64`) image to
+   validation, including `make check-drift` (a tag on a commit that bypassed
+   per-PR CI must not ship stale generated artifacts).
+2. **install-confidence** — the full [install/upgrade/uninstall
+   matrix](#install-confidence) on Kind, in parallel with validate-release.
+   **Blocking**: `build-and-push` depends on it, so a broken install path
+   fails the release before anything is published.
+3. **build-and-push** — multi-arch (`linux/amd64,linux/arm64`) image to
    `ghcr.io/neo4j-partners/neo4j-kubernetes-operator`, **signed with Sigstore
    Cosign keyless** (`id-token: write` OIDC — no long-lived secrets).
-3. **create-release** — assembles the kubectl-applyable bundles
+4. **create-release** — assembles the kubectl-applyable bundles
    (`neo4j-kubernetes-operator-complete.yaml`, `…operator.yaml`), stamps the OLM
    CSV via `make bundle-release` (with a guard that refuses to publish if
    `createdAt:` is still the dev placeholder), renders the release body from
@@ -211,12 +252,15 @@ from the tag.
 **Before tagging** (on an up-to-date, green `main`):
 
 1. `make ship-prep` — regenerates everything, builds the bundle, and runs
-   `helm-lint` + `check-csv-coverage` (more than CI's drift gate). Review
-   `git status` and commit anything regenerated.
-2. If there are breaking changes or notable upgrade steps, add/extend the
+   `helm-lint` + `check-csv-coverage`. Review `git status` and commit anything
+   regenerated.
+2. (Recommended) `make install-confidence` — the same install/upgrade/uninstall
+   matrix the release workflow runs as a blocking gate. Running it locally
+   first means a failure costs you minutes, not a dead tag.
+3. If there are breaking changes or notable upgrade steps, add/extend the
    `Upgrading from vX to vY` section in
    [`migration_guide.md`](../user_guide/migration_guide.md).
-3. Draft the **What's Changed** notes — `git log <last-tag>..HEAD --pretty=oneline`
+4. Draft the **What's Changed** notes — `git log <last-tag>..HEAD --pretty=oneline`
    is a good starting point. (The release workflow renders only the
    boilerplate from `.github/release-notes-template.md`; the changelog is
    hand-written.)
@@ -233,15 +277,16 @@ kubectl bundles + OLM CSV), **Pages — Docs** (`/v1.12/` + `/latest/`), and
 
 **After the workflows finish:**
 
-4. Paste the **What's Changed** section into the GitHub release body (above the
+5. Paste the **What's Changed** section into the GitHub release body (above the
    generated boilerplate).
-5. Verify:
+6. Verify:
    - `gh run list` — Release, Pages — Docs, Pages — Helm Repo all green.
    - `gh release view v1.12.0` — has `…-complete.yaml` and `…operator.yaml` assets.
    - `helm repo update && helm search repo neo4j-operator/neo4j-operator --versions` — new version listed.
    - Docs `/latest/` and `/v1.12/` load and the version dropdown shows the release.
    - `cosign verify ghcr.io/neo4j-partners/neo4j-kubernetes-operator:v1.12.0 …` succeeds.
-   - (Optional, highest-confidence) `helm install` the published chart on a fresh Kind cluster.
+   - The release run's **Install Confidence Gate** job is green (it ran
+     automatically — no manual fresh-Kind `helm install` needed).
 
 ## Publishing to GitHub Pages
 

--- a/docs/developer_guide/makefile_reference.md
+++ b/docs/developer_guide/makefile_reference.md
@@ -42,6 +42,7 @@ make deploy-dev           # Deploy to development namespace
 # Pre-release / sync (after touching API types or +kubebuilder markers)
 make sync-all             # Regenerate all artifacts (CRDs, RBAC, helm chart, kustomize lists)
 make ship-prep            # sync-all + bundle + helm lint + CSV coverage check
+make install-confidence   # Pre-release gate: helm install/upgrade/uninstall matrix on Kind (~10-15 min)
 make check-drift          # CI gate: fails if any generated file is stale
 make bundle-release       # Bundle + real createdAt: timestamp (release workflow only)
 make install-hooks        # One-time: install pre-commit hooks (runs check-drift before commit)
@@ -137,6 +138,11 @@ Chains: `manifests` → `generate` → `sync-kustomize` → `sync-editor-viewer-
 **Description**: Pre-release one-shot. Runs `sync-all` plus `bundle`, `helm-lint`, and `check-csv-coverage`.
 **Usage**: `make ship-prep`
 **When to run**: before tagging a release. Verifies the Helm chart lints, the OperatorHub bundle validates, and every CRD is registered in the CSV.
+
+### `make install-confidence`
+**Description**: Pre-release confidence gate. Runs `scripts/install-confidence.sh`: builds the operator image from the working tree, creates a throwaway Kind cluster, and walks the five-leg install/upgrade/uninstall matrix — helm install (cluster mode + smoke CR), helm install (`namespaces` mode + `rbac.perNamespaceRoles`, asserting no manager ClusterRole), helm upgrade from the previously published chart including the mandatory server-side CRD refresh, documented-order uninstall with a live CR, and the kubectl server-side-apply path. ~10–15 minutes; needs kind, helm, kubectl, docker.
+**Usage**: `make install-confidence` (optionally `PREV_CHART_VERSION=1.11.2 make install-confidence` to pin the upgrade-from chart).
+**When to run**: before tagging a release. The same matrix runs automatically as a blocking job in `release.yml`, so a local run turns a would-be dead tag into a minutes-cheap local failure. Also dispatchable in CI via the `Install Confidence` workflow. See [CI & Workflows → Install Confidence](ci_and_workflows.md#install-confidence).
 
 ### `make check-drift`
 **Description**: Regenerate every artifact and `git diff --exit-code` to fail if anything is stale. Used as a CI gate (`.github/workflows/ci.yml`).

--- a/docs/developer_guide/testing.md
+++ b/docs/developer_guide/testing.md
@@ -655,6 +655,20 @@ It("Should use optimal resource patterns", func() {
 
 ## CI/CD Testing
 
+### Install/upgrade/uninstall matrix (install-confidence)
+
+Beyond unit and integration tests, the **install paths themselves** are tested:
+`make install-confidence` runs a five-leg helm/kubectl install, upgrade (with
+the mandatory server-side CRD refresh), and ordered-uninstall matrix on a
+throwaway Kind cluster. It runs automatically as a **blocking job in the
+release workflow** and is manually dispatchable (`install-confidence.yml`).
+Run it locally before tagging — see
+[CI & Workflows → Install Confidence](ci_and_workflows.md#install-confidence)
+for the legs and
+[the Makefile reference](makefile_reference.md#make-install-confidence) for
+usage. Per-PR CI also lints the chart and checks OperatorHub CSV coverage in
+the drift job, so chart template errors fail at PR time, not release time.
+
 ### GitHub Actions Integration
 
 Tests run automatically in CI with:


### PR DESCRIPTION
Stacked on #230 (documents that PR's machinery — will retarget to main after #230 merges).

Developer/testing docs now cover the new install-path validation: the five-leg `make install-confidence` matrix and dispatch workflow, the blocking release-gate job, the release-runbook step (run it locally so a failure costs minutes, not a dead tag), and the drift job's new helm-lint + CSV-coverage steps. Updated: `ci_and_workflows.md` (new section + release jobs + runbook), `makefile_reference.md` (target entry), `testing.md` (pointer in CI/CD Testing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or workflow behavior modified in this diff.
> 
> **Overview**
> Developer docs now describe **install-path validation** and **tighter per-PR chart gates** that complement existing CI/release workflows.
> 
> **`ci_and_workflows.md`** expands the drift job to note that **`helm-lint`** and **`check-csv-coverage`** run there (not only in `ship-prep`), including untracked generated files and clearer failure summaries. It adds an **Install Confidence** section for the five-leg Kind matrix (`make install-confidence` / `install-confidence.yml`), documents **`install-confidence` as a blocking release job** before `build-and-push`, and updates the release runbook (local `install-confidence`, post-release check for the Install Confidence Gate).
> 
> **`makefile_reference.md`** adds **`make install-confidence`** to Quick Start and a full target entry (legs, `PREV_CHART_VERSION`, release blocking).
> 
> **`testing.md`** adds a CI/CD subsection pointing readers to install-confidence and the drift job’s helm/CSV checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a979701f20063ace69045d8489d4745257659bca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->