### PR TITLE
fix(examples): users-roles examples must pass their own validators

### DIFF
--- a/examples/users-roles/01-readonly-user.yaml
+++ b/examples/users-roles/01-readonly-user.yaml
@@ -1,9 +1,10 @@
 # Read-only application user bound to the built-in `reader` role.
 #
 # Apply order is irrelevant: the operator converges. If you apply the
-# Neo4jUser before the Secret, the user enters Pending until the Secret
-# lands; if you apply it before the cluster is Ready, it enters Pending
-# until the cluster transitions.
+# Neo4jUser before the Secret exists, the user reports Failed (validation)
+# but converges to Ready automatically once the Secret lands; applied
+# before the cluster is Ready, it waits in Pending until the cluster
+# transitions.
 
 # ── App-user password Secret (create this BEFORE you apply this manifest) ──────
 # Not defined inline: `kubectl apply -f` would re-apply it every run and OVERWRITE

--- a/examples/users-roles/02-custom-role-with-user.yaml
+++ b/examples/users-roles/02-custom-role-with-user.yaml
@@ -12,13 +12,17 @@ metadata:
   namespace: prod
 spec:
   clusterRef: prod-cluster
-  # spec.name defaults to metadata.name; both are "analytics_reader"-style.
-  # Each privilege MUST end with `TO <name>` so the controller can derive
-  # the matching REVOKE if the privilege is later removed from the spec.
+  # Neo4j role names may contain only letters, digits and underscores —
+  # hyphens (the Kubernetes naming convention used by metadata.name above)
+  # are NOT valid. Set spec.name to the underscore form explicitly; users
+  # then reference THIS name (not the CR name) in their spec.roles.
+  name: analytics_reader
+  # Each privilege MUST end with `TO <spec.name>` so the controller can
+  # derive the matching REVOKE if the privilege is later removed.
   privileges:
-    - "GRANT ACCESS ON DATABASE analytics TO analytics-reader"
-    - "GRANT MATCH {*} ON GRAPH analytics NODES * TO analytics-reader"
-    - "DENY WRITE ON GRAPH analytics TO analytics-reader"
+    - "GRANT ACCESS ON DATABASE analytics TO analytics_reader"
+    - "GRANT MATCH {*} ON GRAPH analytics NODES * TO analytics_reader"
+    - "DENY WRITE ON GRAPH analytics TO analytics_reader"
 ---
 # ── App-user password Secret (create this BEFORE you apply this manifest) ──────
 # Not defined inline: `kubectl apply -f` would re-apply it every run and OVERWRITE
@@ -42,4 +46,4 @@ spec:
   passwordSecretRef:
     name: analytics-reader-creds
   roles:
-    - analytics-reader   # references the Neo4jRole above by spec.name
+    - analytics_reader   # the Neo4j role name (the Neo4jRole's spec.name, NOT its metadata.name)

--- a/examples/users-roles/06-rolebinding-sso-user.yaml
+++ b/examples/users-roles/06-rolebinding-sso-user.yaml
@@ -21,5 +21,5 @@ spec:
   username: alice   # RoleBinding usernames must match ^[a-zA-Z][a-zA-Z0-9_.\-]*$ (no @)
   roles:
     - editor
-    - analytics-reader          # may reference a Neo4jRole; pending until it exists
+    - analytics_reader          # the Neo4j role name (a Neo4jRole's spec.name); pending until it exists
   # enforceExclusive: true      # uncomment to revoke any role not in .spec.roles


### PR DESCRIPTION
From the v1.12.0 users/roles user-journey test: `02-custom-role-with-user.yaml` **fails validation as shipped** — Neo4j role names can't contain hyphens, and the example relies on `spec.name` defaulting from the hyphenated `metadata.name` (its comment claims the naming works). Since Kubernetes names conventionally use hyphens and Neo4j names can't, `metadata.name ≠ spec.name` for virtually every real custom role — and `Neo4jUser.spec.roles` must reference the **Neo4j** name, which the example also got wrong. Example 06 carried the same reference; example 01's comment promised `Pending` for a missing Secret where the operator actually reports `Failed` (then converges — verified live).

The happy path itself is genuinely solid, all verified live on a 3-node cluster: corrected role+user reach Ready, privileges enforce (write denied with a clear message), **drift correction revoked a manually-granted privilege within 45s**, and password rotation via Secret update works (old password rejected).

Behavior-consistency follow-ups filed separately (missing-Secret phase routing; CR-name resolution in spec.roles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example YAML and comment updates only; no controller, API, or runtime behavior changes.
> 
> **Overview**
> **Documentation-only fixes** to the `examples/users-roles/` manifests so they pass the same validation rules the operator enforces and match observed reconcile behavior.
> 
> **`02-custom-role-with-user.yaml`** now sets **`spec.name: analytics_reader`** (underscore form) while keeping a hyphenated Kubernetes **`metadata.name`**, and updates **`privileges`** so each `TO` clause targets that Neo4j name. **`Neo4jUser.spec.roles`** and the inline comments now state that entries must reference the **Neo4j role name** (`Neo4jRole.spec.name`), not the CR’s metadata name.
> 
> **`06-rolebinding-sso-user.yaml`** changes the custom role reference from `analytics-reader` to **`analytics_reader`** for the same reason.
> 
> **`01-readonly-user.yaml`** corrects the apply-order comment: applying a **`Neo4jUser` before its password Secret exists** is described as **Failed (validation)** with automatic convergence once the Secret appears, rather than **Pending**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7f4d4baace958a3c4dbebc8a95e8c780b6a5df6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->