### PR TITLE
fix(startup): terminate the startup-feedback loop on readiness; gate readyz on cache sync (#236)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -715,12 +715,22 @@ func runManager(ctx context.Context, settings managerSettings, selection watchNa
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		return fmt.Errorf("unable to set up health check: %w", err)
 	}
-	if err := mgr.AddReadyzCheck("readyz", createReadinessCheck(settings.skipCacheWait)); err != nil {
+
+	// started closes when the manager runs our signal Runnable — which
+	// controller-runtime does only after every informer cache has synced.
+	// It drives both the readiness probe (readyz genuinely reflects cache
+	// sync instead of always returning OK) and the startup-feedback loop's
+	// exit condition (#236: the loop previously ticked forever).
+	started := newManagerStartedSignal()
+	if err := mgr.Add(started); err != nil {
+		return fmt.Errorf("unable to add startup signal runnable: %w", err)
+	}
+	if err := mgr.AddReadyzCheck("readyz", createReadinessCheck(settings.skipCacheWait, started.ch)); err != nil {
 		return fmt.Errorf("unable to set up ready check: %w", err)
 	}
 
 	setupLog.Info("starting manager")
-	go startupFeedback(ctx, settings.operatorMode, settings.metricsAddr, settings.probeAddr, settings.skipCacheWait)
+	go startupFeedback(ctx, settings.operatorMode, settings.metricsAddr, settings.probeAddr, settings.skipCacheWait, started.ch)
 
 	if settings.skipCacheWait {
 		setupLog.Info("skipping cache sync wait - starting immediately")
@@ -882,27 +892,57 @@ func getSelectiveResourceCache() map[client.Object]cache.ByObject {
 	}
 }
 
-// createReadinessCheck creates a readiness check that can optionally skip cache sync
-func createReadinessCheck(skipCacheWait bool) healthz.Checker {
+// managerStartedSignal is a manager Runnable whose only job is to close its
+// channel when the manager starts it. controller-runtime starts plain
+// (non-leader-election) runnables only AFTER every informer cache has synced,
+// so the closed channel is a faithful "caches synced, manager running"
+// signal. NeedLeaderElection()=false means standby replicas (leader election
+// lost/pending) also report Ready — a standby is healthy, just not leading.
+type managerStartedSignal struct{ ch chan struct{} }
+
+func newManagerStartedSignal() *managerStartedSignal {
+	return &managerStartedSignal{ch: make(chan struct{})}
+}
+
+func (s *managerStartedSignal) Start(ctx context.Context) error {
+	close(s.ch)
+	<-ctx.Done() // block until shutdown so the runnable group treats us as long-running
+	return nil
+}
+
+func (s *managerStartedSignal) NeedLeaderElection() bool { return false }
+
+// createReadinessCheck creates a readiness check that can optionally skip cache sync.
+//
+// The comprehensive variant previously logged two INFO lines per kubelet
+// probe (every ~10s, forever) and unconditionally returned nil — log spam
+// with no verification (#236). It now returns an error until the manager
+// has actually started (caches synced) and is silent on the happy path.
+func createReadinessCheck(skipCacheWait bool, started <-chan struct{}) healthz.Checker {
 	if skipCacheWait {
 		setupLog.Info("using simplified readiness check (skipCacheWait=true)")
 		return healthz.Ping
 	}
 
-	setupLog.Info("using comprehensive readiness check with cache sync verification")
+	setupLog.Info("using readiness check gated on cache sync")
 	return func(_ *http.Request) error {
-		// Enhanced readiness check that provides detailed logging
-		setupLog.Info("readiness check triggered", "timestamp", time.Now().Format(time.RFC3339))
-
-		// Standard readiness check that waits for cache sync
-		// The controller-runtime manager will handle cache sync status internally
-		setupLog.Info("readiness check completed successfully")
-		return nil
+		select {
+		case <-started:
+			return nil
+		default:
+			return fmt.Errorf("manager still starting: informer caches not yet synced")
+		}
 	}
 }
 
-// startupFeedback provides startup feedback based on mode and cache strategy
-func startupFeedback(ctx context.Context, mode OperatorMode, metricsAddr, probeAddr string, skipCacheWait bool) {
+// startupFeedback provides startup feedback based on mode and cache strategy.
+//
+// The waiting loops exit as soon as `started` closes (the manager signal
+// runnable runs once caches are synced) with a single "startup complete"
+// line. Previously the production loop had NO exit condition besides ctx
+// cancellation and logged "still waiting for startup to complete" every 15s
+// for the operator's entire lifetime (#236).
+func startupFeedback(ctx context.Context, mode OperatorMode, metricsAddr, probeAddr string, skipCacheWait bool, started <-chan struct{}) {
 	defer func() {
 		if r := recover(); r != nil {
 			setupLog.Error(nil, "startup feedback goroutine panicked", "panic", r)
@@ -910,6 +950,13 @@ func startupFeedback(ctx context.Context, mode OperatorMode, metricsAddr, probeA
 	}()
 
 	setupLog.Info("starting startup feedback goroutine", "mode", mode, "skipCacheWait", skipCacheWait)
+
+	logStarted := func() {
+		setupLog.Info("manager startup complete - informer caches synced",
+			"metrics_endpoint", "http://localhost"+metricsAddr+"/metrics",
+			"health_endpoint", "http://localhost"+probeAddr+"/healthz",
+			"ready_endpoint", "http://localhost"+probeAddr+"/readyz")
+	}
 
 	switch mode {
 	case ProductionMode:
@@ -919,8 +966,13 @@ func startupFeedback(ctx context.Context, mode OperatorMode, metricsAddr, probeA
 			}
 			setupLog.Info("manager starting with cache optimizations")
 		} else {
-			if !sleepWithContext(ctx, 5*time.Second) {
+			select {
+			case <-started:
+				logStarted()
 				return
+			case <-ctx.Done():
+				return
+			case <-time.After(5 * time.Second):
 			}
 			setupLog.Info("manager is starting - waiting for informer caches to sync (this may take 30-60 seconds)")
 
@@ -931,6 +983,9 @@ func startupFeedback(ctx context.Context, mode OperatorMode, metricsAddr, probeA
 			for {
 				select {
 				case <-ctx.Done():
+					return
+				case <-started:
+					logStarted()
 					return
 				case <-ticker.C:
 					attempts++
@@ -973,6 +1028,9 @@ func startupFeedback(ctx context.Context, mode OperatorMode, metricsAddr, probeA
 			for {
 				select {
 				case <-ctx.Done():
+					return
+				case <-started:
+					logStarted()
 					return
 				case <-ticker.C:
 					attempts++

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"reflect"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -94,5 +95,87 @@ func TestWatchNamespaceSelectionEqual(t *testing.T) {
 	}
 	if watchNamespaceSelectionEqual(left, watchNamespaceSelection{namespaces: []string{"b", "c"}}) {
 		t.Fatalf("expected selections to differ")
+	}
+}
+
+// --- #236: startup feedback must terminate; readyz must reflect cache sync ---
+
+func TestCreateReadinessCheck_GatedOnStartedChannel(t *testing.T) {
+	started := make(chan struct{})
+	check := createReadinessCheck(false, started)
+
+	if err := check(nil); err == nil {
+		t.Fatal("readyz must fail before the manager has started (caches not synced)")
+	}
+	close(started)
+	if err := check(nil); err != nil {
+		t.Fatalf("readyz must succeed after the started signal: %v", err)
+	}
+}
+
+func TestCreateReadinessCheck_SkipCacheWaitIsPing(t *testing.T) {
+	started := make(chan struct{}) // never closed
+	check := createReadinessCheck(true, started)
+	if err := check(nil); err != nil {
+		t.Fatalf("skipCacheWait readiness must be unconditional Ping: %v", err)
+	}
+}
+
+func TestManagerStartedSignal_ClosesOnStartAndBlocks(t *testing.T) {
+	s := newManagerStartedSignal()
+	if s.NeedLeaderElection() {
+		t.Fatal("signal must opt out of leader election so standby replicas report Ready")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- s.Start(ctx) }()
+
+	select {
+	case <-s.ch:
+		// closed promptly — good
+	case <-time.After(2 * time.Second):
+		t.Fatal("started channel was not closed by Start")
+	}
+
+	select {
+	case <-done:
+		t.Fatal("Start must block until context cancellation (long-running runnable)")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Start returned error on shutdown: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return after context cancellation")
+	}
+}
+
+// TestStartupFeedback_ExitsWhenStarted pins the #236 fix: the production-mode
+// feedback loop must RETURN once the started signal fires instead of ticking
+// "still waiting for startup to complete" for the operator's lifetime.
+func TestStartupFeedback_ExitsWhenStarted(t *testing.T) {
+	started := make(chan struct{})
+	close(started) // manager already started — feedback must exit immediately
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	returned := make(chan struct{})
+	go func() {
+		startupFeedback(ctx, ProductionMode, ":8080", ":8081", false, started)
+		close(returned)
+	}()
+
+	select {
+	case <-returned:
+		// exited via the started signal, not the ctx timeout — proven by
+		// returning well before the 3s ctx deadline
+	case <-time.After(2 * time.Second):
+		t.Fatal("startupFeedback did not exit after the started signal (the #236 infinite loop)")
 	}
 }


### PR DESCRIPTION
Addresses #236 (left open for pinned-release verification per team policy).

The production startup-feedback loop had **no exit condition** other than operator shutdown — it ticked "still waiting for startup to complete" every 15s forever (the report shows `attempts: 210`, ~52 min of spam from a healthy operator). Separately, the "comprehensive readiness check" logged two INFO lines on every kubelet probe and unconditionally returned `nil` — log noise with no actual verification.

**Fix:** a `managerStartedSignal` Runnable closes a channel when the manager starts it. controller-runtime starts plain (non-leader-election) runnables only **after all informer caches sync**, so the channel is a faithful readiness signal; `NeedLeaderElection()=false` keeps standby replicas Ready. The feedback loops select on it, emit one `manager startup complete — informer caches synced` line, and exit. `readyz` now returns an error until the signal fires and is silent afterwards — the probe genuinely reflects cache sync for the first time. `skipCacheWait` behavior unchanged (plain Ping).

Note for reviewers: per-PR core CI runs on this; the in-flight extended suite tested the parent commit — the delta is this startup/probe wiring only, exercised by every integration job's operator deployment anyway (`waitForOperatorReady` hits `readyz`).

Pinned by three new unit tests (checker gating, signal semantics incl. blocking long-running contract, and loop termination). Full `go test ./cmd/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Kubernetes readiness semantics so workloads may stay NotReady longer until caches sync; behavior is more correct but affects rollout timing and anything polling readyz.
> 
> **Overview**
> Fixes **#236** by wiring operator startup to a real **cache-sync** signal instead of noisy, misleading readiness and feedback behavior.
> 
> A new **`managerStartedSignal`** manager Runnable closes a channel when controller-runtime starts it (after informer caches sync). **`readyz`** now fails until that channel closes—no more per-probe INFO spam or always-OK checks when caches are not ready. **`skipCacheWait`** still uses plain **`healthz.Ping`**.
> 
> **`startupFeedback`** selects on the same signal in production and dev wait loops: one **"manager startup complete"** log, then exit, instead of **"still waiting"** every 15s for the process lifetime. Standby replicas stay Ready via **`NeedLeaderElection() = false`**.
> 
> Unit tests cover readiness gating, signal semantics, and feedback loop termination.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b553e7f6cb01d5391c9e0927e972e5e1b37797d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
