### PR TITLE
fix: v1.12.0 user-journey field findings — restore verification, replaceExisting, retry, validate gate, tempPath, Secret pending

### DIFF
--- a/internal/controller/backup_restore_field_findings_test.go
+++ b/internal/controller/backup_restore_field_findings_test.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"testing"
 
+	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
@@ -116,5 +117,45 @@ func TestRestoreOverwriteConfirmed(t *testing.T) {
 				t.Errorf("restoreOverwriteConfirmed = %v, want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+// Retention-on-delete field findings: the cleanup Job was (1) owner-ref'd to
+// the CR being deleted — the GC raced (and beat) the prune script — and
+// (2) built on `find -printf`, which busybox/alpine find doesn't implement,
+// so even a surviving Job died under `set -e`. Verified live: maxCount=2 with
+// 7 artifacts pruned nothing.
+func TestBuildRetentionScript_BusyboxPortable(t *testing.T) {
+	policy := &neo4jv1beta1.RetentionPolicy{MaxCount: 2, MaxAge: "7d"}
+	script := buildRetentionScript(policy, "chain")
+	if strings.Contains(script, "-printf") {
+		t.Errorf("retention script must not use find -printf (unsupported on busybox/alpine):\n%s", script)
+	}
+	if !strings.Contains(script, "stat -c '%Y %n'") {
+		t.Errorf("expected busybox-portable stat -c mtime listing:\n%s", script)
+	}
+	if !strings.Contains(script, "MAX_COUNT=2") {
+		t.Errorf("maxCount not rendered:\n%s", script)
+	}
+}
+
+func TestCleanupJobHasNoOwnerReference(t *testing.T) {
+	r := newShardedTestReconciler(t)
+	backup := fieldFindingsBackup(nil)
+	backup.Spec.Retention = &neo4jv1beta1.RetentionPolicy{MaxCount: 2}
+	backup.Spec.Options = &neo4jv1beta1.BackupOptions{BackupType: "FULL"}
+
+	if err := r.cleanupBackupArtifacts(context.Background(), backup); err != nil {
+		t.Fatalf("cleanupBackupArtifacts: %v", err)
+	}
+	jobs := &batchv1.JobList{}
+	if err := r.List(context.Background(), jobs); err != nil {
+		t.Fatalf("list jobs: %v", err)
+	}
+	if len(jobs.Items) != 1 {
+		t.Fatalf("expected exactly one cleanup Job, got %d", len(jobs.Items))
+	}
+	if len(jobs.Items[0].OwnerReferences) != 0 {
+		t.Errorf("cleanup Job must NOT be owner-ref'd to the CR being deleted (GC races the prune script); got: %v", jobs.Items[0].OwnerReferences)
 	}
 }

--- a/internal/controller/backup_restore_field_findings_test.go
+++ b/internal/controller/backup_restore_field_findings_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package controller
+
+// Pinning tests for the v1.12.0 field findings (#251, #253-#256): bugs that
+// shipped because the documented paths were never the tested paths. Each test
+// here executes the path the DOCS teach, not the path the original specs took.
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
+)
+
+func fieldFindingsCluster(tag string) *neo4jv1beta1.Neo4jEnterpriseCluster {
+	return &neo4jv1beta1.Neo4jEnterpriseCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "ec", Namespace: "default"},
+		Spec: neo4jv1beta1.Neo4jEnterpriseClusterSpec{
+			Image:    neo4jv1beta1.ImageSpec{Repo: "neo4j", Tag: tag},
+			Topology: neo4jv1beta1.TopologyConfiguration{Servers: 2},
+		},
+	}
+}
+
+func fieldFindingsBackup(opts *neo4jv1beta1.BackupOptions) *neo4jv1beta1.Neo4jBackup {
+	return &neo4jv1beta1.Neo4jBackup{
+		ObjectMeta: metav1.ObjectMeta{Name: "bk", Namespace: "default"},
+		Spec: neo4jv1beta1.Neo4jBackupSpec{
+			Target: neo4jv1beta1.BackupTarget{
+				Kind:       neo4jv1beta1.BackupTargetKindDatabase,
+				Name:       "neo4j",
+				ClusterRef: "ec",
+			},
+			Storage: neo4jv1beta1.StorageLocation{
+				Type: "pvc",
+				PVC:  &neo4jv1beta1.PVCSpec{Name: "backup-pvc"},
+			},
+			Options: opts,
+		},
+	}
+}
+
+// #256: a user-supplied options.tempPath must get a mkdir prelude — neo4j-admin
+// refuses a staging path that doesn't exist, and nothing else creates it (the
+// shipped MinIO example failed on exactly this).
+func TestBuildBackupCommand_TempPathGetsMkdirPrelude(t *testing.T) {
+	r := newShardedTestReconciler(t)
+	backup := fieldFindingsBackup(&neo4jv1beta1.BackupOptions{TempPath: "/tmp/neo4j-backup-staging"})
+
+	cmd, err := r.buildBackupCommand(context.Background(), backup, fieldFindingsCluster("5.26.0-enterprise"))
+	if err != nil {
+		t.Fatalf("buildBackupCommand: %v", err)
+	}
+	if !strings.Contains(cmd, "mkdir -p '/tmp/neo4j-backup-staging' && ") {
+		t.Errorf("tempPath must be created before neo4j-admin runs; got: %q", cmd)
+	}
+	if !strings.Contains(cmd, "--temp-path='/tmp/neo4j-backup-staging'") {
+		t.Errorf("expected quoted --temp-path; got: %q", cmd)
+	}
+}
+
+// #255: `neo4j-admin backup validate` exists only on CalVer images. On 5.26
+// the clause must be SKIPPED (previously it was emitted, rejected by the CLI,
+// and swallowed by `|| true` — the user silently got no validation).
+func TestBuildBackupCommand_ValidateGatedOnCalver(t *testing.T) {
+	vTrue := true
+	r := newShardedTestReconciler(t)
+	backup := fieldFindingsBackup(&neo4jv1beta1.BackupOptions{Validate: &vTrue})
+
+	cmd, err := r.buildBackupCommand(context.Background(), backup, fieldFindingsCluster("5.26.0-enterprise"))
+	if err != nil {
+		t.Fatalf("buildBackupCommand (5.26): %v", err)
+	}
+	if strings.Contains(cmd, "backup validate") {
+		t.Errorf("validate clause must be skipped on 5.26 (subcommand doesn't exist); got: %q", cmd)
+	}
+
+	cmd, err = r.buildBackupCommand(context.Background(), backup, fieldFindingsCluster("2026.04-enterprise"))
+	if err != nil {
+		t.Fatalf("buildBackupCommand (calver): %v", err)
+	}
+	if !strings.Contains(cmd, "backup validate") {
+		t.Errorf("validate clause expected on CalVer; got: %q", cmd)
+	}
+}
+
+// #253: both spec.force and options.replaceExisting are documented as the
+// overwrite confirmation; the Job command builders must honor BOTH (only
+// force was wired, so the documented replaceExisting path failed with
+// "Database ... already exists").
+func TestRestoreOverwriteConfirmed(t *testing.T) {
+	cases := []struct {
+		name string
+		spec neo4jv1beta1.Neo4jRestoreSpec
+		want bool
+	}{
+		{"force only", neo4jv1beta1.Neo4jRestoreSpec{Force: true}, true},
+		{"replaceExisting only", neo4jv1beta1.Neo4jRestoreSpec{Options: &neo4jv1beta1.RestoreOptionsSpec{ReplaceExisting: true}}, true},
+		{"both", neo4jv1beta1.Neo4jRestoreSpec{Force: true, Options: &neo4jv1beta1.RestoreOptionsSpec{ReplaceExisting: true}}, true},
+		{"neither", neo4jv1beta1.Neo4jRestoreSpec{}, false},
+		{"nil options", neo4jv1beta1.Neo4jRestoreSpec{Options: nil}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &neo4jv1beta1.Neo4jRestore{Spec: tc.spec}
+			if got := restoreOverwriteConfirmed(r); got != tc.want {
+				t.Errorf("restoreOverwriteConfirmed = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/controller/cluster_upgrade_gate_test.go
+++ b/internal/controller/cluster_upgrade_gate_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package controller
+
+// Pinning tests for #262: an image change while the cluster is not Ready must
+// be HELD (never silently applied by the normal config-restart path), Ready
+// must not be declared mid-rollout, and these guarantees are what makes the
+// status.version backfill at Ready truthful.
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
+)
+
+func gateTestReconciler(t *testing.T, objs ...runtime.Object) *Neo4jEnterpriseClusterReconciler {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = neo4jv1beta1.AddToScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).
+		WithStatusSubresource(&neo4jv1beta1.Neo4jEnterpriseCluster{}).Build()
+	return &Neo4jEnterpriseClusterReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(16)}
+}
+
+func gateTestSTS(image string, replicas int32, currentRev, updateRev string, updated, ready int32) *appsv1.StatefulSet {
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "c-server", Namespace: "default"},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "neo4j", Image: image}}},
+			},
+		},
+		Status: appsv1.StatefulSetStatus{
+			CurrentRevision: currentRev,
+			UpdateRevision:  updateRev,
+			UpdatedReplicas: updated,
+			ReadyReplicas:   ready,
+		},
+	}
+}
+
+func gateTestCluster(tag, phase string) *neo4jv1beta1.Neo4jEnterpriseCluster {
+	return &neo4jv1beta1.Neo4jEnterpriseCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: "default"},
+		Spec: neo4jv1beta1.Neo4jEnterpriseClusterSpec{
+			Image:    neo4jv1beta1.ImageSpec{Repo: "neo4j", Tag: tag},
+			Topology: neo4jv1beta1.TopologyConfiguration{Servers: 3},
+		},
+		Status: neo4jv1beta1.Neo4jEnterpriseClusterStatus{Phase: phase},
+	}
+}
+
+// The core #262 pin: image drift + cluster NOT Ready → the in-memory spec is
+// pinned to the StatefulSet's current image, so the normal path cannot stomp
+// the version change in as a config restart.
+func TestHoldImageDriftUntilReady_PinsSpecWhileNotReady(t *testing.T) {
+	sts := gateTestSTS("neo4j:5.26.0-enterprise", 3, "rev1", "rev1", 3, 3)
+	cluster := gateTestCluster("2026.04-enterprise", "Forming")
+	r := gateTestReconciler(t, sts, cluster)
+
+	r.holdImageDriftUntilReady(context.Background(), cluster)
+
+	if cluster.Spec.Image.Tag != "5.26.0-enterprise" || cluster.Spec.Image.Repo != "neo4j" {
+		t.Errorf("spec must be pinned to the running image while not Ready; got %s:%s", cluster.Spec.Image.Repo, cluster.Spec.Image.Tag)
+	}
+}
+
+func TestHoldImageDriftUntilReady_NoDriftNoTouch(t *testing.T) {
+	sts := gateTestSTS("neo4j:5.26.0-enterprise", 3, "rev1", "rev1", 3, 3)
+	cluster := gateTestCluster("5.26.0-enterprise", "Forming")
+	r := gateTestReconciler(t, sts, cluster)
+	r.holdImageDriftUntilReady(context.Background(), cluster)
+	if cluster.Spec.Image.Tag != "5.26.0-enterprise" {
+		t.Errorf("no drift: spec must be untouched; got %s", cluster.Spec.Image.Tag)
+	}
+}
+
+func TestHoldImageDriftUntilReady_NoStatefulSetNoTouch(t *testing.T) {
+	cluster := gateTestCluster("2026.04-enterprise", "")
+	r := gateTestReconciler(t, cluster)
+	r.holdImageDriftUntilReady(context.Background(), cluster)
+	if cluster.Spec.Image.Tag != "2026.04-enterprise" {
+		t.Errorf("initial install (no STS): spec must be untouched; got %s", cluster.Spec.Image.Tag)
+	}
+}
+
+// Ready must not be declared while a rollout is in flight (#262: 'Ready' was
+// reported over a mixed-version cluster mid-roll).
+func TestServerStatefulSetFullyRolled(t *testing.T) {
+	cases := []struct {
+		name string
+		sts  *appsv1.StatefulSet
+		want bool
+	}{
+		{"fully rolled", gateTestSTS("neo4j:x", 3, "rev2", "rev2", 3, 3), true},
+		{"revision mismatch (mid-roll)", gateTestSTS("neo4j:x", 3, "rev1", "rev2", 1, 3), false},
+		{"updated lagging", gateTestSTS("neo4j:x", 3, "rev2", "rev2", 2, 3), false},
+		{"ready lagging", gateTestSTS("neo4j:x", 3, "rev2", "rev2", 3, 2), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cluster := gateTestCluster("x", "Forming")
+			r := gateTestReconciler(t, tc.sts, cluster)
+			got, detail := r.serverStatefulSetFullyRolled(context.Background(), cluster)
+			if got != tc.want {
+				t.Errorf("fullyRolled = %v (detail %q), want %v", got, detail, tc.want)
+			}
+		})
+	}
+}

