### PR TITLE
fix(demo,docs): user-journey and demo polish from the v1.12.0 fresh-eyes walkthrough

### DIFF
--- a/docs/user_guide/getting_started.md
+++ b/docs/user_guide/getting_started.md
@@ -7,8 +7,9 @@ This guide will walk you through the process of deploying your first Neo4j Enter
 *   A Kubernetes cluster (v1.32+)
 *   `kubectl` installed and configured
 *   Neo4j Enterprise Edition — **5.26 LTS or any CalVer release** (2025.x, 2026.x, …); evaluation license acceptable for testing. See [Supported Neo4j Versions](version_support.md) for the full support policy.
-*   Go 1.26+ (for building from source)
 *   cert-manager 1.20+ (optional, for TLS-enabled deployments)
+
+Building from source additionally needs Go 1.26+ — see the [Installation Guide](installation.md) for that path.
 
 > **Neo4j version:** the examples below pin `5.26.0-enterprise`, but every one
 > works on a CalVer release too — just change the image `tag` (e.g.
@@ -52,17 +53,11 @@ For detailed information about modes, configuration options, and caching strateg
 
 ### Quick Mode Selection
 
-```bash
-# Production deployment (uses local image by default)
-make deploy-prod
-
-# Development deployment (uses local image by default)
-make deploy-dev
-
-# Alternative: Registry-based deployment
-make deploy-prod-registry  # Requires ghcr.io access
-make deploy-dev-registry   # Requires registry access for dev image
-```
+The Helm install above runs in production mode by default; set
+`developmentMode: true` in your values for development mode. Contributors
+working from a clone of this repository can instead use the `make`
+deployment targets (`make deploy-prod`, `make deploy-dev`) — see the
+[Makefile reference](../developer_guide/makefile_reference.md).
 
 **⚠️ Important:** The operator must always run in-cluster, even for development. This ensures proper DNS resolution and cluster connectivity required for Neo4j cluster formation.
 
@@ -88,7 +83,7 @@ For development, testing, or simple workloads that don't require high availabili
 2.  **Deploy the standalone instance:**
 
     ```bash
-    kubectl apply -f examples/standalone/single-node-standalone.yaml
+    kubectl apply -f https://raw.githubusercontent.com/neo4j-partners/neo4j-kubernetes-operator/main/examples/standalone/single-node-standalone.yaml
     ```
 
 3.  **Check deployment status:**
@@ -123,7 +118,7 @@ For production workloads requiring high availability and clustering:
 2.  **Deploy the minimal cluster:**
 
     ```bash
-    kubectl apply -f examples/clusters/minimal-cluster.yaml
+    kubectl apply -f https://raw.githubusercontent.com/neo4j-partners/neo4j-kubernetes-operator/main/examples/clusters/minimal-cluster.yaml
     ```
 
 3.  **Monitor deployment (2-3 minutes expected):**
@@ -146,10 +141,10 @@ For production workloads requiring high availability and clustering:
 
     ```bash
     # Five-server production cluster (TLS via cert-manager)
-    kubectl apply -f examples/clusters/multi-server-cluster.yaml
+    kubectl apply -f https://raw.githubusercontent.com/neo4j-partners/neo4j-kubernetes-operator/main/examples/clusters/multi-server-cluster.yaml
 
     # Three-server cluster, no TLS (simplest for local testing)
-    kubectl apply -f examples/clusters/three-node-simple.yaml
+    kubectl apply -f https://raw.githubusercontent.com/neo4j-partners/neo4j-kubernetes-operator/main/examples/clusters/three-node-simple.yaml
     ```
 
 3.  **Monitor deployment (3-5 minutes expected):**

--- a/docs/user_guide/guides/backup_restore.md
+++ b/docs/user_guide/guides/backup_restore.md
@@ -8,7 +8,7 @@ Back up and restore Neo4j Enterprise clusters and standalone instances via the `
 kubectl create secret generic neo4j-admin-secret \
   --from-literal=username=neo4j --from-literal=password=admin123
 
-kubectl apply -f examples/backup-restore/backup-pvc-simple.yaml
+kubectl apply -f https://raw.githubusercontent.com/neo4j-partners/neo4j-kubernetes-operator/main/examples/backup-restore/backup-pvc-simple.yaml
 kubectl get neo4jbackups simple-backup -w
 ```
 

--- a/hack/cleanup-dev.sh
+++ b/hack/cleanup-dev.sh
@@ -310,10 +310,13 @@ EOF
     esac
 done
 
-# Ensure we're not in a pipe that could mask errors
-if [[ -t 0 ]]; then
+# The TTY guard exists to protect the interactive confirm() prompts — with
+# FORCE=true every prompt is bypassed, so non-TTY (CI, make demo-fast,
+# scripted runs) is safe and must work; refusing here made dev-destroy
+# silently skip cleanup behind an ERROR that '|| true' swallowed.
+if [[ -t 0 || "${FORCE}" == "true" ]]; then
     main "$@"
 else
-    log_error "This script should not be run in a pipeline for safety reasons"
+    log_error "Interactive confirmation needs a TTY. Re-run with FORCE=true to skip prompts (e.g. FORCE=true hack/cleanup-dev.sh)"
     exit 1
 fi

--- a/scripts/demo-setup.sh
+++ b/scripts/demo-setup.sh
@@ -76,7 +76,7 @@ main() {
     # Step 1: Destroy existing environment
     log_section "Cleaning Up Existing Environment"
     log_info "Destroying any existing dev and test clusters..."
-    make dev-destroy 2>/dev/null || true
+    FORCE=true make dev-destroy 2>/dev/null || true
     make test-destroy 2>/dev/null || true
     sleep 2
 

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -323,13 +323,10 @@ show_connection_info() {
 
     log_section "Connection Information"
 
-    # Standalone uses different service naming
-    local client_service
-    if [[ "${resource_type}" == "standalone" ]]; then
-        client_service="${cluster_name}-service"
-    else
-        client_service="${cluster_name}-client"
-    fi
+    # {name}-client is the canonical client Service for BOTH kinds since the
+    # v1.12 naming unification (#215); the {name}-service alias is deprecated
+    # and removed in the next release — never show it to demo viewers.
+    local client_service="${cluster_name}-client"
     local bolt_port="7687"
     local http_port="7474"
     local https_port="7473"
@@ -721,10 +718,10 @@ demonstrate_standalone_external_access() {
     log_demo "  • Secure TLS connections"
 
     log_info "Setting up port-forward to standalone..."
-    log_command "kubectl port-forward svc/${CLUSTER_NAME_SINGLE}-service -n ${DEMO_NAMESPACE} 7473:7473 7687:7687 &"
+    log_command "kubectl port-forward svc/${CLUSTER_NAME_SINGLE}-client -n ${DEMO_NAMESPACE} 7473:7473 7687:7687 &"
 
     # Start port-forward in background
-    kubectl port-forward svc/${CLUSTER_NAME_SINGLE}-service -n ${DEMO_NAMESPACE} 7473:7473 7687:7687 >/dev/null 2>&1 &
+    kubectl port-forward svc/${CLUSTER_NAME_SINGLE}-client -n ${DEMO_NAMESPACE} 7473:7473 7687:7687 >/dev/null 2>&1 &
     local pf_pid=$!
 
     sleep 3
@@ -1604,7 +1601,7 @@ demo_cleanup() {
     kubectl delete secret neo4j-admin-secret -n "${DEMO_NAMESPACE}" --ignore-not-found=true 2>/dev/null
     kubectl delete secret demo-reader-creds -n "${DEMO_NAMESPACE}" --ignore-not-found=true 2>/dev/null
     kubectl delete svc -l "neo4j.com/cluster=${CLUSTER_NAME_MULTI}" -n "${DEMO_NAMESPACE}" --ignore-not-found=true 2>/dev/null
-    kubectl delete svc "${CLUSTER_NAME_SINGLE}-service" -n "${DEMO_NAMESPACE}" --ignore-not-found=true 2>/dev/null
+    kubectl delete svc "${CLUSTER_NAME_SINGLE}-client" -n "${DEMO_NAMESPACE}" --ignore-not-found=true 2>/dev/null
     kubectl delete configmap "${CLUSTER_NAME_SINGLE}-config" -n "${DEMO_NAMESPACE}" --ignore-not-found=true 2>/dev/null
     kubectl delete pvc -l "app=${CLUSTER_NAME_SINGLE}" -n "${DEMO_NAMESPACE}" --ignore-not-found=true 2>/dev/null
     kubectl delete pvc -l "neo4j.com/cluster=${CLUSTER_NAME_MULTI}" -n "${DEMO_NAMESPACE}" --ignore-not-found=true 2>/dev/null


### PR DESCRIPTION
Ran the full post-release user journey on a sterile machine: published docs → Helm install of v1.12.0 → standalone (Ready 70s) → 3-node cluster (Ready ~2m) → DBs with topology — all green; plus a complete `make demo-fast` (all 8 parts pass on a from-source operator). Four findings, all fixed:

1. **demo.sh taught the deprecated Service name** — Part 3's copy-paste `port-forward svc/{name}-service` works only while the one-release alias exists. Unified on `{name}-client` (connection info + port-forward + cleanup).
2. **`cleanup-dev.sh` silently no-ops in every scripted run** — its TTY guard refused non-interactive stdin and `dev-destroy`'s `|| true` swallowed the refusal (the demo only survived because of the subsequent bare `kind delete`). `FORCE=true` now permits non-TTY since it bypasses the prompts the guard protects; `demo-setup.sh` passes it.
3. **Quickstart's apply commands assumed a clone** the documented Helm path never creates — now raw GitHub URLs; Go prereq scoped to source builds; make-target section reframed as contributor path. (Gallery/installation clone-scoped sections checked — legitimately relative.)
4. Same relative-path fix in the backup guide opener.

Verification: `bash -n` on all three scripts; demo `--cleanup-only` re-run live through the edited path; doc links checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and shell-script UX fixes only; no operator runtime, auth, or data-path changes.
> 
> **Overview**
> Aligns **Helm-first quickstarts** with users who never clone the repo: example `kubectl apply` commands now use **raw GitHub URLs**, **Go 1.26+** is documented only for source builds, and **make deploy-*** is framed as the contributor path instead of the default mode selection.
> 
> **Demo and dev scripts** now teach the v1.12 canonical **`{name}-client`** Service (standalone port-forward, connection info, and cleanup) instead of the deprecated **`{name}-service`** alias.
> 
> **`hack/cleanup-dev.sh`** allows non-TTY runs when **`FORCE=true`** (prompts are already skipped), fixing **`dev-destroy`** / **`demo-setup`** cases where cleanup exited early and errors were swallowed by **`|| true`**; **`demo-setup.sh`** passes **`FORCE=true`** into **`make dev-destroy`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4d0745d57a97cbac3164d627b7724ae40ba6326. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->