### PR TITLE
feat(release): publication behind gates, failure incidents, retraction workflow (#245 #246)

### DIFF
--- a/.github/workflows/pages-docs.yml
+++ b/.github/workflows/pages-docs.yml
@@ -4,7 +4,13 @@ name: Pages — Docs
 # gh-pages branch as a versioned subdirectory using mike.
 #
 #   - Push to main         → publishes to /main/ alias  (rolling preview)
-#   - Push of v* tag       → publishes to /vX.Y/ and updates the /latest/ alias
+#   - workflow_call from release.yml (after every release gate has passed)
+#     → publishes /vX.Y/ and updates the /latest/ alias. The versioned
+#     publication deliberately has NO tag trigger of its own: publishing on
+#     tag push ran in PARALLEL with the release gates, so a failed release
+#     left /vX.Y/ + latest advertising a version that never shipped (#245,
+#     observed live on the first v1.12.0 tag). The called workflow inherits
+#     the caller's GITHUB_REF (the tag), so the derivation below is unchanged.
 #
 # The chart-publishing workflow (pages-helm.yml) writes to /charts/ on the
 # same gh-pages branch; concurrency: gh-pages serialises pushes between the
@@ -20,8 +26,7 @@ on:
   push:
     branches:
       - main
-    tags:
-      - 'v*'
+  workflow_call: {}
   workflow_dispatch:
     inputs:
       version-alias:

--- a/.github/workflows/pages-helm.yml
+++ b/.github/workflows/pages-helm.yml
@@ -11,10 +11,12 @@ name: Pages — Helm Repo
 # The docs workflow (pages-docs.yml) writes to /, /latest/, /vX.Y/, /main/ on the
 # same gh-pages branch; concurrency: gh-pages serialises pushes so they cannot race.
 
+# NOTE (#245): no tag trigger — the classic-repo publication is invoked via
+# workflow_call from release.yml AFTER all release gates pass. Publishing on
+# tag push offered a chart whose appVersion pointed at an image that might
+# never exist (the gate-failed-after-tag case, observed live at v1.12.0).
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_call: {}
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/release-retract.yml
+++ b/.github/workflows/release-retract.yml
@@ -1,0 +1,300 @@
+# Release retraction (#246): safely unpublish a dire release.
+#
+# Doctrine: RETRACT AND SUPERSEDE, never reuse a version — registry layers,
+# Helm repo caches, OLM catalogs and the Rekor transparency log all cache
+# immutably; a version string must never mean two different builds. The fix
+# always ships as the next patch version.
+#
+# ALWAYS run with dry-run=true first: the dry-run is also the GRACE-WINDOW
+# PROBE — it enumerates which surfaces already carry the version and prints
+# either "window OPEN" (tag delete-and-re-cut is still safe) or "window
+# CLOSED at <surface>" (retract here, supersede with vX.Y.Z+1).
+name: Release Retract
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to retract (e.g. v1.12.1)'
+        required: true
+        type: string
+      previous-good-tag:
+        description: 'Tag to repoint moving image tags / latest docs at (e.g. v1.12.0). Required unless dry-run.'
+        required: false
+        default: ''
+        type: string
+      reason:
+        description: 'Why this release is being retracted (lands in the release banner and the record issue)'
+        required: true
+        type: string
+      dry-run:
+        description: 'Probe and print the plan only — no changes (ALWAYS run this first)'
+        required: false
+        default: true
+        type: boolean
+      repoint-moving-tags:
+        description: 'Repoint X.Y and X image tags at previous-good-tag (the silent-exposure channel)'
+        required: false
+        default: true
+        type: boolean
+      retract-release:
+        description: 'Mark the GitHub release RETRACTED (title banner + prerelease flag)'
+        required: false
+        default: true
+        type: boolean
+      remove-helm-classic:
+        description: 'Remove the chart version from the classic gh-pages Helm index'
+        required: false
+        default: true
+        type: boolean
+      remove-oci-chart:
+        description: 'Delete the chart version from the OCI registry'
+        required: false
+        default: true
+        type: boolean
+      retract-docs:
+        description: 'Republish /vX.Y/ + latest docs from previous-good-tag'
+        required: false
+        default: true
+        type: boolean
+      delete-pinned-image:
+        description: 'DELETE the vX.Y.Z image from ghcr (breaks running clusters that re-pull — security-dire only)'
+        required: false
+        default: false
+        type: boolean
+      delete-git-tag:
+        description: 'Delete the git tag (default keep — honest history; forks/caches have it anyway)'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write    # gh-pages edits, tag deletion
+  packages: write    # image tag repoint / deletion
+  issues: write      # retraction record
+
+concurrency:
+  group: gh-pages
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE: ghcr.io/neo4j-partners/neo4j-kubernetes-operator
+  ORG: neo4j-partners
+  PKG_OPERATOR: neo4j-kubernetes-operator
+  PKG_CHART: charts%2Fneo4j-operator
+  PAGES_BASE_URL: https://neo4j-partners.github.io/neo4j-kubernetes-operator
+
+jobs:
+  retract:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Compute versions
+      id: v
+      run: |
+        TAG="${{ inputs.tag }}"
+        CLEAN="${TAG#v}"
+        MINOR="${TAG%.*}"             # vX.Y.Z -> vX.Y
+        MAJOR="${MINOR%.*}"           # vX.Y   -> vX
+        echo "tag=$TAG"      >> "$GITHUB_OUTPUT"
+        echo "clean=$CLEAN"  >> "$GITHUB_OUTPUT"
+        echo "minor=$MINOR"  >> "$GITHUB_OUTPUT"
+        echo "major=${MAJOR#v}" >> "$GITHUB_OUTPUT"
+        PREV="${{ inputs.previous-good-tag }}"
+        echo "prev=$PREV" >> "$GITHUB_OUTPUT"
+        echo "prevclean=${PREV#v}" >> "$GITHUB_OUTPUT"
+        if [ "${{ inputs.dry-run }}" != "true" ] && [ -z "$PREV" ]; then
+          echo "::error::previous-good-tag is required for execution (only dry-run may omit it)"
+          exit 1
+        fi
+
+    # ── PROBE (always runs; in dry-run this is the entire job) ─────────────
+    - name: Probe surfaces / grace window
+      id: probe
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        TAG="${{ steps.v.outputs.tag }}"; CLEAN="${{ steps.v.outputs.clean }}"; MINOR="${{ steps.v.outputs.minor }}"
+        closed=""
+        probe() { printf '%-22s %s\n' "$1:" "$2"; }
+
+        # image tag on ghcr
+        if gh api "orgs/${ORG}/packages/container/${PKG_OPERATOR}/versions" --paginate \
+             --jq '.[].metadata.container.tags[]' 2>/dev/null | grep -qx "$TAG"; then
+          probe "image ${TAG}" "PUBLISHED"; closed="${closed} image"
+          echo "image=true" >> "$GITHUB_OUTPUT"
+        else
+          probe "image ${TAG}" "absent"; echo "image=false" >> "$GITHUB_OUTPUT"
+        fi
+
+        # GitHub release
+        if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+          probe "github release" "PUBLISHED"; closed="${closed} release"
+          echo "release=true" >> "$GITHUB_OUTPUT"
+        else
+          probe "github release" "absent"; echo "release=false" >> "$GITHUB_OUTPUT"
+        fi
+
+        # classic helm index
+        if curl -fsS "${PAGES_BASE_URL}/charts/index.yaml" 2>/dev/null | grep -q "version: ${CLEAN}$"; then
+          probe "helm classic ${CLEAN}" "PUBLISHED"; closed="${closed} helm-classic"
+          echo "helmclassic=true" >> "$GITHUB_OUTPUT"
+        else
+          probe "helm classic ${CLEAN}" "absent"; echo "helmclassic=false" >> "$GITHUB_OUTPUT"
+        fi
+
+        # OCI chart
+        if gh api "orgs/${ORG}/packages/container/${PKG_CHART}/versions" --paginate \
+             --jq '.[].metadata.container.tags[]' 2>/dev/null | grep -qx "$CLEAN"; then
+          probe "oci chart ${CLEAN}" "PUBLISHED"; closed="${closed} oci-chart"
+          echo "ocichart=true" >> "$GITHUB_OUTPUT"
+        else
+          probe "oci chart ${CLEAN}" "absent"; echo "ocichart=false" >> "$GITHUB_OUTPUT"
+        fi
+
+        # versioned docs
+        if curl -fsS -o /dev/null "${PAGES_BASE_URL}/${MINOR}/" 2>/dev/null; then
+          probe "docs /${MINOR}/" "PUBLISHED"; closed="${closed} docs"
+          echo "docs=true" >> "$GITHUB_OUTPUT"
+        else
+          probe "docs /${MINOR}/" "absent"; echo "docs=false" >> "$GITHUB_OUTPUT"
+        fi
+
+        # OperatorHub submission
+        PR=$(gh pr list --repo k8s-operatorhub/community-operators \
+              --search "neo4j-kubernetes-operator ${CLEAN} in:title" --state all \
+              --json number,state,url --jq '.[0] | "\(.state) \(.url)"' 2>/dev/null || true)
+        probe "operatorhub PR" "${PR:-none found}"
+        case "$PR" in
+          MERGED*) closed="${closed} operatorhub(MERGED)";;
+        esac
+        echo "ohpr=${PR}" >> "$GITHUB_OUTPUT"
+
+        echo ""
+        if [ -z "$closed" ]; then
+          echo "GRACE WINDOW: OPEN — no public artifact carries ${TAG}; tag delete-and-re-cut is safe."
+        else
+          echo "GRACE WINDOW: CLOSED at:${closed} — retract these surfaces and SUPERSEDE with the next patch version. Never re-cut ${TAG}."
+        fi
+
+    - name: Dry-run — stop here
+      if: inputs.dry-run == true
+      run: echo "Dry-run complete. Review the probe above, then re-run with dry-run=false and previous-good-tag set."
+
+    # ── EXECUTION ──────────────────────────────────────────────────────────
+    - name: Repoint moving image tags at previous good
+      if: inputs.dry-run == false && inputs.repoint-moving-tags == true && steps.probe.outputs.image == 'true'
+      run: |
+        echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+        PREVCLEAN="${{ steps.v.outputs.prevclean }}"
+        MINORCLEAN="${{ steps.v.outputs.minor }}"; MINORCLEAN="${MINORCLEAN#v}"
+        MAJOR="${{ steps.v.outputs.major }}"
+        for t in "$MINORCLEAN" "$MAJOR"; do
+          echo "repointing ${IMAGE}:${t} -> ${IMAGE}:${PREVCLEAN}"
+          docker buildx imagetools create -t "${IMAGE}:${t}" "${IMAGE}:${PREVCLEAN}"
+        done
+
+    - name: Retract GitHub release
+      if: inputs.dry-run == false && inputs.retract-release == true && steps.probe.outputs.release == 'true'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        TAG="${{ steps.v.outputs.tag }}"
+        CUR_TITLE=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json name --jq .name)
+        gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json body --jq .body > /tmp/body.md
+        {
+          echo "> [!CAUTION]"
+          echo "> **RETRACTED ($(date -u +%Y-%m-%d)):** ${{ inputs.reason }}"
+          echo "> Do not install this version. Use ${{ steps.v.outputs.prev }} or the next patch release."
+          echo ""
+          cat /tmp/body.md
+        } > /tmp/newbody.md
+        gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" \
+          --title "⚠️ RETRACTED — ${CUR_TITLE}" \
+          --prerelease \
+          --notes-file /tmp/newbody.md
+
+    - name: Remove chart from classic Helm repo
+      if: inputs.dry-run == false && inputs.remove-helm-classic == true && steps.probe.outputs.helmclassic == 'true'
+      run: |
+        CLEAN="${{ steps.v.outputs.clean }}"
+        git clone --depth 1 --branch gh-pages \
+          "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git" /tmp/ghp
+        cd /tmp/ghp/charts
+        rm -f "neo4j-operator-${CLEAN}.tgz"
+        # Regenerate the index from the remaining tarballs (full regen — all
+        # surviving versions are present in this directory).
+        curl -fsSL https://get.helm.sh/helm-v3.16.0-linux-amd64.tar.gz | tar xz -C /tmp linux-amd64/helm
+        /tmp/linux-amd64/helm repo index . --url "${PAGES_BASE_URL}/charts"
+        cd /tmp/ghp
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git add charts && git commit -m "retract: remove neo4j-operator ${CLEAN} from Helm index (${{ inputs.reason }})" && git push
+
+    - name: Delete OCI chart version
+      if: inputs.dry-run == false && inputs.remove-oci-chart == true && steps.probe.outputs.ocichart == 'true'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        CLEAN="${{ steps.v.outputs.clean }}"
+        ID=$(gh api "orgs/${ORG}/packages/container/${PKG_CHART}/versions" --paginate \
+              --jq ".[] | select(.metadata.container.tags[]? == \"${CLEAN}\") | .id" | head -1)
+        [ -n "$ID" ] && gh api -X DELETE "orgs/${ORG}/packages/container/${PKG_CHART}/versions/${ID}" \
+          && echo "deleted OCI chart version ${CLEAN} (id ${ID})"
+
+    - name: Republish docs from previous good
+      if: inputs.dry-run == false && inputs.retract-docs == true && steps.probe.outputs.docs == 'true'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        # /vX.Y/ + latest re-derive from the previous good tag via the
+        # dispatchable docs workflow (handles both same-minor patch retracts
+        # and new-minor retracts; for a new minor the alias now points at the
+        # previous content rather than dangling).
+        PREVMINOR="${{ steps.v.outputs.prev }}"; PREVMINOR="${PREVMINOR%.*}"
+        gh workflow run pages-docs.yml --repo "$GITHUB_REPOSITORY" --ref "${{ steps.v.outputs.prev }}" \
+          -f version-alias="${{ steps.v.outputs.minor }}" -f update-latest=true
+        echo "dispatched docs republish of ${{ steps.v.outputs.minor }} + latest from ${{ steps.v.outputs.prev }}"
+
+    - name: Delete pinned image (security-dire only)
+      if: inputs.dry-run == false && inputs.delete-pinned-image == true && steps.probe.outputs.image == 'true'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        TAG="${{ steps.v.outputs.tag }}"; CLEAN="${{ steps.v.outputs.clean }}"
+        for t in "$TAG" "$CLEAN"; do
+          ID=$(gh api "orgs/${ORG}/packages/container/${PKG_OPERATOR}/versions" --paginate \
+                --jq ".[] | select(.metadata.container.tags[]? == \"${t}\") | .id" | head -1)
+          [ -n "$ID" ] && gh api -X DELETE "orgs/${ORG}/packages/container/${PKG_OPERATOR}/versions/${ID}" \
+            && echo "deleted image version ${t} (id ${ID})"
+        done
+
+    - name: Delete git tag
+      if: inputs.dry-run == false && inputs.delete-git-tag == true
+      run: |
+        git clone --depth 1 "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git" /tmp/repo
+        cd /tmp/repo && git push origin ":refs/tags/${{ steps.v.outputs.tag }}"
+
+    - name: File retraction record
+      if: inputs.dry-run == false
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        {
+          echo "**Retracted:** ${{ steps.v.outputs.tag }}"
+          echo "**Superseded by / repointed to:** ${{ steps.v.outputs.prev }}"
+          echo "**Reason:** ${{ inputs.reason }}"
+          echo "**Run:** ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          echo ""
+          echo "Surfaces at probe time: image=${{ steps.probe.outputs.image }} release=${{ steps.probe.outputs.release }} helm-classic=${{ steps.probe.outputs.helmclassic }} oci-chart=${{ steps.probe.outputs.ocichart }} docs=${{ steps.probe.outputs.docs }}"
+          echo "OperatorHub: ${{ steps.probe.outputs.ohpr }}"
+          echo ""
+          echo "**Manual follow-ups:**"
+          echo "- [ ] If the OperatorHub PR was MERGED: submit a superseding bundle or channel-graph edit (cannot be yanked)."
+          echo "- [ ] Ship the superseding patch release."
+          echo "- [ ] Notify the team channel."
+        } > /tmp/record.md
+        gh issue create --repo "$GITHUB_REPOSITORY" \
+          --title "RETRACTION RECORD: ${{ steps.v.outputs.tag }}" \
+          --label bug \
+          --body-file /tmp/record.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -376,6 +376,61 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  # Versioned docs + classic Helm repo publish ONLY after every gate and
+  # artifact above exists (#245) — these used to fire on the tag push, in
+  # parallel with the gates. The called workflows inherit this run's
+  # GITHUB_REF (the tag), so their version derivation is unchanged.
+  publish-docs:
+    name: Publish Versioned Docs
+    needs: [create-release]
+    permissions:
+      contents: write
+    uses: ./.github/workflows/pages-docs.yml
+
+  publish-helm:
+    name: Publish Helm Repo (classic)
+    needs: [create-release]
+    permissions:
+      contents: write
+    uses: ./.github/workflows/pages-helm.yml
+
+  # Incident reporter (#245): if ANY job in the release failed, open an issue
+  # with the failed jobs and a link — a failed tag should never be silent.
+  # With publication ordered behind the gates there is nothing to roll back;
+  # this job is the paper trail.
+  release-failure-incident:
+    name: Release Failure Incident
+    if: failure()
+    needs: [determine-tag, validate-release, install-confidence, build-and-push, create-release, submit-operatorhub, publish-docs, publish-helm]
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      actions: read
+    steps:
+    - name: File incident issue
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG: ${{ needs.determine-tag.outputs.tag_name }}
+      run: |
+        FAILED=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs" \
+          --jq '[.jobs[] | select(.conclusion=="failure") | .name] | join(", ")')
+        {
+          echo "Release run for \`${TAG}\` failed before completing publication."
+          echo ""
+          echo "**Failed job(s):** ${FAILED:-see run}"
+          echo "**Run:** ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          echo ""
+          echo "Publication is ordered behind the gates (#245), so nothing user-facing"
+          echo "was published by this run unless create-release succeeded. If the tag"
+          echo "needs to move: re-cutting is safe only while the grace window is open —"
+          echo "run the release-retract workflow in dry-run mode to check (#246)."
+        } > /tmp/incident.md
+        gh issue create \
+          --repo "${GITHUB_REPOSITORY}" \
+          --title "Release ${TAG} failed: ${FAILED:-unknown job}" \
+          --label bug \
+          --body-file /tmp/incident.md
+
   submit-operatorhub:
     name: Submit to OperatorHub
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
         args: ['--allow-multiple-documents']