--- a/internal/controller/neo4jbackup_controller.go
+++ b/internal/controller/neo4jbackup_controller.go
@@ -860,6 +860,19 @@ func (r *Neo4jBackupReconciler) waitForChainConcurrencyClear(ctx context.Context
 	return nil
 }
 
+// warnValidateUnsupported emits the one-time Warning that options.validate
+// has no effect on this Neo4j version. Called from Job/CronJob CREATION
+// paths only (never from buildBackupCommand, which runs every reconcile).
+func (r *Neo4jBackupReconciler) warnValidateUnsupported(backup *neo4jv1beta1.Neo4jBackup, cluster *neo4jv1beta1.Neo4jEnterpriseCluster) {
+	if backup.Spec.Options == nil || backup.Spec.Options.Validate == nil || !*backup.Spec.Options.Validate {
+		return
+	}
+	if v, err := neo4j.ParseVersion(cluster.Spec.Image.Tag); err == nil && !v.IsCalver {
+		r.Recorder.Event(backup, corev1.EventTypeWarning, "BackupValidateUnsupported",
+			fmt.Sprintf("options.validate requires a CalVer (2025.x+) Neo4j image — `neo4j-admin backup validate` does not exist on %s; skipping validation", cluster.Spec.Image.Tag))
+	}
+}
+
 func (r *Neo4jBackupReconciler) createBackupJob(ctx context.Context, backup *neo4jv1beta1.Neo4jBackup, cluster *neo4jv1beta1.Neo4jEnterpriseCluster) (*batchv1.Job, error) {
 	// Glob-safety check for sharded backups: refuse to submit a Job whose
 	// `{name}*` neo4j-admin glob would also pull in unrelated databases. No-op
@@ -950,6 +963,7 @@ func (r *Neo4jBackupReconciler) createBackupJob(ctx context.Context, backup *neo
 	if err := controllerutil.SetControllerReference(backup, job, r.Scheme); err != nil {
 		return nil, err
 	}
+	r.warnValidateUnsupported(backup, cluster)
 	if err := r.Create(ctx, job); err != nil {
 		// AlreadyExists = a previous reconcile created the Job but the
 		// informer cache hadn't caught up when handleOneTimeBackup looked it
@@ -1072,7 +1086,7 @@ func (r *Neo4jBackupReconciler) createBackupCronJob(ctx context.Context, backup 
 		},
 	}
 
-	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, cronJob, func() error {
+	opResult, err := controllerutil.CreateOrUpdate(ctx, r.Client, cronJob, func() error {
 		labels := backupLabels(backup, "backup-cron")
 		cronJob.Labels = labels
 		cronJob.Spec.Schedule = backup.Spec.Schedule
@@ -1125,6 +1139,10 @@ func (r *Neo4jBackupReconciler) createBackupCronJob(ctx context.Context, backup 
 		}
 		return controllerutil.SetControllerReference(backup, cronJob, r.Scheme)
 	})
+	if err == nil && opResult == controllerutil.OperationResultCreated {
+		// Warn once, at CronJob creation — not on every reconcile pass.
+		r.warnValidateUnsupported(backup, cluster)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -1298,8 +1316,12 @@ func (r *Neo4jBackupReconciler) buildBackupCommand(ctx context.Context, backup *
 		// `|| true` swallowed it, and the user silently got no validation
 		// (#255). Skip the clause and say so loudly instead.
 		if !version.IsCalver {
-			r.Recorder.Event(backup, corev1.EventTypeWarning, "BackupValidateUnsupported",
-				fmt.Sprintf("options.validate requires a CalVer (2025.x+) Neo4j image — `neo4j-admin backup validate` does not exist on %s; skipping validation", cluster.Spec.Image.Tag))
+			// Skip silently here — buildBackupCommand runs on EVERY
+			// scheduled-backup reconcile, so eventing from this spot
+			// spams Warning events while nothing changes. The event is
+			// emitted once at Job/CronJob creation via
+			// warnValidateUnsupported.
+			log.FromContext(ctx).Info("options.validate skipped: not supported on this Neo4j version", "tag", cluster.Spec.Image.Tag)
 		} else {
 			validateDBArg := dbName
 			if allDatabases {

--- a/internal/controller/neo4jbackup_controller.go
+++ b/internal/controller/neo4jbackup_controller.go
@@ -1139,8 +1139,11 @@ func (r *Neo4jBackupReconciler) createBackupCronJob(ctx context.Context, backup 
 		}
 		return controllerutil.SetControllerReference(backup, cronJob, r.Scheme)
 	})
-	if err == nil && opResult == controllerutil.OperationResultCreated {
-		// Warn once, at CronJob creation — not on every reconcile pass.
+	if err == nil && (opResult == controllerutil.OperationResultCreated || opResult == controllerutil.OperationResultUpdated) {
+		// Warn when the CronJob is created OR actually changes (a user adding
+		// options.validate to an existing schedule lands here as Updated).
+		// CreateOrUpdate returns OperationResultNone for no-op passes, so
+		// steady-state reconciles stay silent.
 		r.warnValidateUnsupported(backup, cluster)
 	}
 	if err != nil {

--- a/internal/controller/neo4jbackup_controller.go
+++ b/internal/controller/neo4jbackup_controller.go
@@ -1232,6 +1232,12 @@ func (r *Neo4jBackupReconciler) buildBackupCommand(ctx context.Context, backup *
 		if backup.Spec.Options.TempPath != "" {
 			// User-controlled path into a /bin/sh -c command — quote (#219).
 			cmd += " --temp-path=" + shellQuote(backup.Spec.Options.TempPath)
+			// neo4j-admin refuses a staging path that doesn't exist
+			// ("Storage staging path does not exist") and nothing else
+			// creates a bare tempPath — the restore path has had this
+			// prelude since the wave hardening; the backup path didn't,
+			// which broke the shipped MinIO example (#256).
+			cmd = "mkdir -p " + shellQuote(backup.Spec.Options.TempPath) + " && " + cmd
 		} else if backup.Spec.Options.TempStorage != nil {
 			cmd += " --temp-path=/tmp/neo4j-staging"
 		}
@@ -1287,16 +1293,25 @@ func (r *Neo4jBackupReconciler) buildBackupCommand(ctx context.Context, backup *
 	// — unparseable. Strip the trailing `*` here so validate sees the
 	// canonical parent name.
 	if backup.Spec.Options != nil && backup.Spec.Options.Validate != nil && *backup.Spec.Options.Validate {
-		validateDBArg := dbName
-		if allDatabases {
-			validateDBArg = "*"
+		// `neo4j-admin backup validate` exists only on CalVer images — on
+		// 5.26 the CLI rejects the subcommand ("Unmatched arguments"), the
+		// `|| true` swallowed it, and the user silently got no validation
+		// (#255). Skip the clause and say so loudly instead.
+		if !version.IsCalver {
+			r.Recorder.Event(backup, corev1.EventTypeWarning, "BackupValidateUnsupported",
+				fmt.Sprintf("options.validate requires a CalVer (2025.x+) Neo4j image — `neo4j-admin backup validate` does not exist on %s; skipping validation", cluster.Spec.Image.Tag))
 		} else {
-			validateDBArg = strings.TrimSuffix(validateDBArg, "*")
+			validateDBArg := dbName
+			if allDatabases {
+				validateDBArg = "*"
+			} else {
+				validateDBArg = strings.TrimSuffix(validateDBArg, "*")
+			}
+			// toPath carries user-controlled spec fields — quote it (#219). The
+			// database arg is double-quoted by design (validated name or literal
+			// glob that neo4j-admin, not the shell, must expand).
+			cmd += fmt.Sprintf(` && (neo4j-admin backup validate --from-path=%s --database="%s" || true)`, shellQuote(toPath), validateDBArg)
 		}
-		// toPath carries user-controlled spec fields — quote it (#219). The
-		// database arg is double-quoted by design (validated name or literal
-		// glob that neo4j-admin, not the shell, must expand).
-		cmd += fmt.Sprintf(` && (neo4j-admin backup validate --from-path=%s --database="%s" || true)`, shellQuote(toPath), validateDBArg)
 	}
 
 	if backup.Spec.Storage.Type == "pvc" {

--- a/internal/controller/neo4jbackup_controller.go
+++ b/internal/controller/neo4jbackup_controller.go
@@ -1763,9 +1763,10 @@ func (r *Neo4jBackupReconciler) cleanupBackupArtifacts(ctx context.Context, back
 		},
 	}
 
-	if err := controllerutil.SetControllerReference(backup, cleanupJob, r.Scheme); err != nil {
-		return err
-	}
+	// Deliberately NO owner reference: this Job is created while the CR's
+	// finalizer is completing — owner-ref'ing it to the dying CR hands it to
+	// the garbage collector immediately, which deletes the Job before (or
+	// while) the prune script runs. The 300s TTL is the cleanup mechanism.
 	if err := r.Create(ctx, cleanupJob); err != nil {
 		return fmt.Errorf("failed to create cleanup job: %w", err)
 	}
@@ -1809,7 +1810,10 @@ if [ "$FILE_COUNT" -gt "$MAX_COUNT" ]; then
     echo "Deleting $TO_DELETE oldest artifacts (keeping $MAX_COUNT)"
     # Oldest-first by filesystem mtime — never coupled to the filename's
     # timestamp format.
-    find "$BACKUP_DIR" -maxdepth 1 -type f -name '*.backup' -printf '%%T@ %%p\n' | \
+    # busybox/alpine find lacks GNU printf-style output — stat -c '%%Y %%n'
+    # is the portable mtime listing (the previous GNU-only form made the
+    # whole script die under set -e, so retention never pruned anything).
+    find "$BACKUP_DIR" -maxdepth 1 -type f -name '*.backup' -exec stat -c '%%Y %%n' {} + | \
         sort -n | \
         head -n "$TO_DELETE" | \
         cut -d' ' -f2- | \
@@ -1826,7 +1830,7 @@ fi
 # Delete backup artifacts older than %s — but always keep the newest one,
 # even if it has aged out (a retention policy must never delete the ONLY
 # remaining backup).
-NEWEST=$(find "$BACKUP_DIR" -maxdepth 1 -type f -name '*.backup' -printf '%%T@ %%p\n' | sort -rn | head -n1 | cut -d' ' -f2-)
+NEWEST=$(find "$BACKUP_DIR" -maxdepth 1 -type f -name '*.backup' -exec stat -c '%%Y %%n' {} + | sort -rn | head -n1 | cut -d' ' -f2-)
 find "$BACKUP_DIR" -maxdepth 1 -type f -name '*.backup' %s -print | while IFS= read -r f; do
     [ "$f" = "$NEWEST" ] && continue
     rm -f "$f"

--- a/internal/controller/neo4jenterprisecluster_controller.go
+++ b/internal/controller/neo4jenterprisecluster_controller.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -67,6 +68,10 @@ type Neo4jEnterpriseClusterReconciler struct {
 	Validator          *validation.ClusterValidator
 	ConfigMapManager   *ConfigMapManager
 	SplitBrainDetector *SplitBrainDetector
+	// deferredUpgradeTargets dedupes the UpgradeDeferred event per cluster
+	// (key ns/name → deferred image) so a held image change doesn't emit an
+	// event on every Forming-phase reconcile (#262 review).
+	deferredUpgradeTargets sync.Map
 }
 
 const (
@@ -2851,10 +2856,17 @@ func (r *Neo4jEnterpriseClusterReconciler) holdImageDriftUntilReady(ctx context.
 	if idx <= 0 {
 		return // unparseable image — leave the spec alone
 	}
-	log.FromContext(ctx).Info("Image change deferred until the cluster is Ready — the rolling-upgrade state machine will perform it",
+	log.FromContext(ctx).V(1).Info("Image change deferred until the cluster is Ready — the rolling-upgrade state machine will perform it",
 		"current", currentImage, "desired", desiredImage, "phase", cluster.Status.Phase)
-	r.Recorder.Eventf(cluster, corev1.EventTypeNormal, "UpgradeDeferred",
-		"Image change to %s deferred until the cluster is Ready; the rolling-upgrade state machine will perform it", desiredImage)
+	// Event once per deferred target (not per reconcile — a Forming cluster
+	// reconciles every ~30s and would spam the event stream). In-memory
+	// dedupe: an operator restart re-emits a single event, which is fine.
+	key := cluster.Namespace + "/" + cluster.Name
+	if prev, _ := r.deferredUpgradeTargets.Load(key); prev != desiredImage {
+		r.Recorder.Eventf(cluster, corev1.EventTypeNormal, "UpgradeDeferred",
+			"Image change to %s deferred until the cluster is Ready; the rolling-upgrade state machine will perform it", desiredImage)
+		r.deferredUpgradeTargets.Store(key, desiredImage)
+	}
 	cluster.Spec.Image.Repo = currentImage[:idx]
 	cluster.Spec.Image.Tag = currentImage[idx+1:]
 }

--- a/internal/controller/neo4jenterprisecluster_controller.go
+++ b/internal/controller/neo4jenterprisecluster_controller.go
@@ -311,6 +311,16 @@ func (r *Neo4jEnterpriseClusterReconciler) Reconcile(ctx context.Context, req ct
 		return r.handleRollingUpgrade(ctx, cluster)
 	}
 
+	// #262: image drift while the cluster is NOT Ready must never reach the
+	// normal path below — its builders would stomp the new image into the
+	// StatefulSet as a plain config change, performing the version change as
+	// a bare roll with none of the upgrade machine's gating (no partition
+	// staging, no per-pod SHOW SERVERS verification, no version stamping).
+	// Pin the in-memory spec to the image the StatefulSet currently runs;
+	// once the cluster reaches Ready, isUpgradeRequired fires on the drift
+	// and the state machine performs the upgrade properly.
+	r.holdImageDriftUntilReady(ctx, cluster)
+
 	// Neo4jEnterpriseCluster is always multi-node from the start
 	// (minimum 1 primary + 1 secondary OR 2+ primaries)
 	// No need for single-node to multi-node transition logic
@@ -610,9 +620,30 @@ func (r *Neo4jEnterpriseClusterReconciler) Reconcile(ctx context.Context, req ct
 		return ctrl.Result{RequeueAfter: r.RequeueAfter}, nil
 	}
 
+	// Never declare Ready while the server StatefulSet is mid-rollout: a
+	// half-rolled (possibly mixed-version) cluster that answers Bolt is
+	// converging, not Ready (#262).
+	if rolled, detail := r.serverStatefulSetFullyRolled(ctx, cluster); !rolled {
+		_ = r.updateClusterStatus(ctx, cluster, "Forming", "Waiting for server StatefulSet rollout to complete: "+detail)
+		return ctrl.Result{RequeueAfter: r.RequeueAfter}, nil
+	}
+
 	// Update status to "Ready" only if cluster formation is verified
 	// Note: Split-brain detection is already performed in verifyNeo4jClusterFormation
-	statusChanged := r.updateClusterStatus(ctx, cluster, "Ready", "Neo4j cluster is fully formed and ready")
+	//
+	// status.version backfill (#262): the upgrade machine stamps the version
+	// after verified upgrades, but a cluster that never upgraded (or whose
+	// version change happened before the machine existed) has it empty —
+	// which silently grants the NEXT upgrade the first-upgrade
+	// compatibility-check skip. At this point the StatefulSet is fully
+	// rolled to the template and the template matches spec (drift is held
+	// above), so spec.image.tag IS the running version.
+	var statusChanged bool
+	if cluster.Status.Version == "" {
+		statusChanged = r.updateClusterStatusWithVersion(ctx, cluster, "Ready", "Neo4j cluster is fully formed and ready", cluster.Spec.Image.Tag)
+	} else {
+		statusChanged = r.updateClusterStatus(ctx, cluster, "Ready", "Neo4j cluster is fully formed and ready")
+	}
 
 	// Scale-down draining (server cordon→deallocate→drop) is driven earlier in
 	// the reconcile by reconcileScaleDownDrain, which owns the
@@ -2792,4 +2823,63 @@ func (r *Neo4jEnterpriseClusterReconciler) SetupWithManager(mgr ctrl.Manager) er
 	}
 
 	return builder.Complete(r)
+}
+
+// holdImageDriftUntilReady neutralizes spec-vs-StatefulSet image drift on the
+// IN-MEMORY cluster object while the cluster is not Ready, so the normal
+// reconcile path keeps converging the cluster on its CURRENT image instead of
+// silently applying a version change outside the upgrade state machine
+// (#262). No-ops when the StatefulSet doesn't exist yet (initial install) or
+// there is no drift.
+func (r *Neo4jEnterpriseClusterReconciler) holdImageDriftUntilReady(ctx context.Context, cluster *neo4jv1beta1.Neo4jEnterpriseCluster) {
+	serverSts := &appsv1.StatefulSet{}
+	if err := r.Get(ctx, types.NamespacedName{
+		Name:      fmt.Sprintf("%s-server", cluster.Name),
+		Namespace: cluster.Namespace,
+	}, serverSts); err != nil {
+		return
+	}
+	if len(serverSts.Spec.Template.Spec.Containers) == 0 {
+		return
+	}
+	currentImage := serverSts.Spec.Template.Spec.Containers[0].Image
+	desiredImage := fmt.Sprintf("%s:%s", cluster.Spec.Image.Repo, cluster.Spec.Image.Tag)
+	if currentImage == desiredImage {
+		return
+	}
+	idx := strings.LastIndex(currentImage, ":")
+	if idx <= 0 {
+		return // unparseable image — leave the spec alone
+	}
+	log.FromContext(ctx).Info("Image change deferred until the cluster is Ready — the rolling-upgrade state machine will perform it",
+		"current", currentImage, "desired", desiredImage, "phase", cluster.Status.Phase)
+	r.Recorder.Eventf(cluster, corev1.EventTypeNormal, "UpgradeDeferred",
+		"Image change to %s deferred until the cluster is Ready; the rolling-upgrade state machine will perform it", desiredImage)
+	cluster.Spec.Image.Repo = currentImage[:idx]
+	cluster.Spec.Image.Tag = currentImage[idx+1:]
+}
+
+// serverStatefulSetFullyRolled reports whether the server StatefulSet has no
+// rollout in flight: every replica updated to the current template revision
+// and ready. A false result carries a human-readable detail for the status
+// message.
+func (r *Neo4jEnterpriseClusterReconciler) serverStatefulSetFullyRolled(ctx context.Context, cluster *neo4jv1beta1.Neo4jEnterpriseCluster) (bool, string) {
+	serverSts := &appsv1.StatefulSet{}
+	if err := r.Get(ctx, types.NamespacedName{
+		Name:      fmt.Sprintf("%s-server", cluster.Name),
+		Namespace: cluster.Namespace,
+	}, serverSts); err != nil {
+		return false, "server StatefulSet not found"
+	}
+	replicas := int32(1)
+	if serverSts.Spec.Replicas != nil {
+		replicas = *serverSts.Spec.Replicas
+	}
+	if serverSts.Status.UpdateRevision != "" && serverSts.Status.CurrentRevision != serverSts.Status.UpdateRevision {
+		return false, fmt.Sprintf("revision rollout in progress (%d/%d pods updated)", serverSts.Status.UpdatedReplicas, replicas)
+	}
+	if serverSts.Status.UpdatedReplicas < replicas || serverSts.Status.ReadyReplicas < replicas {
+		return false, fmt.Sprintf("%d/%d pods updated, %d/%d ready", serverSts.Status.UpdatedReplicas, replicas, serverSts.Status.ReadyReplicas, replicas)
+	}
+	return true, ""
 }

--- a/internal/controller/neo4jrestore_controller.go
+++ b/internal/controller/neo4jrestore_controller.go
@@ -69,6 +69,10 @@ const (
 // backup_resolver.go) directly.
 var errBackupNotReady = ErrBackupNotReady
 
+// errStaleRestoreJob: a fresh attempt's stale failed Job is still
+// terminating — transient; route to Pending + requeue, never Failed.
+var errStaleRestoreJob = stderrors.New("stale restore job still terminating")
+
 // restoreServiceAccountName is the ServiceAccount used by all restore Job
 // pods. Mirrors neo4j-backup-sa on the backup side; intentionally separate
 // so cluster operators can scope IAM permissions narrowly (read-only for
@@ -409,6 +413,11 @@ func (r *Neo4jRestoreReconciler) startRestore(ctx context.Context, restore *neo4
 		if stderrors.Is(err, errBackupNotReady) {
 			logger.Info("Restore is waiting for the referenced backup to complete", "error", err.Error())
 			r.updateRestoreStatus(ctx, restore, StatusPending, fmt.Sprintf("Waiting for backup to complete: %v", err))
+			return ctrl.Result{RequeueAfter: r.RequeueAfter}, nil
+		}
+		if stderrors.Is(err, errStaleRestoreJob) {
+			logger.Info("Previous attempt's Job still terminating; will retry", "error", err.Error())
+			r.updateRestoreStatus(ctx, restore, StatusPending, fmt.Sprintf("Waiting for the previous attempt's Job to finish terminating: %v", err))
 			return ctrl.Result{RequeueAfter: r.RequeueAfter}, nil
 		}
 		logger.Error(err, "Failed to create restore job")
@@ -921,11 +930,20 @@ func (r *Neo4jRestoreReconciler) createRestoreJob(ctx context.Context, restore *
 				if delErr := r.Delete(ctx, stale, &client.DeleteOptions{PropagationPolicy: &policy}); delErr != nil && !errors.IsNotFound(delErr) {
 					return nil, fmt.Errorf("failed to delete stale restore Job %q for retry: %w", jobName, delErr)
 				}
+				freed := false
 				for i := 0; i < 20; i++ {
 					if getErr := r.Get(ctx, types.NamespacedName{Name: jobName, Namespace: restore.Namespace}, &batchv1.Job{}); errors.IsNotFound(getErr) {
+						freed = true
 						break
 					}
 					time.Sleep(500 * time.Millisecond)
+				}
+				if !freed {
+					// Don't fall through to Create — AlreadyExists would
+					// re-adopt the still-terminating failed Job and re-fail
+					// the fresh attempt (the exact #254 symptom). Transient:
+					// route to Pending and let the requeue retry.
+					return nil, fmt.Errorf("%w: stale restore Job %q is still terminating", errStaleRestoreJob, jobName)
 				}
 			}
 		}

--- a/internal/controller/neo4jrestore_controller.go
+++ b/internal/controller/neo4jrestore_controller.go
@@ -905,6 +905,32 @@ func (r *Neo4jRestoreReconciler) createRestoreJob(ctx context.Context, restore *
 
 	jobName := restore.Name + "-restore"
 
+	// Fresh attempt after a terminal failure (#254): the Failed guard only
+	// lets a NEW generation through, but the previous attempt's failed Job
+	// still exists under this name — Create would hit AlreadyExists, the
+	// race fallback below would adopt the FAILED Job, and the retry would
+	// instantly re-fail. Delete the stale Job first and wait (bounded) for
+	// the name to free. Scoped to phase==Failed so the same-attempt race
+	// tolerance (two reconciles during the stopCluster window) is untouched.
+	if restore.Status.Phase == StatusFailed {
+		stale := &batchv1.Job{}
+		if err := r.Get(ctx, types.NamespacedName{Name: jobName, Namespace: restore.Namespace}, stale); err == nil {
+			if jobConditionTrue(stale, batchv1.JobFailed) {
+				log.FromContext(ctx).Info("Deleting stale failed restore Job for fresh attempt", "job", jobName)
+				policy := metav1.DeletePropagationBackground
+				if delErr := r.Delete(ctx, stale, &client.DeleteOptions{PropagationPolicy: &policy}); delErr != nil && !errors.IsNotFound(delErr) {
+					return nil, fmt.Errorf("failed to delete stale restore Job %q for retry: %w", jobName, delErr)
+				}
+				for i := 0; i < 20; i++ {
+					if getErr := r.Get(ctx, types.NamespacedName{Name: jobName, Namespace: restore.Namespace}, &batchv1.Job{}); errors.IsNotFound(getErr) {
+						break
+					}
+					time.Sleep(500 * time.Millisecond)
+				}
+			}
+		}
+	}
+
 	// Resolve source.type=backup into a concrete StorageLocation + per-run
 	// subfolder once, then swap it onto a shallow restore copy so every
 	// downstream builder (command, env vars, volumes, volume mounts) sees
@@ -1501,8 +1527,11 @@ func (r *Neo4jRestoreReconciler) buildRestoreCommand(ctx context.Context, restor
 	}
 	cmd := preludeCmd + neo4j.GetRestoreCommand(version, restore.Spec.DatabaseName, backupPath)
 
-	// Add --overwrite-destination flag if force is specified
-	if restore.Spec.Force {
+	// Confirm overwriting an existing database. Both spec.force and
+	// options.replaceExisting are accepted — the preflight error text and
+	// the API reference promise both (#253; previously only force was
+	// wired, so the documented replaceExisting path failed at the Job).
+	if restoreOverwriteConfirmed(restore) {
 		cmd += " --overwrite-destination=true"
 	}
 
@@ -1647,7 +1676,7 @@ func (r *Neo4jRestoreReconciler) buildPITRRestoreCommand(ctx context.Context, re
 
 	cmd := preludeCmd + neo4j.GetRestoreCommand(version, restore.Spec.DatabaseName, backupPath)
 
-	if restore.Spec.Force {
+	if restoreOverwriteConfirmed(restore) {
 		cmd += " --overwrite-destination=true"
 	}
 
@@ -2614,14 +2643,41 @@ func (r *Neo4jRestoreReconciler) startClusterCypherRestore(
 		return ctrl.Result{RequeueAfter: r.RequeueAfter}, nil
 	}
 
-	// Database ABSENT: `CREATE DATABASE … OPTIONS{seedURI} WAIT` is
-	// SYNCHRONOUS — it blocks until the database is online (or fails fast on a
-	// bad/unreachable seed). It's a single atomic operation, so we keep it
-	// inline and mark Completed directly on success.
+	// Database ABSENT: `CREATE DATABASE … OPTIONS{seedURI} WAIT` blocks
+	// until the operation finishes — but FINISHED IS NOT SEEDED (#251): on a
+	// failed seed download (unreachable URI, missing endpoint config) the
+	// statement returns without a driver error and leaves the allocation
+	// offline with the failure in SHOW DATABASE's statusMessage. Verify the
+	// actual allocation state before declaring success; the statusMessage
+	// is the actionable detail the user needs.
 	if createErr := neo4jClient.CreateDatabaseWithSeedURIOptions(ctx, restore.Spec.DatabaseName, seedURI, false); createErr != nil {
 		logger.Error(createErr, "CREATE DATABASE OPTIONS{seedURI} failed")
 		r.updateRestoreStatus(ctx, restore, StatusFailed, fmt.Sprintf("CREATE DATABASE OPTIONS{seedURI} failed: %v", createErr))
 		return ctrl.Result{RequeueAfter: r.RequeueAfter}, createErr
+	}
+
+	if failMsg, ferr := neo4jClient.DatabaseSeedFailureMessage(ctx, restore.Spec.DatabaseName); ferr == nil && failMsg != "" {
+		// Explicit allocation failure (e.g. "Object not found at the path:
+		// s3://…") — fail NOW with Neo4j's own diagnosis instead of either
+		// declaring false success or burning the full poll budget.
+		msg := fmt.Sprintf("Database %q was created but the seed FAILED: %s — fix the cause, DROP DATABASE %s IF EXISTS, and re-trigger the restore",
+			restore.Spec.DatabaseName, failMsg, restore.Spec.DatabaseName)
+		logger.Error(nil, "Cluster Cypher restore seed failed", "statusMessage", failMsg)
+		r.updateRestoreStatus(ctx, restore, StatusFailed, msg)
+		r.Recorder.Event(restore, corev1.EventTypeWarning, EventReasonRestoreFailed, msg)
+		return ctrl.Result{}, nil
+	}
+	if online, total, _, stateErr := neo4jClient.DatabaseOnlineState(ctx, restore.Spec.DatabaseName); stateErr != nil || total == 0 || online != total {
+		// Not online yet but no explicit failure either — a large seed can
+		// outlive the statement's internal wait. Hand off to the requeue
+		// poll (bounded by spec.timeout), which Completes on online and
+		// Fails at the deadline with the live diagnosis.
+		if err := r.markCypherRestoreIssued(ctx, restore); err != nil {
+			return ctrl.Result{RequeueAfter: r.RequeueAfter}, err
+		}
+		r.updateRestoreStatus(ctx, restore, StatusRunning,
+			fmt.Sprintf("Database %q created; waiting for the seed to converge online", restore.Spec.DatabaseName))
+		return ctrl.Result{RequeueAfter: r.RequeueAfter}, nil
 	}
 
 	completion := metav1.Now()
@@ -2763,6 +2819,14 @@ func (r *Neo4jRestoreReconciler) pollClusterRestoreOnline(ctx context.Context, r
 		return ctrl.Result{RequeueAfter: r.RequeueAfter}, nil
 	}
 	defer func() { _ = neo4jClient.Close() }()
+
+	if failMsg, ferr := neo4jClient.DatabaseSeedFailureMessage(ctx, restore.Spec.DatabaseName); ferr == nil && failMsg != "" {
+		msg := fmt.Sprintf("Restore of %q failed: %s — fix the cause, DROP DATABASE %s IF EXISTS, and re-trigger",
+			restore.Spec.DatabaseName, failMsg, restore.Spec.DatabaseName)
+		r.updateRestoreStatus(ctx, restore, StatusFailed, msg)
+		r.Recorder.Event(restore, corev1.EventTypeWarning, EventReasonRestoreFailed, msg)
+		return ctrl.Result{}, nil
+	}
 
 	online, total, diag, stateErr := neo4jClient.DatabaseOnlineState(ctx, restore.Spec.DatabaseName)
 	if stateErr == nil && total > 0 && online == total {
@@ -3194,4 +3258,15 @@ func isPodReady(pod *corev1.Pod) bool {
 	}
 
 	return false
+}
+
+// restoreOverwriteConfirmed reports whether the user confirmed restoring over
+// an existing database — via spec.force OR options.replaceExisting. The two
+// are equivalent confirmations everywhere (cluster recreate gate, preflight
+// error text, API reference); the Job command must honor both too.
+func restoreOverwriteConfirmed(restore *neo4jv1beta1.Neo4jRestore) bool {
+	if restore.Spec.Force {
+		return true
+	}
+	return restore.Spec.Options != nil && restore.Spec.Options.ReplaceExisting
 }

--- a/internal/controller/neo4juser_controller.go
+++ b/internal/controller/neo4juser_controller.go
@@ -108,6 +108,14 @@ func (r *Neo4jUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			r.Recorder.Event(user, corev1.EventTypeWarning, EventReasonValidationFailed, msg)
 			return ctrl.Result{RequeueAfter: requeue}, nil
 		}
+		if len(res.Pending) > 0 {
+			// Transient dependency gaps (e.g. password Secret not applied
+			// yet): Pending + requeue, like missing roles — apply order is
+			// documented as irrelevant (#259).
+			msg := strings.Join(res.Pending, "; ")
+			r.setStatus(ctx, user, "Pending", metav1.ConditionFalse, "SecretPending", msg, nil, "", nil)
+			return ctrl.Result{RequeueAfter: requeue}, nil
+		}
 	}
 
 	// Resolve cluster

--- a/internal/neo4j/client.go
+++ b/internal/neo4j/client.go
@@ -1986,6 +1986,39 @@ func (c *Client) RecreateDatabaseWithSeedURI(
 // (currentStatus + statusMessage per row) for logging on timeout. It runs a
 // single bounded SHOW DATABASE, so callers can poll it across reconciles
 // without holding a worker (see pollClusterRestoreOnline).
+// DatabaseSeedFailureMessage returns the first non-empty statusMessage among
+// the database's OFFLINE allocations — Neo4j's explicit "this allocation
+// failed and here's why" signal (e.g. "Object not found at the path: s3://…"
+// for a bad seed URI). Empty string = no explicit failure recorded (the
+// database may be online, starting, or simply absent).
+func (c *Client) DatabaseSeedFailureMessage(ctx context.Context, databaseName string) (string, error) {
+	session := c.driver.NewSession(ctx, neo4j.SessionConfig{
+		AccessMode:   neo4j.AccessModeRead,
+		DatabaseName: "system",
+	})
+	defer session.Close(ctx)
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	result, err := session.Run(timeoutCtx,
+		"SHOW DATABASE $name YIELD currentStatus, statusMessage",
+		map[string]any{"name": databaseName})
+	if err != nil {
+		return "", fmt.Errorf("SHOW DATABASE %q: %w", databaseName, err)
+	}
+	for result.Next(timeoutCtx) {
+		rec := result.Record()
+		cur, _ := rec.Get("currentStatus")
+		msg, _ := rec.Get("statusMessage")
+		m := fmt.Sprintf("%v", msg)
+		if fmt.Sprintf("%v", cur) == "offline" && m != "" && m != "<nil>" {
+			return m, nil
+		}
+	}
+	return "", result.Err()
+}
+
 func (c *Client) DatabaseOnlineState(ctx context.Context, databaseName string) (online, total int, diag string, err error) {
 	session := c.driver.NewSession(ctx, neo4j.SessionConfig{
 		AccessMode:   neo4j.AccessModeRead,

--- a/internal/validation/user_validator.go
+++ b/internal/validation/user_validator.go
@@ -46,6 +46,11 @@ func NewUserValidator(c client.Client) *UserValidator {
 type UserValidationResult struct {
 	Errors   field.ErrorList
 	Warnings []string
+	// Pending collects TRANSIENT dependency gaps (e.g. the password Secret
+	// not created yet) that must route the user to phase Pending — the
+	// documented apply-order-is-irrelevant convergence — rather than
+	// Failed, mirroring how missing roles are handled (#259).
+	Pending []string
 }
 
 // neo4jUsernamePattern enforces Neo4j's username rules: ASCII letter
@@ -167,8 +172,11 @@ func (v *UserValidator) validatePasswordSecret(ctx context.Context, user *neo4jv
 	secretKey := types.NamespacedName{Name: ref.Name, Namespace: user.Namespace}
 	if err := v.client.Get(ctx, secretKey, secret); err != nil {
 		if errors.IsNotFound(err) {
-			result.Errors = append(result.Errors, field.NotFound(path.Child("name"),
-				fmt.Sprintf("Secret %q not found in namespace %q", ref.Name, user.Namespace)))
+			// Transient: the Secret may simply not have been applied yet.
+			// Pending (not Failed) so apply order genuinely doesn't matter,
+			// consistent with missing-role handling (#259).
+			result.Pending = append(result.Pending,
+				fmt.Sprintf("waiting for password Secret %q in namespace %q", ref.Name, user.Namespace))
 			return
 		}
 		result.Warnings = append(result.Warnings,

--- a/internal/validation/user_validator_test.go
+++ b/internal/validation/user_validator_test.go
@@ -125,8 +125,13 @@ func TestUserValidator_PasswordSecretMissing(t *testing.T) {
 		},
 	}
 	res := v.Validate(context.Background(), user)
-	if len(res.Errors) == 0 {
-		t.Fatalf("expected error for missing secret")
+	// #259: a not-yet-applied Secret is a transient dependency → Pending,
+	// never a validation Error (which would route the user to Failed).
+	if len(res.Errors) != 0 {
+		t.Fatalf("missing secret must not be an error: %v", res.Errors)
+	}
+	if len(res.Pending) == 0 {
+		t.Fatalf("expected Pending entry for missing secret")
 	}
 }
 
@@ -183,5 +188,37 @@ func TestUserValidator_PublicWarning(t *testing.T) {
 	res := v.Validate(context.Background(), user)
 	if len(res.Warnings) == 0 {
 		t.Fatalf("expected a warning about explicit PUBLIC, got %v", res.Warnings)
+	}
+}
+
+// TestUserValidator_MissingSecretIsPendingNotFailed pins #259: a not-yet-applied
+// password Secret is a TRANSIENT dependency — it must land in result.Pending
+// (routing the user to phase Pending, like missing roles) instead of
+// result.Errors (which routes to Failed and contradicts the documented
+// apply-order-is-irrelevant convergence).
+func TestUserValidator_MissingSecretIsPendingNotFailed(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = neo4jv1beta1.AddToScheme(scheme)
+	cluster := &neo4jv1beta1.Neo4jEnterpriseCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: "default"},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster).Build()
+	v := NewUserValidator(c)
+
+	user := &neo4jv1beta1.Neo4jUser{
+		ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
+		Spec: neo4jv1beta1.Neo4jUserSpec{
+			ClusterRef:        "c",
+			Username:          "app_user",
+			PasswordSecretRef: &neo4jv1beta1.SecretKeyRef{Name: "not-applied-yet"},
+		},
+	}
+	res := v.Validate(context.Background(), user)
+	if len(res.Errors) != 0 {
+		t.Fatalf("missing Secret must not be a validation ERROR (routes to Failed); got: %v", res.Errors)
+	}
+	if len(res.Pending) != 1 || !strings.Contains(res.Pending[0], "not-applied-yet") {
+		t.Fatalf("missing Secret must be reported via Pending; got: %v", res.Pending)
 	}
 }


### PR DESCRIPTION
Fixes the nine released bugs from the v1.12.0 documented-path field test (#251 #253 #254 #255 #256 #259 #261 #262 — all auto-close on merge). This is the consolidated user-fixes branch: every behavioral finding from walking the published docs, backup/restore AND users/roles.

| Fix | Behavior change | Live verification |
|---|---|---|
| #251 | Cluster seedURI restores verify allocation state before `Completed`: explicit failure `statusMessage` → immediate `Failed` carrying Neo4j's diagnosis; not-yet-online → requeue poll (respects `spec.timeout`) | Bad-seed restore now fails with `Object not found at the path: s3://…` + recovery steps |
| #253 | `options.replaceExisting` honored at both Job-command sites (`restoreOverwriteConfirmed`: force OR replaceExisting) | replaceExisting-only standalone round-trip: `Completed`, sentinel restored, junk gone |
| #254 | Fresh attempt after terminal failure deletes the stale failed Job instead of adopting it; rule-46 same-attempt race untouched | fail → spec patch → `Completed` with zero manual steps |
| #255 | `validate` CalVer-gated; on 5.26 skipped with a `BackupValidateUnsupported` warning event | Event fires with exact guidance; zero validate clauses in the Job command |
| #256 | Backup `tempPath` gets the `mkdir -p` prelude (parity with restore) | The previously-crashing tempPath backup: `Completed` |

Three new pinning tests execute the *documented* paths the original specs never took. Full `make test-unit` green. Coverage-gap analysis that explains how all five shipped is on the issues.

Additionally **#259** (users/roles journey): a Neo4jUser applied before its password Secret now routes `Pending` ("waiting for password Secret …") instead of `Failed`, converging to Ready when the Secret lands — live-verified, consistent with missing-role handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches backup/restore Job commands, cluster Ready/upgrade gating, and restore retry logic on production data paths; changes are targeted bug fixes with new unit tests rather than broad refactors.
> 
> **Overview**
> Fixes v1.12.0 bugs where **documented** user paths diverged from what controllers actually did. **Backup**: custom `options.tempPath` now gets a `mkdir -p` prelude; `options.validate` runs only on CalVer images with a one-time `BackupValidateUnsupported` warning on 5.x; retention cleanup Jobs no longer owner-ref the deleting CR and use busybox-portable `stat` instead of GNU `find -printf`. **Restore**: `--overwrite-destination` honors both `spec.force` and `options.replaceExisting`; retries after `Failed` delete the stale Job before recreate; cluster Cypher seed restores check Neo4j `statusMessage` / online state instead of treating `CREATE … WAIT` as success. **Cluster (#262)**: image tag changes while not Ready are held in-memory until Ready + full StatefulSet rollout; `status.version` backfills at Ready; deduped `UpgradeDeferred` events. **Neo4jUser (#259)**: missing password Secret → `Pending`, not validation `Failed`. Pinning tests cover these documented paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d025016a65a0109e2292f55ac91ac26f968de10b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


