### PR TITLE
test(integration): assert the shell-quoted --to-path the wave-1 hardening emits

### DIFF
--- a/test/integration/backup_integration_test.go
+++ b/test/integration/backup_integration_test.go
@@ -424,8 +424,12 @@ var _ = Describe("Backup Integration Tests", Label("extended"), Ordered, func() 
 		Expect(container.Args).To(HaveLen(2), "container Args must be [-c, <command>]")
 		// Rule 40: all runs of one CR share `<base>/<chain-root>/`; the
 		// chain-root is the CR name by default. PVC target → /backup/<name>/.
-		Expect(container.Args[1]).To(MatchRegexp(`--to-path=/backup/`+backup.Name+`/?`),
-			"--to-path must be the shared per-CR directory /backup/<chain-root>/ (chain-root = CR name)")
+		// The path is single-quoted since the rule-44 hardening (shellQuote on
+		// every user-influenced segment of the /bin/sh -c payload) — the
+		// quoting is load-bearing against shell injection, so assert it
+		// rather than tolerate it.
+		Expect(container.Args[1]).To(ContainSubstring(`--to-path='/backup/`+backup.Name+`/'`),
+			"--to-path must be the shell-quoted shared per-CR directory '/backup/<chain-root>/' (chain-root = CR name)")
 		Expect(container.Args[1]).ToNot(ContainSubstring("${BACKUP_RUN_ID}"),
 			"rule 40: --to-path must NOT include a ${BACKUP_RUN_ID} per-run subfolder — "+
 				"diff backups chain off the prior full in the SAME directory; per-run "+


### PR DESCRIPTION
Fixes the single failure in the extended re-run ([run 27410762588](https://github.com/neo4j-partners/neo4j-kubernetes-operator/actions/runs/27410762588): 46/47 passed): the backup spec matched `--to-path=/backup/<name>/` unquoted, but the wave-1 rule-44 hardening shellQuotes the path — actual command is `--to-path='/backup/<name>/'`. **Product is correct; stale extended-lane expectation**, same class as #240 (extended specs never ran on the wave PRs).

The new assertion pins the quoting itself (it's the injection guard — tolerating both forms would weaken the pin). Sweep of `test/integration/` confirms no other command-shape assertions exist.

Independent of #241 (different files); landing after it per release sequencing, then re-dispatching the extended suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no production code or runtime behavior is modified.
> 
> **Overview**
> Updates the extended backup integration test so it expects **shell-quoted** `--to-path` in the backup Job’s `/bin/sh -c` command (`--to-path='/backup/<chain-root>/'`), matching rule-44 **shellQuote** hardening on user-influenced path segments.
> 
> The assertion switches from an unquoted path regex to `ContainSubstring` and documents that the quotes are part of the injection guard, so the test must not accept both quoted and unquoted forms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0acddddfcca4504d10180b4fb4260d2f9739e8f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->