-        exclude: ^(config/manager/|\.github/workflows/|charts/).*\.ya?ml$
+        exclude: ^(config/manager/|charts/).*\.ya?ml$
       # - id: check-added-large-files
       #   args: ['--maxkb=1000']  # Limit to 1MB
       - id: check-case-conflict

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -14,14 +14,13 @@ rules:
     max-spaces-inside-empty: 0
   indentation:
     spaces: 2
-    indent-sequences: true
+    indent-sequences: whatever  # workflows use 4-space sequences; syntax coverage matters, style does not
     check-multi-line-strings: false
 
 ignore: |
   /config/
   /charts/
   /hack/
-  /.github/workflows/
   /dev-data/
   *.yaml.tmpl
   *.yml.tmpl

--- a/docs/developer_guide/ci_and_workflows.md
+++ b/docs/developer_guide/ci_and_workflows.md
@@ -276,9 +276,11 @@ from the tag.
 git tag v1.12.0 && git push origin v1.12.0
 ```
 
-This fans out to **Release** (multi-arch signed images + GitHub release +
-kubectl bundles + OLM CSV), **Pages — Docs** (`/v1.12/` + `/latest/`), and
-**Pages — Helm Repo** (`/charts/`).
+This fires **Release** only. The versioned docs (`/vX.Y/` + `/latest/`) and
+the classic Helm repo (`/charts/`) are published by the Release workflow's
+final jobs **after every gate and artifact exists** — a failed release
+publishes nothing (#245). Push-to-main docs (`/main/`) are unaffected. Any
+job failure auto-files an incident issue with the failed jobs and run link.
 
 **After the workflows finish:**
 
@@ -297,6 +299,21 @@ kubectl bundles + OLM CSV), **Pages — Docs** (`/v1.12/` + `/latest/`), and
 7. Comment on every issue the release fixes that was reported by someone else,
    naming the released version and asking the reporter to re-verify against it
    — reporter-filed issues stay open until verified on a pinned release.
+
+### Retracting a release
+
+`release-retract.yml` (manual dispatch, #246) safely unpublishes a dire
+release. Doctrine: **retract and supersede — never reuse a version** (registry
+layers, Helm caches, OLM catalogs and Rekor cache immutably). **Always run
+with `dry-run: true` first**: the dry-run doubles as the grace-window probe,
+printing either "window OPEN" (tag delete-and-re-cut still safe — nothing
+published) or "window CLOSED at <surface>" (retract + ship vX.Y.Z+1).
+Execution repoints the moving image tags at `previous-good-tag`, banners the
+GitHub release as RETRACTED, removes the chart from both channels, republishes
+docs from the previous good tag, and files a retraction-record issue with the
+manual follow-ups (notably: a MERGED OperatorHub PR can only be superseded,
+never yanked). Deleting the pinned image or the git tag are explicit opt-in
+flags, default off.
 
 ## Publishing to GitHub Pages
 


### PR DESCRIPTION
Implements the two release-process issues ahead of v1.12.1, which becomes their live test.

**#245**: `pages-docs`/`pages-helm` lose tag triggers and become `workflow_call`ed final jobs of `release.yml` (needing `create-release`) — a failed release publishes nothing; `/main/` docs and manual dispatch unchanged. Plus a `release-failure-incident` job (auto-filed issue on any failure) and closure of the pre-commit hole that let a syntactically-broken `release.yml` ship (`.github/workflows/` is no longer ignored by check-yaml/yamllint — that gate caught two injection mistakes during this very PR's authoring).

**#246**: `release-retract.yml` — dry-run-first retraction with the grace-window probe (window OPEN → safe re-cut / CLOSED at \<surface\> → supersede), per-surface toggles with safe defaults, moving-tag repointing, RETRACTED release banner, both chart channels, docs republish from previous good, retraction-record issue. Pinned-image/git-tag deletion explicit opt-ins.

**Post-merge validation plan**: run `release-retract` in dry-run against v1.12.0 (read-only — proves the probe), then v1.12.1's tag exercises the reordered publication end-to-end.

Closes #245
Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release publication order and adds workflows that mutate gh-pages, GHCR tags/packages, and GitHub releases; defaults and dry-run mitigate mistakes, but operator error during live retraction could affect consumers.
> 
> **Overview**
> Fixes **#245** by stopping versioned docs and the classic Helm repo from publishing on tag push in parallel with release gates. **`pages-docs.yml`** and **`pages-helm.yml`** drop `v*` tag triggers and add **`workflow_call`**; **`release.yml`** invokes them as **`publish-docs`** / **`publish-helm`** only after **`create-release`**, so a failed release does not advertise `/latest/`, `/vX.Y/`, or a chart for a version that never shipped. A **`release-failure-incident`** job opens a GitHub issue on any release failure, listing failed jobs and pointing maintainers at the retract dry-run for grace-window checks.
> 
> Adds **#246** **`release-retract.yml`**: manual, **dry-run-first** workflow that probes public surfaces (image, release, Helm classic/OCI, docs, OperatorHub PR) and reports grace window OPEN vs CLOSED, then optionally repoints moving image tags, banners the GitHub release RETRACTED, removes chart entries, republishes docs from a previous good tag, and files a retraction-record issue—with destructive steps (pinned image / git tag delete) opt-in only.
> 
> **Linting:** pre-commit **`check-yaml`** and **yamllint** no longer ignore **`.github/workflows/`** (yamllint uses **`indent-sequences: whatever`** for workflow style). Developer docs describe the reordered tag flow and the retraction runbook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6580cb58b0439f1b590faaec2ea3ef926f367c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->