### PR TITLE
test(integration): align remaining specs with the #215 {name}-client rename

### DIFF
--- a/test/integration/mcp_integration_test.go
+++ b/test/integration/mcp_integration_test.go
@@ -368,8 +368,9 @@ var _ = Describe("MCP Integration Tests", Label("extended"), func() {
 
 				neo4jURI := findEnvVar(container.Env, "NEO4J_URI")
 				// Standalone MCP URI uses the routing scheme for parity with
-				// the cluster builder; see internal/resources/mcp.go.
-				expectedURI := fmt.Sprintf("neo4j://%s-service.%s.svc.cluster.local:7687", standaloneName, namespace.Name)
+				// the cluster builder, and targets the canonical {name}-client
+				// Service (#215 rename); see internal/resources/mcp.go.
+				expectedURI := fmt.Sprintf("neo4j://%s-client.%s.svc.cluster.local:7687", standaloneName, namespace.Name)
 				if neo4jURI == nil || neo4jURI.Value != expectedURI {
 					return fmt.Errorf("expected NEO4J_URI=%s", expectedURI)
 				}

--- a/test/integration/standalone_deployment_test.go
+++ b/test/integration/standalone_deployment_test.go
@@ -142,11 +142,22 @@ var _ = Describe("Neo4jEnterpriseStandalone Integration Tests", Label("core"), f
 			}, sts)).To(Succeed())
 			Expect(*sts.Spec.Replicas).To(Equal(int32(1)))
 
-			By("Verifying Service was created")
+			By("Verifying canonical client Service was created")
+			// {name}-client is the canonical Service since the #215 rename.
+			// Asserting -client (not the one-release -service alias) so this
+			// spec survives the alias removal next release.
 			svc := &corev1.Service{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name: standaloneName + "-service", Namespace: namespaceName,
+				Name: standaloneName + "-client", Namespace: namespaceName,
 			}, svc)).To(Succeed())
+
+			By("Verifying deprecated -service alias exists with the deprecation annotation")
+			alias := &corev1.Service{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name: standaloneName + "-service", Namespace: namespaceName,
+			}, alias)).To(Succeed())
+			Expect(alias.Annotations).To(HaveKeyWithValue("neo4j.com/deprecated-alias-of", standaloneName+"-client"))
+			Expect(alias.Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
 
 			By("Verifying standalone status is Ready")
 			updated := &neo4jv1beta1.Neo4jEnterpriseStandalone{}


### PR DESCRIPTION
Fixes the extended-suite failure on main ([run 27408561169](https://github.com/neo4j-partners/neo4j-kubernetes-operator/actions/runs/27408561169)): the MCP standalone spec asserted `NEO4J_URI` → `{name}-service`, stale against #228 (the builder emits `{name}-client` — `internal/resources/mcp.go:591`). The spec is extended-lane, so #228's per-PR CI (core lane) never executed it. **Product behavior is correct** — verified live in today's v1.11.2→v1.12.0 upgrade rehearsal; this is a test-expectation fix only.

Sweep found one more: the core-lane standalone deployment spec asserted the `-service` Service exists — passing today only via the deprecated alias, and primed to break when the alias is removed next release. It now asserts the canonical `-client` and pins the alias's deprecation contract (ClusterIP + `neo4j.com/deprecated-alias-of` annotation).

Full `grep` sweep of `test/integration/` shows no other `-service` expectations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to expected Service names and alias annotations; no production code paths modified.
> 
> **Overview**
> Updates integration tests so they match the **#215** canonical `{name}-client` Service naming instead of the old `{name}-service` expectation.
> 
> In **MCP STDIO standalone** specs, the expected `NEO4J_URI` host is changed from `{name}-service` to `{name}-client`, matching what `internal/resources/mcp.go` emits (fixes extended-suite failure on main).
> 
> In the **core standalone deployment** spec, the primary assertion now checks the canonical `{name}-client` Service exists, and adds checks that the deprecated `{name}-service` alias remains with `neo4j.com/deprecated-alias-of` and `ClusterIP` type so the test still passes after the alias is removed next release.
> 
> **No operator/runtime behavior changes** — test expectations only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 698a2e8b8b5358cedbbfd9f14dc91f9917e61f96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->