### PR TITLE
fix: v1.12.1 readiness — #263 forensics, #227 hardening (stale-online, proxy deadline, SA conflicts, chain flock), #242, #252, #247

### DIFF
--- a/docs/api_reference/neo4jrestore.md
+++ b/docs/api_reference/neo4jrestore.md
@@ -58,7 +58,7 @@ kubectl exec <instance>-server-0 -c neo4j -- bash -c \
 | `options` | [`RestoreOptionsSpec`](#restoreoptionsspec) | ❌ | Additional restore configuration options |
 | `force` | `bool` | ❌ | Confirm restoring **over an existing database** (default: `false`). Standalone targets: passes `--overwrite-destination` to `neo4j-admin`. Cluster targets: required (or `options.replaceExisting: true`) before the operator issues the destructive `dbms.recreateDatabase` against an existing database. |
 | `stopCluster` | `bool` | ❌ | **Standalone targets only** (cluster targets restore via Cypher and ignore it). `true` scales the instance down before the restore Job (mounting `data-{name}-server-0` directly) and scales it back up after. With `false`, the operator **refuses** to run the Job while any server pod is running — it never writes into a live data volume. |
-| `timeout` | `string` | ❌ | Go duration (e.g. `"30m"`, `"2h"`). For **cluster** targets this bounds the online-convergence wait after `dbms.recreateDatabase` is issued (default **5m** when unset) — raise it for multi-GB stores seeded from object storage. |
+| `timeout` | `string` | ❌ | Go duration (e.g. `"30m"`, `"2h"`). For **cluster** targets this bounds the online-convergence wait after `dbms.recreateDatabase` is issued (default **5m** when unset) — raise it for multi-GB stores seeded from object storage. For **PVC-backed cluster restores** it also bounds the wait for the backup-seed-proxy Deployment to become Ready (default **3m** when unset); on expiry the restore fails with the proxy pod's condition (e.g. an RWO backup PVC still attached elsewhere). |
 
 **Target compatibility**: `clusterRef` can reference either:
 

--- a/docs/developer_guide/ci_and_workflows.md
+++ b/docs/developer_guide/ci_and_workflows.md
@@ -219,6 +219,15 @@ The same matrix runs as a **blocking job in `release.yml`** — a release tag
 cannot publish an image or chart if any leg fails. Use the local run (or the
 dispatch workflow) to catch problems before tagging instead of failing the tag.
 
+**Output contract** (#247): every sub-step prints a `[HH:MM:SS +elapsed]`
+prefix and waits pre-announce their timeout (helm `--wait` 180s/300s,
+rollout 180s, smoke poll 60s) — so a watcher can always tell *slow* from
+*stuck*. The docker build logs to `/tmp/ic-build.log` (tailed on failure).
+On any failure the script dumps cluster diagnostics — pods, the operator
+Deployment + its logs, recent events, helm releases — before exiting, and in
+Actions a verdict table (every passed check + the failing one) lands in the
+step summary on both pass and fail.
+
 ## Release
 
 **`release.yml` — tag-driven release pipeline.** Push a `vX.Y.Z` tag (or dispatch

--- a/docs/user_guide/guides/backup_restore.md
+++ b/docs/user_guide/guides/backup_restore.md
@@ -151,6 +151,15 @@ storage:
           eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/neo4j-backup-role
 ```
 
+> **One workload identity per namespace.** `neo4j-backup-sa` (and
+> `neo4j-restore-sa`) are **shared by every backup/restore CR in the
+> namespace** — workload-identity trust policies bind to the ServiceAccount
+> name. If two CRs declare *different* `autoCreate.annotations`, the last
+> one reconciled wins and the other's cloud access breaks; the operator
+> flags this with a `ServiceAccountAnnotationConflict` Warning event on the
+> overwriting CR. Use one IAM role/identity with access to **all** backup
+> locations in the namespace, or split the CRs across namespaces.
+
 The IAM role must allow these actions on your bucket:
 
 ```json
@@ -255,6 +264,12 @@ kubectl run minio-client --rm -it --restart=Never \
 >   --from-literal=AWS_REGION=us-east-1 \
 >   --from-literal=AWS_ENDPOINT_URL_S3=http://minio.minio.svc:9000
 > ```
+>
+> If a cluster restore resolves to a custom-endpoint backup and the operator
+> can verify the endpoint is missing from the server pods, it emits a
+> `SeedEndpointNotProjected` Warning event on the `Neo4jRestore` with this
+> exact fix — check `kubectl describe neo4jrestore <name>` before the seed
+> fails.
 
 Full examples with scheduled incremental backups: [`examples/backup-restore/backup-minio.yaml`](https://github.com/neo4j-partners/neo4j-kubernetes-operator/blob/main/examples/backup-restore/backup-minio.yaml).
 
@@ -646,7 +661,7 @@ spec:
 - Both CRs must use the same storage backend (type + bucket + path).
 - `chainFromBackup` cannot point to self.
 
-**Concurrent runs across chained CRs are blocked automatically.** Each Job carries an `app.kubernetes.io/part-of: <chain-root>` label; the operator refuses to start a new backup Job while any other Job in the same chain is still active (`status.active>0`) — routes the new run to `Pending` and requeues. This prevents the hourly DIFF from firing while the daily FULL is still writing, which would corrupt the chain. Offsetting schedules (different minute on the hour) avoids the wait in practice.
+**Concurrent runs across chained CRs are blocked automatically.** Each Job carries an `app.kubernetes.io/part-of: <chain-root>` label; the operator refuses to start a new backup Job while any other Job in the same chain is still active (`status.active>0`) — routes the new run to `Pending` and requeues. On **PVC storage** there's a second, run-time guard: each backup Job takes a lock file (`<chain-root>/.chain.lock`) on the shared directory before running `neo4j-admin`, so two Jobs that slip past the creation-time check (e.g. CronJob children firing in the same instant) serialize instead of corrupting the chain — the second waits up to 1 hour, then fails for its normal retry. Offsetting schedules (different minute on the hour) avoids the wait in practice.
 
 **Restore** seeds from the **latest successful artifact of the CR you reference** — *not* the latest file in the shared directory. This selects your recovery point:
 
@@ -875,6 +890,17 @@ On a cluster target this runs entirely over Cypher (no Job, `stopCluster` is ign
 **Best for:** Quick recovery from an existing `Neo4jBackup` resource.
 
 #### Restore from a Storage Location
+
+**Finding `backupPath`:** the operator records every run's directory and
+artifact filename on the originating `Neo4jBackup`:
+
+```bash
+kubectl get neo4jbackup <name> -o jsonpath='{.status.history[0].backupsPath}'        # directory
+kubectl get neo4jbackup <name> -o jsonpath='{.status.history[0].artifactFilename}'   # exact .backup file
+```
+
+(If the Backup CR still exists, `source.type: backup` with `backupRef`
+resolves the path for you — prefer it.)
 
 ```yaml
 apiVersion: neo4j.neo4j.com/v1beta1

--- a/docs/user_guide/guides/seed-uri.md
+++ b/docs/user_guide/guides/seed-uri.md
@@ -163,7 +163,7 @@ spec:
 
 - `AWS_SESSION_TOKEN` (for temporary credentials)
 - `AWS_REGION`
-- `AWS_ENDPOINT_URL_S3` — required for **MinIO / S3-compatible** stores. The `endpointURL`/`forcePathStyle` fields on `Neo4jBackup`/`Neo4jRestore` only affect their **Job pods**; the server pods doing seedURI fetches read the SDK's standard env vars, so put the endpoint in the Secret you project via `spec.extraEnvFrom`.
+- `AWS_ENDPOINT_URL_S3` — required for **MinIO / S3-compatible** stores. The `endpointURL`/`forcePathStyle` fields on `Neo4jBackup`/`Neo4jRestore` only affect their **Job pods**; the server pods doing seedURI fetches read the SDK's standard env vars, so put the endpoint in the Secret you project via `spec.extraEnvFrom`. (Cluster restores that resolve to a custom-endpoint backup emit a `SeedEndpointNotProjected` Warning event when the operator can verify the endpoint is missing from the server pods.)
 
 ### Google Cloud Storage
 **Required:**

--- a/docs/user_guide/troubleshooting/backup_restore.md
+++ b/docs/user_guide/troubleshooting/backup_restore.md
@@ -151,6 +151,15 @@ kubectl run backup-auth-check --rm -it --image=amazon/aws-cli --serviceaccount=<
    }
    ```
 
+3. **Identity conflicts between CRs** — backups that worked start failing
+   auth after another backup/restore CR was added: `neo4j-backup-sa` /
+   `neo4j-restore-sa` are shared per namespace, and two CRs declaring
+   different `identity.autoCreate.annotations` overwrite each other (last
+   writer wins). Look for a `ServiceAccountAnnotationConflict` Warning
+   event (`kubectl get events --field-selector reason=ServiceAccountAnnotationConflict`).
+   Fix: one identity per namespace with access to all backup locations, or
+   split the CRs across namespaces.
+
 #### Google Cloud Storage Issues
 
 **Service Account Problems:**
@@ -548,21 +557,25 @@ For full disaster recovery (corrupted primary, restore to a new cluster from lat
 - [Split-Brain Recovery](split-brain-recovery.md)
 
 
-## Restore reports Completed but the database is offline / unavailable
+## Cluster restore fails with "the seed FAILED: …"
 
-**Symptom:** `Neo4jRestore` shows `phase: Completed`, but connecting to the
-database fails with "database is unavailable", and:
+**Symptom:** a cluster-target `Neo4jRestore` goes `Failed` with a message like:
 
-```cypher
-SHOW DATABASE <name> YIELD name, currentStatus, requestedStatus, statusMessage;
+```
+Database "mydb" was created but the seed FAILED: Object not found at the
+path: s3://… — fix the cause, DROP DATABASE mydb IF EXISTS, and re-trigger
+the restore
 ```
 
-shows `currentStatus: offline` with a populated `statusMessage`.
+The quoted part is Neo4j's own `statusMessage` — it names the real cause.
 
-**Cause:** the seed download failed on the server pods; the `statusMessage`
-names the real cause. The most common one: `Object not found at the path:
-s3://…` on an **S3-compatible endpoint** (MinIO, on-prem) — the server JVMs
-are missing the endpoint configuration. Add to the cluster CR:
+**Most common cause:** `Object not found at the path: s3://…` on an
+**S3-compatible endpoint** (MinIO, on-prem) — the server JVMs are missing the
+endpoint configuration. The cluster Cypher restore makes the *server* pods
+fetch the seed, and the `endpointURL` field on the backup only reaches
+backup/restore *Job* pods. The operator emits a `SeedEndpointNotProjected`
+Warning event on the restore when it can verify the endpoint is missing.
+Add to the cluster CR:
 
 ```yaml
 spec:
@@ -576,21 +589,38 @@ spec:
 **Recovery:** fix the cause, `DROP DATABASE <name> IF EXISTS` (it holds no
 data), then re-trigger the restore (see the next section).
 
-## Retrying a Failed restore does nothing (or re-fails instantly)
+> Operator **v1.12.0 only**: a failed seed was reported as `phase: Completed`
+> with the database left `offline` — check `SHOW DATABASE <name> YIELD
+> statusMessage` for the cause. From v1.12.1 the restore fails fast with the
+> message above.
 
-**Symptom:** after a `Failed` restore you change the spec (new generation) to
-retry, but the restore immediately returns to `Failed` without a new Job pod
-running.
+## Retrying a finished restore
 
-**Cause:** the previous failed Job still exists under the same name, and the
-retry re-reads its Failed state.
-
-**Fix:** delete the old Job first, then bump the spec:
+`Completed`/`Failed` are terminal for the current spec generation. Any spec
+change that bumps the generation issues a fresh attempt:
 
 ```bash
-kubectl delete job <restore-name>-restore
 kubectl patch neo4jrestore <restore-name> --type=merge -p '{"spec":{"timeout":"10m"}}'
 ```
 
-(Cluster-target restores use the Cypher path — no Job — so a plain spec bump
-suffices there.)
+> Operator **v1.12.0 only**: on standalone (Job-based) targets the previous
+> failed Job blocked the retry — delete it first with
+> `kubectl delete job <restore-name>-restore`. From v1.12.1 the operator
+> replaces the stale Job itself; the spec bump alone suffices on all targets.
+
+## Restore stuck Pending on "Waiting for backup-seed-proxy"
+
+**Symptom:** a PVC-backed cluster restore stays `Pending` with
+`Waiting for backup-seed-proxy Deployment to become Ready (…)`, then goes
+`Failed` after the wait budget (3 minutes by default; `spec.timeout`
+overrides) with the proxy pod's condition in the message.
+
+**Cause:** the operator serves the backup PVC to the server pods through a
+small HTTP proxy Deployment, and that proxy can't start. The parenthesised
+diagnosis names the reason; the most common is the backup PVC being
+**ReadWriteOnce and still attached to another pod/node** (e.g. a backup Job
+pod that hasn't terminated, or a node that still holds the volume).
+
+**Fix:** release the PVC (wait for / delete the pod holding it), or move the
+backups to RWX storage or object storage. Then re-trigger the restore with a
+spec bump.

--- a/internal/controller/backup_restore_field_findings_test.go
+++ b/internal/controller/backup_restore_field_findings_test.go
@@ -159,3 +159,44 @@ func TestCleanupJobHasNoOwnerReference(t *testing.T) {
 		t.Errorf("cleanup Job must NOT be owner-ref'd to the CR being deleted (GC races the prune script); got: %v", jobs.Items[0].OwnerReferences)
 	}
 }
+
+// #227: PVC-backed backup Jobs must serialize on the chain directory via
+// flock — the operator's Job-creation gate can't stop two CronJob children
+// (FULL parent + DIFF child sharing the dir via chainFromBackup) firing into
+// the same reconcile gap. The lock is fd-based (no nested quoting) and held
+// for the whole command chain; cloud targets have no shared fs to lock.
+func TestBuildBackupCommand_PVCChainDirFlock(t *testing.T) {
+	r := newShardedTestReconciler(t)
+	backup := fieldFindingsBackup(nil)
+
+	cmd, err := r.buildBackupCommand(context.Background(), backup, fieldFindingsCluster("5.26.0-enterprise"))
+	if err != nil {
+		t.Fatalf("buildBackupCommand: %v", err)
+	}
+	wantPrefix := "mkdir -p '/backup/bk/' && exec 9>'/backup/bk/.chain.lock' && flock -w 3600 9 && "
+	if !strings.HasPrefix(cmd, wantPrefix) {
+		t.Fatalf("PVC backup command must take the chain-dir flock before neo4j-admin:\nwant prefix %q\ngot %q", wantPrefix, cmd)
+	}
+
+	// A DIFF child chained into another CR's dir locks the PARENT's chain
+	// root — that's the directory the two CRs contend on.
+	backup.Spec.ChainFromBackup = "daily-full"
+	cmd, err = r.buildBackupCommand(context.Background(), backup, fieldFindingsCluster("5.26.0-enterprise"))
+	if err != nil {
+		t.Fatalf("buildBackupCommand (chained): %v", err)
+	}
+	if !strings.Contains(cmd, "exec 9>'/backup/daily-full/.chain.lock'") {
+		t.Fatalf("chained backup must lock the parent chain root, got %q", cmd)
+	}
+
+	// Cloud targets: no flock (nothing to lock on object storage).
+	backup = fieldFindingsBackup(nil)
+	backup.Spec.Storage = neo4jv1beta1.StorageLocation{Type: "s3", Bucket: "bkt"}
+	cmd, err = r.buildBackupCommand(context.Background(), backup, fieldFindingsCluster("5.26.0-enterprise"))
+	if err != nil {
+		t.Fatalf("buildBackupCommand (s3): %v", err)
+	}
+	if strings.Contains(cmd, "flock") {
+		t.Fatalf("cloud backup must not attempt flock, got %q", cmd)
+	}
+}

--- a/internal/controller/cluster_connectivity_streak_test.go
+++ b/internal/controller/cluster_connectivity_streak_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
+)
+
+// Pins the #263 connectivity-failure forensics: the streak counts
+// consecutive failures per cluster, preserves the first-failure timestamp,
+// and resets on success so the next outage starts a fresh streak.
+func TestConnectivityFailureStreak(t *testing.T) {
+	r := &Neo4jEnterpriseClusterReconciler{}
+	cluster := &neo4jv1beta1.Neo4jEnterpriseCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "ns1"},
+	}
+	other := &neo4jv1beta1.Neo4jEnterpriseCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "ns2"},
+	}
+
+	s1 := r.recordConnectivityFailure(cluster)
+	if s1.count != 1 {
+		t.Fatalf("first failure: count = %d, want 1", s1.count)
+	}
+	firstSince := s1.since
+
+	s2 := r.recordConnectivityFailure(cluster)
+	if s2.count != 2 {
+		t.Fatalf("second failure: count = %d, want 2", s2.count)
+	}
+	if !s2.since.Equal(firstSince) {
+		t.Fatalf("streak start moved on repeat failure: %v != %v", s2.since, firstSince)
+	}
+
+	// Streaks are per cluster — a different namespace starts at 1.
+	if got := r.recordConnectivityFailure(other); got.count != 1 {
+		t.Fatalf("other cluster streak: count = %d, want 1", got.count)
+	}
+
+	// Success resets the streak; the next failure starts over.
+	r.clearConnectivityFailures(context.Background(), cluster)
+	if got := r.recordConnectivityFailure(cluster); got.count != 1 {
+		t.Fatalf("post-reset failure: count = %d, want 1", got.count)
+	}
+
+	// Clearing a cluster with no streak is a no-op.
+	r.clearConnectivityFailures(context.Background(), other)
+	r.clearConnectivityFailures(context.Background(), other)
+}
+
+func TestFirstNonNilErr(t *testing.T) {
+	e1, e2 := errors.New("one"), errors.New("two")
+	if got := firstNonNilErr(nil, e1, e2); !errors.Is(got, e1) {
+		t.Fatalf("firstNonNilErr = %v, want %v", got, e1)
+	}
+	if got := firstNonNilErr(nil, nil); got != nil {
+		t.Fatalf("firstNonNilErr all-nil = %v, want nil", got)
+	}
+}

--- a/internal/controller/events.go
+++ b/internal/controller/events.go
@@ -18,6 +18,9 @@ const (
 	EventReasonScaleDownPendingDrain         = "ScaleDownPendingDrain"
 	EventReasonScaleDownDraining             = "ScaleDownDraining"
 	EventReasonScaleDownBlocked              = "ScaleDownBlocked"
+	// EventReasonConnectivityDegraded — the operator has failed to reach the
+	// cluster's Bolt endpoint for a sustained streak of reconciles (#263).
+	EventReasonConnectivityDegraded = "ConnectivityDegraded"
 )
 
 // Rolling upgrade events

--- a/internal/controller/events.go
+++ b/internal/controller/events.go
@@ -41,15 +41,20 @@ const (
 	EventReasonBackupScheduled = "BackupScheduled"
 	// EventReasonBackupRetentionCaveat — retention pruning configured on a CR
 	// whose chain may contain differential artifacts (#217).
-	EventReasonBackupRetentionCaveat  = "BackupRetentionCaveat"
-	EventReasonBackupStarted          = "BackupStarted"
-	EventReasonBackupCompleted        = "BackupCompleted"
-	EventReasonBackupFailed           = "BackupFailed"
-	EventReasonRestoreStarted         = "RestoreStarted"
-	EventReasonRestoreCompleted       = "RestoreCompleted"
-	EventReasonRestoreFailed          = "RestoreFailed"
-	EventReasonRestoreFromChainParent = "RestoreFromChainParent"
-	EventReasonDatabaseCreateFailed   = "DatabaseCreateFailed"
+	EventReasonBackupRetentionCaveat = "BackupRetentionCaveat"
+	// EventReasonServiceAccountAnnotationConflict — a backup/restore CR
+	// overwrote DIFFERENT workload-identity annotations on the shared
+	// namespace ServiceAccount; last writer wins and the others' cloud
+	// access breaks (#227).
+	EventReasonServiceAccountAnnotationConflict = "ServiceAccountAnnotationConflict"
+	EventReasonBackupStarted                    = "BackupStarted"
+	EventReasonBackupCompleted                  = "BackupCompleted"
+	EventReasonBackupFailed                     = "BackupFailed"
+	EventReasonRestoreStarted                   = "RestoreStarted"
+	EventReasonRestoreCompleted                 = "RestoreCompleted"
+	EventReasonRestoreFailed                    = "RestoreFailed"
+	EventReasonRestoreFromChainParent           = "RestoreFromChainParent"
+	EventReasonDatabaseCreateFailed             = "DatabaseCreateFailed"
 )
 
 // Database events

--- a/internal/controller/events.go
+++ b/internal/controller/events.go
@@ -47,14 +47,19 @@ const (
 	// namespace ServiceAccount; last writer wins and the others' cloud
 	// access breaks (#227).
 	EventReasonServiceAccountAnnotationConflict = "ServiceAccountAnnotationConflict"
-	EventReasonBackupStarted                    = "BackupStarted"
-	EventReasonBackupCompleted                  = "BackupCompleted"
-	EventReasonBackupFailed                     = "BackupFailed"
-	EventReasonRestoreStarted                   = "RestoreStarted"
-	EventReasonRestoreCompleted                 = "RestoreCompleted"
-	EventReasonRestoreFailed                    = "RestoreFailed"
-	EventReasonRestoreFromChainParent           = "RestoreFromChainParent"
-	EventReasonDatabaseCreateFailed             = "DatabaseCreateFailed"
+	// EventReasonSeedEndpointNotProjected — a cluster Cypher restore
+	// resolved to a custom S3 endpoint (MinIO etc.) but the server pods
+	// verifiably lack AWS_ENDPOINT_URL_S3, so the server-side seed fetch
+	// will target s3.amazonaws.com and fail (#252).
+	EventReasonSeedEndpointNotProjected = "SeedEndpointNotProjected"
+	EventReasonBackupStarted            = "BackupStarted"
+	EventReasonBackupCompleted          = "BackupCompleted"
+	EventReasonBackupFailed             = "BackupFailed"
+	EventReasonRestoreStarted           = "RestoreStarted"
+	EventReasonRestoreCompleted         = "RestoreCompleted"
+	EventReasonRestoreFailed            = "RestoreFailed"
+	EventReasonRestoreFromChainParent   = "RestoreFromChainParent"
+	EventReasonDatabaseCreateFailed     = "DatabaseCreateFailed"
 )
 
 // Database events

--- a/internal/controller/neo4jbackup_controller.go
+++ b/internal/controller/neo4jbackup_controller.go
@@ -2018,6 +2018,13 @@ const backupServiceAccountName = "neo4j-backup-sa"
 // and applies any workload-identity annotations declared in the backup spec.
 // No Role or RoleBinding is created: the backup Job runs neo4j-admin directly and
 // does not need any Kubernetes API access.
+//
+// The SA is SHARED by every backup (and restore) CR in the namespace, and
+// IRSA / Workload Identity trust policies bind to its NAME — renaming or
+// going per-CR would break every existing cloud-identity setup, so until a
+// per-CR design ships (v1.13, #227) conflicting annotations are
+// last-writer-wins. We at least make the fight visible: overwriting a
+// DIFFERENT existing value emits a Warning event naming both values.
 func (r *Neo4jBackupReconciler) ensureBackupServiceAccount(ctx context.Context, backup *neo4jv1beta1.Neo4jBackup) error {
 	namespace := backup.Namespace
 
@@ -2036,17 +2043,24 @@ func (r *Neo4jBackupReconciler) ensureBackupServiceAccount(ctx context.Context, 
 			Namespace: namespace,
 		},
 	}
+	var conflicts []string
 	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, sa, func() error {
 		// Apply workload-identity annotations; preserve any other annotations
 		// already present (e.g. set by cloud-controller or the user directly).
 		if sa.Annotations == nil {
 			sa.Annotations = map[string]string{}
 		}
+		conflicts = serviceAccountAnnotationConflicts(sa.Annotations, wiAnnotations)
 		for k, v := range wiAnnotations {
 			sa.Annotations[k] = v
 		}
 		return nil
 	})
+	if err == nil && len(conflicts) > 0 && r.Recorder != nil {
+		r.Recorder.Event(backup, corev1.EventTypeWarning, EventReasonServiceAccountAnnotationConflict,
+			fmt.Sprintf("Overwrote workload-identity annotations on the SHARED ServiceAccount %s/%s: %s. Multiple backup/restore CRs in this namespace declare different identities; the last reconciled CR wins and the others' cloud access breaks. Use ONE identity per namespace (an IAM role/identity with access to all backup locations), or split the CRs across namespaces.",
+				namespace, backupServiceAccountName, strings.Join(conflicts, "; ")))
+	}
 	return err
 }
 

--- a/internal/controller/neo4jbackup_controller.go
+++ b/internal/controller/neo4jbackup_controller.go
@@ -1341,11 +1341,31 @@ func (r *Neo4jBackupReconciler) buildBackupCommand(ctx context.Context, backup *
 
 	if backup.Spec.Storage.Type == "pvc" {
 		// chainFromBackup feeds the PVC path segment — quote it too (#219).
-		cmd = fmt.Sprintf("mkdir -p %s && %s", shellQuote(toPath), cmd)
+		//
+		// flock on the chain directory (#227): the operator's
+		// waitForChainConcurrencyClear gate runs at Job-CREATION time, but
+		// two CronJobs (a FULL parent + a DIFF child sharing the dir via
+		// chainFromBackup) can still fire their children within the same
+		// reconcile gap and run concurrently — a DIFF reading the chain
+		// while the FULL rewrites it corrupts the chain. The lock is held
+		// by the Job shell (fd 9, auto-released on exit) for the backup AND
+		// the optional validate step; a contender waits up to
+		// chainLockWaitSeconds, then fails the Job (retried per
+		// backoffLimit). PVC-only: cloud chain dirs have no shared
+		// filesystem to lock — there the creation-time gate remains the
+		// only guard. The dot-file never matches the retention pruner's
+		// '*.backup' patterns.
+		lockPath := shellQuote(strings.TrimSuffix(toPath, "/") + "/.chain.lock")
+		cmd = fmt.Sprintf("mkdir -p %s && exec 9>%s && flock -w %d 9 && %s",
+			shellQuote(toPath), lockPath, chainLockWaitSeconds, cmd)
 	}
 
 	return cmd, nil
 }
+
+// chainLockWaitSeconds bounds how long a backup Job waits on the chain-dir
+// flock before giving up (1h — a DIFF queued behind a large in-flight FULL).
+const chainLockWaitSeconds = 3600
 
 // buildToPath returns the --to-path value passed to neo4j-admin. All runs
 // of a single Neo4jBackup CR share this directory — it's how neo4j-admin

--- a/internal/controller/neo4jenterprisecluster_controller.go
+++ b/internal/controller/neo4jenterprisecluster_controller.go
@@ -72,6 +72,19 @@ type Neo4jEnterpriseClusterReconciler struct {
 	// (key ns/name → deferred image) so a held image change doesn't emit an
 	// event on every Forming-phase reconcile (#262 review).
 	deferredUpgradeTargets sync.Map
+	// connectivityFailures tracks consecutive can't-connect reconciles per
+	// cluster (key ns/name → *connectivityFailureStreak) so a persistent
+	// outage is distinguishable from a transient blip in logs and events
+	// (#263 forensics). Cleared on the first successful connection.
+	connectivityFailures sync.Map
+}
+
+// connectivityFailureStreak records when a cluster's Bolt connectivity first
+// failed and how many consecutive reconciles have failed since. The Warning
+// event fires exactly once per streak, at count == threshold.
+type connectivityFailureStreak struct {
+	since time.Time
+	count int
 }
 
 const (
@@ -1871,11 +1884,26 @@ func (r *Neo4jEnterpriseClusterReconciler) verifyNeo4jClusterFormation(ctx conte
 	}
 
 	if !canConnect {
-		// Neo4j is not ready to accept connections yet, wait for it
+		// Neo4j is not ready to accept connections yet, wait for it.
+		// Log the resolved target and the consecutive-failure streak so a
+		// persistent outage (#263) is diagnosable from operator logs alone:
+		// a streak of 1-2 during a rolling restart is expected; a streak
+		// climbing for minutes against a settled cluster is the incident.
+		streak := r.recordConnectivityFailure(cluster)
 		logger.Info("Neo4j not ready to accept connections, waiting...",
-			"clientError", connectError, "testError", testError)
+			"targetURI", neo4jclient.ConnectionURIForEnterprise(cluster),
+			"clientError", connectError, "testError", testError,
+			"consecutiveFailures", streak.count,
+			"failingSince", streak.since.Format(time.RFC3339))
+		if streak.count == connectivityFailureEventThreshold && r.Recorder != nil {
+			r.Recorder.Event(cluster, corev1.EventTypeWarning, EventReasonConnectivityDegraded,
+				fmt.Sprintf("Operator has failed to reach Neo4j at %s for %d consecutive reconciles (since %s); last error: %v",
+					neo4jclient.ConnectionURIForEnterprise(cluster), streak.count,
+					streak.since.Format(time.RFC3339), firstNonNilErr(testError, connectError)))
+		}
 		return false, "Waiting for Neo4j to accept connections", nil
 	}
+	r.clearConnectivityFailures(ctx, cluster)
 
 	// Now perform split-brain detection since Neo4j is responsive
 	logger.Info("Neo4j is responsive, performing split-brain detection")
@@ -2894,4 +2922,47 @@ func (r *Neo4jEnterpriseClusterReconciler) serverStatefulSetFullyRolled(ctx cont
 		return false, fmt.Sprintf("%d/%d pods updated, %d/%d ready", serverSts.Status.UpdatedReplicas, replicas, serverSts.Status.ReadyReplicas, replicas)
 	}
 	return true, ""
+}
+
+// connectivityFailureEventThreshold is the consecutive-failure streak at
+// which a ConnectivityDegraded Warning event fires (once per streak). At the
+// controller's ~30s requeue cadence this is roughly five minutes — past any
+// normal rolling-restart blip, early enough to be actionable.
+const connectivityFailureEventThreshold = 10
+
+// recordConnectivityFailure increments the cluster's consecutive
+// connectivity-failure streak and returns it (#263 forensics).
+func (r *Neo4jEnterpriseClusterReconciler) recordConnectivityFailure(cluster *neo4jv1beta1.Neo4jEnterpriseCluster) *connectivityFailureStreak {
+	key := cluster.Namespace + "/" + cluster.Name
+	v, _ := r.connectivityFailures.LoadOrStore(key, &connectivityFailureStreak{since: time.Now()})
+	streak := v.(*connectivityFailureStreak)
+	streak.count++
+	return streak
+}
+
+// clearConnectivityFailures resets the streak after a successful connection,
+// logging a closing summary if a long streak just ended so the recovery is
+// visible next to the failures.
+func (r *Neo4jEnterpriseClusterReconciler) clearConnectivityFailures(ctx context.Context, cluster *neo4jv1beta1.Neo4jEnterpriseCluster) {
+	key := cluster.Namespace + "/" + cluster.Name
+	if v, loaded := r.connectivityFailures.LoadAndDelete(key); loaded {
+		streak := v.(*connectivityFailureStreak)
+		if streak.count >= connectivityFailureEventThreshold {
+			log.FromContext(ctx).Info("Neo4j connectivity recovered after persistent failure streak",
+				"consecutiveFailures", streak.count,
+				"failingSince", streak.since.Format(time.RFC3339),
+				"outageDuration", time.Since(streak.since).Round(time.Second).String())
+		}
+	}
+}
+
+// firstNonNilErr returns the first non-nil error, for log/event messages
+// that want the most specific failure available.
+func firstNonNilErr(errs ...error) error {
+	for _, e := range errs {
+		if e != nil {
+			return e
+		}
+	}
+	return nil
 }

--- a/internal/controller/neo4jenterprisecluster_controller.go
+++ b/internal/controller/neo4jenterprisecluster_controller.go
@@ -2935,7 +2935,11 @@ const connectivityFailureEventThreshold = 10
 func (r *Neo4jEnterpriseClusterReconciler) recordConnectivityFailure(cluster *neo4jv1beta1.Neo4jEnterpriseCluster) *connectivityFailureStreak {
 	key := cluster.Namespace + "/" + cluster.Name
 	v, _ := r.connectivityFailures.LoadOrStore(key, &connectivityFailureStreak{since: time.Now()})
-	streak := v.(*connectivityFailureStreak)
+	streak, ok := v.(*connectivityFailureStreak)
+	if !ok { // unreachable — the map only ever holds streaks
+		streak = &connectivityFailureStreak{since: time.Now()}
+		r.connectivityFailures.Store(key, streak)
+	}
 	streak.count++
 	return streak
 }
@@ -2946,8 +2950,8 @@ func (r *Neo4jEnterpriseClusterReconciler) recordConnectivityFailure(cluster *ne
 func (r *Neo4jEnterpriseClusterReconciler) clearConnectivityFailures(ctx context.Context, cluster *neo4jv1beta1.Neo4jEnterpriseCluster) {
 	key := cluster.Namespace + "/" + cluster.Name
 	if v, loaded := r.connectivityFailures.LoadAndDelete(key); loaded {
-		streak := v.(*connectivityFailureStreak)
-		if streak.count >= connectivityFailureEventThreshold {
+		streak, ok := v.(*connectivityFailureStreak)
+		if ok && streak.count >= connectivityFailureEventThreshold {
 			log.FromContext(ctx).Info("Neo4j connectivity recovered after persistent failure streak",
 				"consecutiveFailures", streak.count,
 				"failingSince", streak.since.Format(time.RFC3339),

--- a/internal/controller/neo4jrestore_controller.go
+++ b/internal/controller/neo4jrestore_controller.go
@@ -3210,19 +3210,25 @@ func (r *Neo4jRestoreReconciler) resolveClusterPVCRestoreURI(
 
 // seedProxyWaitStart resolves the deadline anchor for the seed-proxy wait.
 // Normally the persisted annotation stamp; if persisting it keeps FAILING,
-// fall back to status.StartTime (set when the restore attempt began) so a
-// broken annotation write can't reopen the unbounded wait #227 removed
-// (Bugbot, PR #265). The fallback is conservative — StartTime predates the
-// proxy wait, so it can only expire the wait EARLIER, never extend it.
-// Returns (anchor, false) only when no anchor exists at all.
+// fall back to the PERSISTED status.startTime so a broken annotation write
+// can't reopen the unbounded wait #227 removed (Bugbot, PR #265). The
+// fallback must be read from the API, not the in-memory object: startRestore
+// resets the in-memory StartTime to "now" on every Pending requeue (the
+// persisted value is protected by updateRestoreStatus's earlier-wins rule),
+// so the in-memory copy slides and would never expire (Bugbot round 2).
+// Conservative either way — StartTime predates the proxy wait, so it can
+// only expire the wait EARLIER, never extend it. Returns (anchor, false)
+// only when no anchor is reachable at all (API fully unavailable — status
+// writes are failing too, so nothing is silently Pending).
 func (r *Neo4jRestoreReconciler) seedProxyWaitStart(ctx context.Context, restore *neo4jv1beta1.Neo4jRestore) (time.Time, bool) {
 	if t, err := r.markSeedProxyWaitStarted(ctx, restore); err == nil {
 		return t, true
 	} else {
-		log.FromContext(ctx).V(1).Info("Failed to persist seed-proxy wait anchor; falling back to status.startTime for the deadline", "error", err.Error())
+		log.FromContext(ctx).V(1).Info("Failed to persist seed-proxy wait anchor; falling back to the persisted status.startTime for the deadline", "error", err.Error())
 	}
-	if restore.Status.StartTime != nil {
-		return restore.Status.StartTime.Time, true
+	latest := &neo4jv1beta1.Neo4jRestore{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(restore), latest); err == nil && latest.Status.StartTime != nil {
+		return latest.Status.StartTime.Time, true
 	}
 	return time.Time{}, false
 }

--- a/internal/controller/neo4jrestore_controller.go
+++ b/internal/controller/neo4jrestore_controller.go
@@ -157,6 +157,17 @@ const (
 	// at most one extra requeue on tiny restores; prevents false Completed
 	// on every recreate that polls early.
 	cypherRestoreStaleOnlineGrace = 30 * time.Second
+
+	// AnnotationSeedProxyWaitStarted anchors the deadline for waiting on the
+	// backup-seed-proxy Deployment to become Ready (#227). Without it a
+	// proxy that can never start — e.g. an RWO backup PVC still attached to
+	// another node — kept the restore Pending forever with no diagnosis.
+	AnnotationSeedProxyWaitStarted = "neo4j.com/seed-proxy-wait-started"
+
+	// seedProxyWaitTimeout is the default budget for the seed proxy to come
+	// up: a single busybox pod, Ready in seconds normally — 3 minutes covers
+	// slow image pulls. spec.timeout, when set, overrides.
+	seedProxyWaitTimeout = 3 * time.Minute
 )
 
 // +kubebuilder:rbac:groups=neo4j.neo4j.com,resources=neo4jrestores,verbs=get;list;watch;create;update;patch;delete
@@ -303,6 +314,12 @@ func (r *Neo4jRestoreReconciler) startRestore(ctx context.Context, restore *neo4
 	if restore.Status.ObservedGeneration != 0 && restore.Status.ObservedGeneration != restore.Generation {
 		if err := r.clearCypherRestoreIssued(ctx, restore); err != nil {
 			logger.Error(err, "Failed to clear stale cypher-restore-issued annotation")
+			return ctrl.Result{RequeueAfter: r.RequeueAfter}, err
+		}
+		// A stale seed-proxy wait anchor from the previous attempt would
+		// instantly expire the new attempt's proxy wait (#227).
+		if err := r.clearSeedProxyWaitStarted(ctx, restore); err != nil {
+			logger.Error(err, "Failed to clear stale seed-proxy wait anchor")
 			return ctrl.Result{RequeueAfter: r.RequeueAfter}, err
 		}
 	}
@@ -3063,14 +3080,99 @@ func (r *Neo4jRestoreReconciler) resolveClusterPVCRestoreURI(
 		return "", ctrl.Result{}, fmt.Errorf("ensure PVC seed proxy: %w", err)
 	}
 	if !proxyAvailable {
+		// Bounded wait (#227): a proxy that can never start — RWO backup PVC
+		// attached to another node, unpullable image, crash loop — previously
+		// kept the restore Pending forever with no diagnosis. Anchor a
+		// deadline on the first wait and surface the proxy's live condition
+		// while waiting; fail with it once the budget is spent.
+		waitStart, werr := r.markSeedProxyWaitStarted(ctx, restore)
+		diagnosis := pvcSeedProxyDiagnosis(ctx, r.Client, restore.Namespace, restore.Name)
+		budget := seedProxyWaitTimeout
+		if restore.Spec.Timeout != "" {
+			if d, perr := time.ParseDuration(restore.Spec.Timeout); perr == nil && d > 0 {
+				budget = d
+			}
+		}
+		if werr == nil && time.Since(waitStart) > budget {
+			msg := fmt.Sprintf("backup-seed-proxy Deployment did not become Ready within %s: %s — a common cause is the backup PVC (%s) being ReadWriteOnce and still attached to another pod/node; fix the cause and re-trigger the restore by bumping the spec",
+				budget, diagnosis, storage.PVC.Name)
+			r.updateRestoreStatus(ctx, restore, StatusFailed, msg)
+			r.Recorder.Event(restore, corev1.EventTypeWarning, EventReasonRestoreFailed, msg)
+			return "", ctrl.Result{}, fmt.Errorf("%s", msg)
+		}
 		logger.Info("PVC seed proxy not yet Ready; requeuing",
-			"backupPVC", storage.PVC.Name)
+			"backupPVC", storage.PVC.Name, "diagnosis", diagnosis)
 		r.updateRestoreStatus(ctx, restore, StatusPending,
-			"Waiting for backup-seed-proxy Deployment to become Ready")
+			fmt.Sprintf("Waiting for backup-seed-proxy Deployment to become Ready (%s)", diagnosis))
 		return "", ctrl.Result{RequeueAfter: r.RequeueAfter}, nil
+	}
+	// Proxy is up — drop the wait anchor so any later wait starts fresh.
+	if err := r.clearSeedProxyWaitStarted(ctx, restore); err != nil {
+		logger.V(1).Info("Failed to clear seed-proxy wait anchor (non-fatal)", "error", err.Error())
 	}
 
 	return pvcSeedProxyURL(restore.Name, restore.Namespace, backupsPath, filename), ctrl.Result{}, nil
+}
+
+// markSeedProxyWaitStarted stamps (idempotently, conflict-retried) the
+// seed-proxy wait anchor and returns the anchor time — the FIRST reconcile's
+// stamp, preserved across requeues so the deadline doesn't slide.
+func (r *Neo4jRestoreReconciler) markSeedProxyWaitStarted(ctx context.Context, restore *neo4jv1beta1.Neo4jRestore) (time.Time, error) {
+	if raw, ok := restore.Annotations[AnnotationSeedProxyWaitStarted]; ok {
+		if t, perr := time.Parse(time.RFC3339, raw); perr == nil {
+			return t, nil
+		}
+	}
+	stamp := metav1.Now().UTC().Format(time.RFC3339)
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest := &neo4jv1beta1.Neo4jRestore{}
+		if err := r.Get(ctx, client.ObjectKeyFromObject(restore), latest); err != nil {
+			return err
+		}
+		if latest.Annotations == nil {
+			latest.Annotations = map[string]string{}
+		}
+		if raw, ok := latest.Annotations[AnnotationSeedProxyWaitStarted]; ok {
+			stamp = raw // preserve the original anchor
+			return nil
+		}
+		latest.Annotations[AnnotationSeedProxyWaitStarted] = stamp
+		return r.Update(ctx, latest)
+	})
+	if err != nil {
+		return time.Time{}, err
+	}
+	if restore.Annotations == nil {
+		restore.Annotations = map[string]string{}
+	}
+	restore.Annotations[AnnotationSeedProxyWaitStarted] = stamp
+	t, perr := time.Parse(time.RFC3339, stamp)
+	if perr != nil {
+		return time.Time{}, perr
+	}
+	return t, nil
+}
+
+// clearSeedProxyWaitStarted removes the wait anchor (idempotent) — called
+// once the proxy is Ready and on fresh attempts so a stale anchor can't
+// instantly expire a later wait.
+func (r *Neo4jRestoreReconciler) clearSeedProxyWaitStarted(ctx context.Context, restore *neo4jv1beta1.Neo4jRestore) error {
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		latest := &neo4jv1beta1.Neo4jRestore{}
+		if err := r.Get(ctx, client.ObjectKeyFromObject(restore), latest); err != nil {
+			return err
+		}
+		if _, ok := latest.Annotations[AnnotationSeedProxyWaitStarted]; !ok {
+			return nil
+		}
+		delete(latest.Annotations, AnnotationSeedProxyWaitStarted)
+		return r.Update(ctx, latest)
+	})
+	if err != nil {
+		return err
+	}
+	delete(restore.Annotations, AnnotationSeedProxyWaitStarted)
+	return nil
 }
 
 // latestSucceededArtifactFilename returns the captured `.backup` artifact

--- a/internal/controller/neo4jrestore_controller.go
+++ b/internal/controller/neo4jrestore_controller.go
@@ -1150,6 +1150,7 @@ func (r *Neo4jRestoreReconciler) ensureRestoreServiceAccount(ctx context.Context
 			Namespace: namespace,
 		},
 	}
+	var conflicts []string
 	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, sa, func() error {
 		// Apply workload-identity annotations; preserve any other
 		// annotations already present (e.g. set by cloud-controller or
@@ -1157,12 +1158,37 @@ func (r *Neo4jRestoreReconciler) ensureRestoreServiceAccount(ctx context.Context
 		if sa.Annotations == nil {
 			sa.Annotations = map[string]string{}
 		}
+		// The SA is SHARED namespace-wide (same constraint as the backup
+		// side — trust policies bind to the SA name, so per-CR SAs are a
+		// v1.13 design, #227). Make last-writer-wins overwrites visible.
+		conflicts = serviceAccountAnnotationConflicts(sa.Annotations, wiAnnotations)
 		for k, v := range wiAnnotations {
 			sa.Annotations[k] = v
 		}
 		return nil
 	})
+	if err == nil && len(conflicts) > 0 && r.Recorder != nil {
+		r.Recorder.Event(restore, corev1.EventTypeWarning, EventReasonServiceAccountAnnotationConflict,
+			fmt.Sprintf("Overwrote workload-identity annotations on the SHARED ServiceAccount %s/%s: %s. Multiple backup/restore CRs in this namespace declare different identities; the last reconciled CR wins and the others' cloud access breaks. Use ONE identity per namespace (an IAM role/identity with access to all backup locations), or split the CRs across namespaces.",
+				namespace, restoreServiceAccountName, strings.Join(conflicts, "; ")))
+	}
 	return err
+}
+
+// serviceAccountAnnotationConflicts returns a description per annotation key
+// whose existing value on the shared ServiceAccount differs from the value
+// this CR is about to write — i.e. an overwrite that likely belongs to
+// ANOTHER CR's workload identity (#227). New keys and identical values are
+// not conflicts.
+func serviceAccountAnnotationConflicts(existing, desired map[string]string) []string {
+	var conflicts []string
+	for k, v := range desired {
+		if cur, ok := existing[k]; ok && cur != v {
+			conflicts = append(conflicts, fmt.Sprintf("%s: %q -> %q", k, cur, v))
+		}
+	}
+	sort.Strings(conflicts)
+	return conflicts
 }
 
 // resolveBackupRef delegates to the package-shared ResolveBackupRef. Kept as

--- a/internal/controller/neo4jrestore_controller.go
+++ b/internal/controller/neo4jrestore_controller.go
@@ -793,8 +793,11 @@ func (r *Neo4jRestoreReconciler) validateRestore(ctx context.Context, restore *n
 		}
 
 	case "storage", SourceTypeS3, SourceTypeGCS, "azure":
-		if restore.Spec.Source.BackupPath == "" {
-			return fmt.Errorf("backupPath is required when source type is %q", restore.Spec.Source.Type)
+		// The undiscoverable field (#242): users don't know what to put here.
+		// Name the answer in the error — the operator records every run's
+		// directory in the originating Neo4jBackup's status.
+		if strings.TrimSpace(strings.Trim(restore.Spec.Source.BackupPath, "/")) == "" {
+			return fmt.Errorf("source.backupPath is required when source type is %q: set it to the directory holding the .backup artifacts (the operator records it per run in the originating Neo4jBackup's status.history[*].backupsPath — `kubectl get neo4jbackup <name> -o jsonpath='{.status.history[0].backupsPath}'`), or for cluster targets the exact .backup file path. If the Neo4jBackup CR still exists, source.type=backup with backupRef resolves the path automatically", restore.Spec.Source.Type)
 		}
 
 	case "pitr":

--- a/internal/controller/neo4jrestore_controller.go
+++ b/internal/controller/neo4jrestore_controller.go
@@ -135,10 +135,28 @@ const (
 	//      one SHOW DATABASE per reconcile and requeues.
 	AnnotationCypherRestoreIssued = "neo4j.com/cypher-restore-issued"
 
+	// AnnotationCypherRestoreObservedOffline records that a poll reconcile
+	// saw the database NOT fully online after the recreate was issued —
+	// i.e. the asynchronous recreate has visibly taken effect. Guards the
+	// stale-online race (#227): `dbms.recreateDatabase` returns before the
+	// old allocations transition offline, so a poll landing in that window
+	// would see the PRE-recreate database fully online and wrongly declare
+	// the restore Completed before the seed even started.
+	AnnotationCypherRestoreObservedOffline = "neo4j.com/cypher-restore-observed-offline"
+
 	// cypherRestoreOnlineTimeout bounds how long pollClusterRestoreOnline will
 	// wait (across requeues) for an asynchronously-recreated database to
 	// converge to online before marking the restore Failed.
 	cypherRestoreOnlineTimeout = 5 * time.Minute
+
+	// cypherRestoreStaleOnlineGrace is how long after the recreate was issued
+	// an all-online observation is treated as suspect when no poll has yet
+	// seen the database offline. Past this window an all-online answer is
+	// accepted even without an offline observation — covering small stores
+	// whose entire offline→seed→online cycle fits between two polls. Costs
+	// at most one extra requeue on tiny restores; prevents false Completed
+	// on every recreate that polls early.
+	cypherRestoreStaleOnlineGrace = 30 * time.Second
 )
 
 // +kubebuilder:rbac:groups=neo4j.neo4j.com,resources=neo4jrestores,verbs=get;list;watch;create;update;patch;delete
@@ -2741,25 +2759,83 @@ func (r *Neo4jRestoreReconciler) markCypherRestoreIssued(ctx context.Context, re
 	return nil
 }
 
-// clearCypherRestoreIssued removes the one-shot recreate marker so a fresh
-// attempt (spec bump after Completed/Failed) re-issues the restore instead of
-// short-circuiting into the poll phase with stale state (#218). Idempotent.
+// cypherRestoreOnlineAcceptable reports whether an all-online SHOW DATABASE
+// answer can be trusted as the restored database (vs. the pre-recreate
+// allocations the asynchronous recreate hasn't torn down yet, #227). True
+// when a prior poll already observed the database offline, or when the
+// stale-online grace window past the issue timestamp has elapsed. Missing or
+// malformed issue stamps fail open — the deadline logic already tolerates
+// them, and blocking acceptance forever would be worse than the race.
+func cypherRestoreOnlineAcceptable(restore *neo4jv1beta1.Neo4jRestore, now time.Time) bool {
+	if restore.Annotations[AnnotationCypherRestoreObservedOffline] == "true" {
+		return true
+	}
+	raw, ok := restore.Annotations[AnnotationCypherRestoreIssued]
+	if !ok {
+		return true
+	}
+	issuedAt, perr := time.Parse(time.RFC3339, raw)
+	if perr != nil {
+		return true
+	}
+	return now.Sub(issuedAt) >= cypherRestoreStaleOnlineGrace
+}
+
+// markCypherRestoreObservedOffline stamps the observed-offline annotation
+// (idempotent, conflict-retried) once a poll has seen the database not fully
+// online — proof the asynchronous recreate took effect.
+func (r *Neo4jRestoreReconciler) markCypherRestoreObservedOffline(ctx context.Context, restore *neo4jv1beta1.Neo4jRestore) error {
+	if restore.Annotations[AnnotationCypherRestoreObservedOffline] == "true" {
+		return nil
+	}
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest := &neo4jv1beta1.Neo4jRestore{}
+		if err := r.Get(ctx, client.ObjectKeyFromObject(restore), latest); err != nil {
+			return err
+		}
+		if latest.Annotations == nil {
+			latest.Annotations = map[string]string{}
+		}
+		if latest.Annotations[AnnotationCypherRestoreObservedOffline] == "true" {
+			return nil
+		}
+		latest.Annotations[AnnotationCypherRestoreObservedOffline] = "true"
+		return r.Update(ctx, latest)
+	})
+	if err != nil {
+		return err
+	}
+	if restore.Annotations == nil {
+		restore.Annotations = map[string]string{}
+	}
+	restore.Annotations[AnnotationCypherRestoreObservedOffline] = "true"
+	return nil
+}
+
+// clearCypherRestoreIssued removes the one-shot recreate marker (and the
+// observed-offline marker that depends on it) so a fresh attempt (spec bump
+// after Completed/Failed) re-issues the restore instead of short-circuiting
+// into the poll phase with stale state (#218). Idempotent.
 func (r *Neo4jRestoreReconciler) clearCypherRestoreIssued(ctx context.Context, restore *neo4jv1beta1.Neo4jRestore) error {
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		latest := &neo4jv1beta1.Neo4jRestore{}
 		if err := r.Get(ctx, client.ObjectKeyFromObject(restore), latest); err != nil {
 			return err
 		}
-		if _, ok := latest.Annotations[AnnotationCypherRestoreIssued]; !ok {
+		_, hasIssued := latest.Annotations[AnnotationCypherRestoreIssued]
+		_, hasOffline := latest.Annotations[AnnotationCypherRestoreObservedOffline]
+		if !hasIssued && !hasOffline {
 			return nil
 		}
 		delete(latest.Annotations, AnnotationCypherRestoreIssued)
+		delete(latest.Annotations, AnnotationCypherRestoreObservedOffline)
 		return r.Update(ctx, latest)
 	})
 	if err != nil {
 		return err
 	}
 	delete(restore.Annotations, AnnotationCypherRestoreIssued)
+	delete(restore.Annotations, AnnotationCypherRestoreObservedOffline)
 	return nil
 }
 
@@ -2848,6 +2924,16 @@ func (r *Neo4jRestoreReconciler) pollClusterRestoreOnline(ctx context.Context, r
 
 	online, total, diag, stateErr := neo4jClient.DatabaseOnlineState(ctx, restore.Spec.DatabaseName)
 	if stateErr == nil && total > 0 && online == total {
+		// Stale-online guard (#227): `dbms.recreateDatabase` is asynchronous —
+		// right after issue, SHOW DATABASE can still report the PRE-recreate
+		// allocations fully online. Accept all-online only once a prior poll
+		// observed the database offline (the recreate visibly took effect) or
+		// the grace window past issue has elapsed.
+		if !cypherRestoreOnlineAcceptable(restore, time.Now()) {
+			logger.V(1).Info("Poll: all-online within the stale-online grace window without an offline observation — likely the pre-recreate allocations; requeueing",
+				"database", restore.Spec.DatabaseName, "grace", cypherRestoreStaleOnlineGrace.String())
+			return ctrl.Result{RequeueAfter: r.RequeueAfter}, nil
+		}
 		completion := metav1.Now()
 		restore.Status.CompletionTime = &completion
 		r.updateRestoreStatus(ctx, restore, StatusCompleted,
@@ -2855,6 +2941,12 @@ func (r *Neo4jRestoreReconciler) pollClusterRestoreOnline(ctx context.Context, r
 		r.Recorder.Event(restore, corev1.EventTypeNormal, EventReasonRestoreCompleted,
 			fmt.Sprintf("Cluster Cypher restore completed for database %q", restore.Spec.DatabaseName))
 		return ctrl.Result{}, nil
+	}
+
+	// Not fully online: the recreate has visibly taken effect — record it so
+	// the next all-online observation is trusted immediately (no grace wait).
+	if merr := r.markCypherRestoreObservedOffline(ctx, restore); merr != nil {
+		logger.V(1).Info("Failed to stamp observed-offline annotation; the grace window still guards acceptance", "error", merr.Error())
 	}
 
 	if expired {

--- a/internal/controller/neo4jrestore_controller.go
+++ b/internal/controller/neo4jrestore_controller.go
@@ -3049,10 +3049,15 @@ func (r *Neo4jRestoreReconciler) pollClusterRestoreOnline(ctx context.Context, r
 		return ctrl.Result{}, nil
 	}
 
-	// Not fully online: the recreate has visibly taken effect — record it so
-	// the next all-online observation is trusted immediately (no grace wait).
-	if merr := r.markCypherRestoreObservedOffline(ctx, restore); merr != nil {
-		logger.V(1).Info("Failed to stamp observed-offline annotation; the grace window still guards acceptance", "error", merr.Error())
+	// Stamp the offline observation ONLY on a positive answer from SHOW
+	// DATABASE saying the database is not fully online (or has no rows —
+	// mid-recreate drop). A query ERROR is not evidence the recreate took
+	// effect — stamping on it would let the next stale all-online answer
+	// bypass the grace guard (Bugbot, PR #265).
+	if stateErr == nil {
+		if merr := r.markCypherRestoreObservedOffline(ctx, restore); merr != nil {
+			logger.V(1).Info("Failed to stamp observed-offline annotation; the grace window still guards acceptance", "error", merr.Error())
+		}
 	}
 
 	if expired {
@@ -3174,7 +3179,7 @@ func (r *Neo4jRestoreReconciler) resolveClusterPVCRestoreURI(
 		// kept the restore Pending forever with no diagnosis. Anchor a
 		// deadline on the first wait and surface the proxy's live condition
 		// while waiting; fail with it once the budget is spent.
-		waitStart, werr := r.markSeedProxyWaitStarted(ctx, restore)
+		waitStart, haveAnchor := r.seedProxyWaitStart(ctx, restore)
 		diagnosis := pvcSeedProxyDiagnosis(ctx, r.Client, restore.Namespace, restore.Name)
 		budget := seedProxyWaitTimeout
 		if restore.Spec.Timeout != "" {
@@ -3182,7 +3187,7 @@ func (r *Neo4jRestoreReconciler) resolveClusterPVCRestoreURI(
 				budget = d
 			}
 		}
-		if werr == nil && time.Since(waitStart) > budget {
+		if haveAnchor && time.Since(waitStart) > budget {
 			msg := fmt.Sprintf("backup-seed-proxy Deployment did not become Ready within %s: %s — a common cause is the backup PVC (%s) being ReadWriteOnce and still attached to another pod/node; fix the cause and re-trigger the restore by bumping the spec",
 				budget, diagnosis, storage.PVC.Name)
 			r.updateRestoreStatus(ctx, restore, StatusFailed, msg)
@@ -3201,6 +3206,25 @@ func (r *Neo4jRestoreReconciler) resolveClusterPVCRestoreURI(
 	}
 
 	return pvcSeedProxyURL(restore.Name, restore.Namespace, backupsPath, filename), ctrl.Result{}, nil
+}
+
+// seedProxyWaitStart resolves the deadline anchor for the seed-proxy wait.
+// Normally the persisted annotation stamp; if persisting it keeps FAILING,
+// fall back to status.StartTime (set when the restore attempt began) so a
+// broken annotation write can't reopen the unbounded wait #227 removed
+// (Bugbot, PR #265). The fallback is conservative — StartTime predates the
+// proxy wait, so it can only expire the wait EARLIER, never extend it.
+// Returns (anchor, false) only when no anchor exists at all.
+func (r *Neo4jRestoreReconciler) seedProxyWaitStart(ctx context.Context, restore *neo4jv1beta1.Neo4jRestore) (time.Time, bool) {
+	if t, err := r.markSeedProxyWaitStarted(ctx, restore); err == nil {
+		return t, true
+	} else {
+		log.FromContext(ctx).V(1).Info("Failed to persist seed-proxy wait anchor; falling back to status.startTime for the deadline", "error", err.Error())
+	}
+	if restore.Status.StartTime != nil {
+		return restore.Status.StartTime.Time, true
+	}
+	return time.Time{}, false
 }
 
 // markSeedProxyWaitStarted stamps (idempotently, conflict-retried) the

--- a/internal/controller/neo4jrestore_controller.go
+++ b/internal/controller/neo4jrestore_controller.go
@@ -1178,6 +1178,60 @@ func (r *Neo4jRestoreReconciler) ensureRestoreServiceAccount(ctx context.Context
 	return err
 }
 
+// warnIfSeedEndpointNotProjected emits a Warning event when the resolved
+// backup storage declares a custom S3 endpoint (MinIO, Ceph RGW, R2) but the
+// target cluster's server pods verifiably lack AWS_ENDPOINT_URL_S3 (#252).
+// The cluster Cypher restore makes the SERVER JVM fetch the seed; the
+// CloudBlock's endpointURL only ever reaches backup/restore JOB pods, so
+// without the env var the AWS SDK targets s3.amazonaws.com and the seed
+// fails ("Object not found" / region errors) — a confusing failure when the
+// backup itself succeeded against the same bucket.
+//
+// Warning, not Failed: the check inspects spec.env and the contents of
+// extraEnvFrom-referenced Secrets/ConfigMaps, and stays SILENT when any
+// referenced source is unreadable — exotic-but-valid setups must not be
+// blocked on an incomplete view. #251's fail-fast still surfaces the real
+// seed failure if the warning goes unheeded.
+func (r *Neo4jRestoreReconciler) warnIfSeedEndpointNotProjected(ctx context.Context, restore *neo4jv1beta1.Neo4jRestore, cluster *neo4jv1beta1.Neo4jEnterpriseCluster, cloud *neo4jv1beta1.CloudBlock) {
+	const endpointEnvVar = "AWS_ENDPOINT_URL_S3"
+	if cloud == nil || cloud.EndpointURL == "" || r.Recorder == nil {
+		return
+	}
+	for _, e := range cluster.Spec.Env {
+		if e.Name == endpointEnvVar {
+			return
+		}
+	}
+	for _, ef := range cluster.Spec.ExtraEnvFrom {
+		prefix := ef.Prefix
+		if ef.SecretRef != nil {
+			s := &corev1.Secret{}
+			if err := r.Get(ctx, types.NamespacedName{Name: ef.SecretRef.Name, Namespace: cluster.Namespace}, s); err != nil {
+				return // can't disprove — stay silent
+			}
+			for k := range s.Data {
+				if prefix+k == endpointEnvVar {
+					return
+				}
+			}
+		}
+		if ef.ConfigMapRef != nil {
+			cm := &corev1.ConfigMap{}
+			if err := r.Get(ctx, types.NamespacedName{Name: ef.ConfigMapRef.Name, Namespace: cluster.Namespace}, cm); err != nil {
+				return
+			}
+			for k := range cm.Data {
+				if prefix+k == endpointEnvVar {
+					return
+				}
+			}
+		}
+	}
+	r.Recorder.Event(restore, corev1.EventTypeWarning, EventReasonSeedEndpointNotProjected,
+		fmt.Sprintf("The backup's storage uses a custom S3 endpoint (%s), but cluster %q's server pods have no %s in their environment. The cluster Cypher restore makes the server JVM fetch the seed itself — without the endpoint, the AWS SDK targets s3.amazonaws.com and the seed fails even though the backup succeeded. Add %s=%s as a key in the credentials Secret projected via the cluster's spec.extraEnvFrom (or as a spec.env entry).",
+			cloud.EndpointURL, cluster.Name, endpointEnvVar, endpointEnvVar, cloud.EndpointURL))
+}
+
 // serviceAccountAnnotationConflicts returns a description per annotation key
 // whose existing value on the shared ServiceAccount differs from the value
 // this CR is about to write — i.e. an overwrite that likely belongs to
@@ -2614,6 +2668,12 @@ func (r *Neo4jRestoreReconciler) startClusterCypherRestore(
 					fmt.Sprintf("Waiting for cluster %q server pods to roll out seed credentials Secret %q", cluster.Name, storage.Cloud.CredentialsSecretRef))
 				return ctrl.Result{RequeueAfter: r.RequeueAfter}, nil
 			}
+		}
+		// Custom S3 endpoint (MinIO & friends): the SERVER JVM fetches the
+		// seed, and endpointURL only reaches Job pods — warn when the
+		// endpoint is verifiably absent from the server pods' env (#252).
+		if storage.Type == "s3" {
+			r.warnIfSeedEndpointNotProjected(ctx, restore, cluster, storage.Cloud)
 		}
 	case "pvc":
 		// Cluster + PVC restore: spawn the in-cluster HTTP proxy in front

--- a/internal/controller/neo4jrestore_resolvedsource_test.go
+++ b/internal/controller/neo4jrestore_resolvedsource_test.go
@@ -365,3 +365,28 @@ func TestMarkCypherRestoreObservedOffline(t *testing.T) {
 	require.NoError(t, r.Get(ctx, client.ObjectKeyFromObject(restore), persisted))
 	assert.Equal(t, "true", persisted.Annotations[AnnotationCypherRestoreObservedOffline])
 }
+
+// #242: source.backupPath was the undiscoverable field — empty (or a bare
+// "/", which resolves to the storage root and fails opaquely downstream)
+// must produce an error that names where the value lives
+// (status.history[*].backupsPath on the originating Neo4jBackup) and the
+// backupRef alternative.
+func TestValidateRestore_StorageBackupPathActionable(t *testing.T) {
+	r := newResolvedSourceReconciler(t)
+	ctx := context.Background()
+
+	for _, bad := range []string{"", "/", "//", "  "} {
+		restore := restoreWithBackupRef("r1", "default", "")
+		restore.Spec.Source.Type = "storage"
+		restore.Spec.Source.BackupRef = ""
+		restore.Spec.Source.BackupPath = bad
+		restore.Spec.Source.Storage = pvcStorage("backup-pvc")
+
+		err := r.validateRestore(ctx, restore)
+		require.Error(t, err, "backupPath %q must be rejected", bad)
+		assert.Contains(t, err.Error(), "status.history[*].backupsPath",
+			"the error must tell the user WHERE to find the path")
+		assert.Contains(t, err.Error(), "backupRef",
+			"the error must mention the backupRef alternative")
+	}
+}

--- a/internal/controller/neo4jrestore_resolvedsource_test.go
+++ b/internal/controller/neo4jrestore_resolvedsource_test.go
@@ -290,3 +290,78 @@ func TestUpdateRestoreStatus_PersistsCallerTimestamps(t *testing.T) {
 	assert.True(t, persisted.Status.StartTime.Equal(&start), "persisted StartTime must not be moved by a requeue")
 	assert.True(t, persisted.Status.CompletionTime.Equal(&completion), "persisted CompletionTime must not be moved by a requeue")
 }
+
+// Pins the #227 stale-online guard: dbms.recreateDatabase is asynchronous, so
+// an all-online SHOW DATABASE right after issue can be the PRE-recreate
+// allocations. Acceptance requires a prior offline observation or the grace
+// window to have elapsed.
+func TestCypherRestoreOnlineAcceptable_StaleOnlineGuard(t *testing.T) {
+	now := time.Now()
+	stamp := func(issuedAgo time.Duration) map[string]string {
+		return map[string]string{
+			AnnotationCypherRestoreIssued: now.Add(-issuedAgo).UTC().Format(time.RFC3339),
+		}
+	}
+	restore := func(ann map[string]string) *neo4jv1beta1.Neo4jRestore {
+		r := restoreWithBackupRef("r1", "default", "nightly")
+		r.Annotations = ann
+		return r
+	}
+
+	// Fresh issue, no offline observation: all-online is suspect — refuse.
+	assert.False(t, cypherRestoreOnlineAcceptable(restore(stamp(time.Second)), now),
+		"all-online 1s after issue without an offline observation must be refused")
+
+	// Offline was observed: trust the next all-online immediately.
+	ann := stamp(time.Second)
+	ann[AnnotationCypherRestoreObservedOffline] = "true"
+	assert.True(t, cypherRestoreOnlineAcceptable(restore(ann), now),
+		"observed-offline marker must unlock acceptance inside the grace window")
+
+	// Grace window elapsed: accept even without an offline observation
+	// (small store seeded entirely between two polls).
+	assert.True(t, cypherRestoreOnlineAcceptable(restore(stamp(cypherRestoreStaleOnlineGrace+time.Second)), now),
+		"all-online past the grace window must be accepted")
+
+	// Missing or malformed issue stamps fail open (deadline logic tolerates
+	// them too; blocking forever would be worse than the race).
+	assert.True(t, cypherRestoreOnlineAcceptable(restore(nil), now))
+	assert.True(t, cypherRestoreOnlineAcceptable(restore(map[string]string{
+		AnnotationCypherRestoreIssued: "not-a-timestamp",
+	}), now))
+}
+
+// clearCypherRestoreIssued must clear BOTH cypher-restore markers — a stale
+// observed-offline annotation surviving into a fresh attempt would defeat the
+// stale-online guard on the next recreate.
+func TestClearCypherRestoreIssued_AlsoClearsObservedOffline(t *testing.T) {
+	restore := restoreWithBackupRef("r1", "default", "nightly")
+	restore.Annotations = map[string]string{
+		AnnotationCypherRestoreIssued:          time.Now().UTC().Format(time.RFC3339),
+		AnnotationCypherRestoreObservedOffline: "true",
+	}
+	r := newResolvedSourceReconciler(t, restore)
+	ctx := context.Background()
+
+	require.NoError(t, r.clearCypherRestoreIssued(ctx, restore))
+
+	persisted := &neo4jv1beta1.Neo4jRestore{}
+	require.NoError(t, r.Get(ctx, client.ObjectKeyFromObject(restore), persisted))
+	assert.NotContains(t, persisted.Annotations, AnnotationCypherRestoreIssued)
+	assert.NotContains(t, persisted.Annotations, AnnotationCypherRestoreObservedOffline)
+	assert.NotContains(t, restore.Annotations, AnnotationCypherRestoreObservedOffline, "in-memory copy must be cleared too")
+}
+
+// markCypherRestoreObservedOffline persists the marker and is idempotent.
+func TestMarkCypherRestoreObservedOffline(t *testing.T) {
+	restore := restoreWithBackupRef("r1", "default", "nightly")
+	r := newResolvedSourceReconciler(t, restore)
+	ctx := context.Background()
+
+	require.NoError(t, r.markCypherRestoreObservedOffline(ctx, restore))
+	require.NoError(t, r.markCypherRestoreObservedOffline(ctx, restore))
+
+	persisted := &neo4jv1beta1.Neo4jRestore{}
+	require.NoError(t, r.Get(ctx, client.ObjectKeyFromObject(restore), persisted))
+	assert.Equal(t, "true", persisted.Annotations[AnnotationCypherRestoreObservedOffline])
+}

--- a/internal/controller/pvc_seed_proxy.go
+++ b/internal/controller/pvc_seed_proxy.go
@@ -13,6 +13,8 @@ package controller
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -61,15 +63,31 @@ func pvcSeedProxyName(ownerName string) string {
 //
 //	http://backup-seed-proxy-products.ns.svc.cluster.local:8080/products-backup/products-g000-T21-04-42.backup
 //	http://backup-seed-proxy-inventory-restore.ns.svc.cluster.local:8080/inventory-backup/inventory-2026-06-08T01-18-06.backup
+//
+// Both backupsPath and filename are percent-escaped per path segment:
+// type=storage restores feed user-supplied spec.source.backupPath through
+// here, and characters like spaces, '%', '?' or '#' would otherwise produce
+// a URL whose path Neo4j's URLConnectionSeedProvider resolves to the wrong
+// file (or whose query/fragment is silently dropped) (#227).
 func pvcSeedProxyURL(ownerName, namespace, backupsPath, filename string) string {
 	return fmt.Sprintf(
 		"http://%s.%s.svc.cluster.local:%d/%s/%s",
 		pvcSeedProxyName(ownerName),
 		namespace,
 		pvcSeedProxyPort,
-		backupsPath,
-		filename,
+		escapeURLPathSegments(backupsPath),
+		url.PathEscape(filename),
 	)
+}
+
+// escapeURLPathSegments percent-escapes each '/'-separated segment of a
+// relative path, preserving the separators.
+func escapeURLPathSegments(p string) string {
+	segments := strings.Split(p, "/")
+	for i, s := range segments {
+		segments[i] = url.PathEscape(s)
+	}
+	return strings.Join(segments, "/")
 }
 
 // ensurePVCSeedProxyResources creates (idempotently) the Deployment + Service
@@ -366,4 +384,51 @@ func buildPVCSeedProxyDeployment(owner client.Object, ownerName, backupPVCName s
 			},
 		},
 	}
+}
+
+// pvcSeedProxyDiagnosis assembles a human-actionable summary of WHY the
+// seed-proxy Deployment isn't Ready (#227): unschedulable pods (e.g. an RWO
+// backup PVC still attached to another node), image-pull failures, crash
+// loops, or the Deployment's own Progressing condition. Best-effort — any
+// lookup failure degrades to a generic message, never an error.
+func pvcSeedProxyDiagnosis(ctx context.Context, c client.Client, namespace, ownerName string) string {
+	var parts []string
+
+	dep := &appsv1.Deployment{}
+	if err := c.Get(ctx, types.NamespacedName{Name: pvcSeedProxyName(ownerName), Namespace: namespace}, dep); err == nil {
+		for _, cond := range dep.Status.Conditions {
+			if cond.Type == appsv1.DeploymentProgressing && cond.Status != corev1.ConditionTrue && cond.Message != "" {
+				parts = append(parts, fmt.Sprintf("Deployment %s: %s", cond.Reason, cond.Message))
+			}
+		}
+	}
+
+	pods := &corev1.PodList{}
+	if err := c.List(ctx, pods, client.InNamespace(namespace), client.MatchingLabels{
+		"app.kubernetes.io/name":     "backup-seed-proxy",
+		"app.kubernetes.io/instance": ownerName,
+	}); err == nil {
+		for i := range pods.Items {
+			pod := &pods.Items[i]
+			for _, cond := range pod.Status.Conditions {
+				if cond.Type == corev1.PodScheduled && cond.Status != corev1.ConditionTrue && cond.Message != "" {
+					parts = append(parts, fmt.Sprintf("Pod %s unschedulable: %s", pod.Name, cond.Message))
+				}
+			}
+			for _, cs := range pod.Status.ContainerStatuses {
+				if w := cs.State.Waiting; w != nil && w.Reason != "" && w.Reason != "ContainerCreating" {
+					msg := w.Reason
+					if w.Message != "" {
+						msg += ": " + w.Message
+					}
+					parts = append(parts, fmt.Sprintf("Pod %s container %s waiting: %s", pod.Name, cs.Name, msg))
+				}
+			}
+		}
+	}
+
+	if len(parts) == 0 {
+		return fmt.Sprintf("no diagnostic conditions on Deployment/Pods yet — inspect with: kubectl describe deployment %s -n %s", pvcSeedProxyName(ownerName), namespace)
+	}
+	return strings.Join(parts, "; ")
 }

--- a/internal/controller/pvc_seed_proxy_url_test.go
+++ b/internal/controller/pvc_seed_proxy_url_test.go
@@ -104,7 +104,7 @@ func TestSeedProxyWaitStarted_AnchorLifecycle(t *testing.T) {
 // status.startTime, and only a restore with no anchor at all skips expiry.
 func TestSeedProxyWaitStart_FallsBackToStartTimeOnPersistFailure(t *testing.T) {
 	restore := restoreWithBackupRef("r1", "default", "nightly")
-	started := metav1.NewTime(time.Now().Add(-10 * time.Minute))
+	started := metav1.NewTime(time.Now().Add(-10 * time.Minute).Truncate(time.Second))
 	restore.Status.StartTime = &started
 
 	scheme := runtime.NewScheme()
@@ -123,12 +123,16 @@ func TestSeedProxyWaitStart_FallsBackToStartTimeOnPersistFailure(t *testing.T) {
 
 	anchor, have := r.seedProxyWaitStart(context.Background(), restore)
 	require.True(t, have, "StartTime fallback must provide an anchor")
-	assert.True(t, anchor.Equal(started.Time), "fallback anchor must be status.startTime")
+	assert.True(t, anchor.Equal(started.Time), "fallback anchor must be the persisted status.startTime")
 
-	// No annotation, no StartTime: no anchor (expiry skipped this reconcile).
-	restore.Status.StartTime = nil
-	_, have = r.seedProxyWaitStart(context.Background(), restore)
-	assert.False(t, have)
+	// The anchor must NOT slide: startRestore resets the IN-MEMORY StartTime
+	// to "now" on every Pending requeue — the fallback reads the PERSISTED
+	// value (Bugbot round 2).
+	slid := metav1.Now()
+	restore.Status.StartTime = &slid
+	anchor, have = r.seedProxyWaitStart(context.Background(), restore)
+	require.True(t, have)
+	assert.True(t, anchor.Equal(started.Time), "fallback anchor must ignore the slid in-memory StartTime")
 
 	// Happy path unaffected: with a working client the stamp is the anchor.
 	rOK := newResolvedSourceReconciler(t, restoreWithBackupRef("r2", "default", "nightly"))

--- a/internal/controller/pvc_seed_proxy_url_test.go
+++ b/internal/controller/pvc_seed_proxy_url_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
+)
+
+// Pins the #227 URL-escaping fix: type=storage restores feed user-supplied
+// spec.source.backupPath into the proxy URL — reserved URL characters must
+// be percent-escaped per path segment, with '/' separators preserved.
+func TestPvcSeedProxyURL_EscapesUserControlledSegments(t *testing.T) {
+	cases := []struct {
+		name        string
+		backupsPath string
+		filename    string
+		want        string
+	}{
+		{
+			name:        "plain path untouched",
+			backupsPath: "inventory-backup",
+			filename:    "inventory-2026-06-08T01-18-06.backup",
+			want:        "http://backup-seed-proxy-r.ns.svc.cluster.local:8080/inventory-backup/inventory-2026-06-08T01-18-06.backup",
+		},
+		{
+			name:        "space, percent and hash escaped; slashes preserved",
+			backupsPath: "my backups/100%",
+			filename:    "db#1.backup",
+			want:        "http://backup-seed-proxy-r.ns.svc.cluster.local:8080/my%20backups/100%25/db%231.backup",
+		},
+		{
+			name:        "question mark cannot start a query string",
+			backupsPath: "dir",
+			filename:    "a?b.backup",
+			want:        "http://backup-seed-proxy-r.ns.svc.cluster.local:8080/dir/a%3Fb.backup",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, pvcSeedProxyURL("r", "ns", tc.backupsPath, tc.filename))
+		})
+	}
+}
+
+// Pins the #227 seed-proxy wait anchor: the first stamp wins (the deadline
+// must not slide on requeues), clearing is idempotent, and a fresh attempt
+// can't inherit a stale anchor.
+func TestSeedProxyWaitStarted_AnchorLifecycle(t *testing.T) {
+	restore := restoreWithBackupRef("r1", "default", "nightly")
+	r := newResolvedSourceReconciler(t, restore)
+	ctx := context.Background()
+
+	first, err := r.markSeedProxyWaitStarted(ctx, restore)
+	require.NoError(t, err)
+	assert.WithinDuration(t, time.Now(), first, time.Minute)
+
+	// Second call preserves the original anchor.
+	again, err := r.markSeedProxyWaitStarted(ctx, restore)
+	require.NoError(t, err)
+	assert.True(t, again.Equal(first), "anchor must not slide on requeue")
+
+	persisted := &neo4jv1beta1.Neo4jRestore{}
+	require.NoError(t, r.Get(ctx, client.ObjectKeyFromObject(restore), persisted))
+	assert.Contains(t, persisted.Annotations, AnnotationSeedProxyWaitStarted)
+
+	require.NoError(t, r.clearSeedProxyWaitStarted(ctx, restore))
+	require.NoError(t, r.clearSeedProxyWaitStarted(ctx, restore)) // idempotent
+
+	require.NoError(t, r.Get(ctx, client.ObjectKeyFromObject(restore), persisted))
+	assert.NotContains(t, persisted.Annotations, AnnotationSeedProxyWaitStarted)
+	assert.NotContains(t, restore.Annotations, AnnotationSeedProxyWaitStarted)
+}

--- a/internal/controller/pvc_seed_proxy_url_test.go
+++ b/internal/controller/pvc_seed_proxy_url_test.go
@@ -18,12 +18,18 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
 )
@@ -91,4 +97,43 @@ func TestSeedProxyWaitStarted_AnchorLifecycle(t *testing.T) {
 	require.NoError(t, r.Get(ctx, client.ObjectKeyFromObject(restore), persisted))
 	assert.NotContains(t, persisted.Annotations, AnnotationSeedProxyWaitStarted)
 	assert.NotContains(t, restore.Annotations, AnnotationSeedProxyWaitStarted)
+}
+
+// Bugbot PR #265 (medium): a persistently failing annotation write must not
+// reopen the unbounded proxy wait — the anchor falls back to
+// status.startTime, and only a restore with no anchor at all skips expiry.
+func TestSeedProxyWaitStart_FallsBackToStartTimeOnPersistFailure(t *testing.T) {
+	restore := restoreWithBackupRef("r1", "default", "nightly")
+	started := metav1.NewTime(time.Now().Add(-10 * time.Minute))
+	restore.Status.StartTime = &started
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, neo4jv1beta1.AddToScheme(scheme))
+	failingClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(restore).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				return errors.New("injected: annotation write always fails")
+			},
+		}).
+		Build()
+	r := &Neo4jRestoreReconciler{Client: failingClient, Scheme: scheme, RequeueAfter: time.Second}
+
+	anchor, have := r.seedProxyWaitStart(context.Background(), restore)
+	require.True(t, have, "StartTime fallback must provide an anchor")
+	assert.True(t, anchor.Equal(started.Time), "fallback anchor must be status.startTime")
+
+	// No annotation, no StartTime: no anchor (expiry skipped this reconcile).
+	restore.Status.StartTime = nil
+	_, have = r.seedProxyWaitStart(context.Background(), restore)
+	assert.False(t, have)
+
+	// Happy path unaffected: with a working client the stamp is the anchor.
+	rOK := newResolvedSourceReconciler(t, restoreWithBackupRef("r2", "default", "nightly"))
+	r2 := restoreWithBackupRef("r2", "default", "nightly")
+	anchor, have = rOK.seedProxyWaitStart(context.Background(), r2)
+	require.True(t, have)
+	assert.WithinDuration(t, time.Now(), anchor, time.Minute)
 }

--- a/internal/controller/serviceaccount_conflict_test.go
+++ b/internal/controller/serviceaccount_conflict_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+
+	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
+)
+
+// Pins the #227 shared-SA conflict detection: new keys and identical values
+// are NOT conflicts; only overwriting a different existing value is.
+func TestServiceAccountAnnotationConflicts(t *testing.T) {
+	existing := map[string]string{
+		"eks.amazonaws.com/role-arn": "arn:aws:iam::1:role/backup-a",
+		"unrelated.io/by-user":       "keep",
+	}
+	desired := map[string]string{
+		"eks.amazonaws.com/role-arn":     "arn:aws:iam::1:role/backup-b", // conflict
+		"unrelated.io/by-user":           "keep",                         // identical — no conflict
+		"iam.gke.io/gcp-service-account": "new@p.iam",                    // new key — no conflict
+	}
+	conflicts := serviceAccountAnnotationConflicts(existing, desired)
+	require.Len(t, conflicts, 1)
+	assert.Contains(t, conflicts[0], "eks.amazonaws.com/role-arn")
+	assert.Contains(t, conflicts[0], "backup-a")
+	assert.Contains(t, conflicts[0], "backup-b")
+
+	assert.Empty(t, serviceAccountAnnotationConflicts(nil, desired))
+	assert.Empty(t, serviceAccountAnnotationConflicts(existing, nil))
+}
+
+// End-to-end on the restore side: a second CR declaring a DIFFERENT identity
+// on the shared SA must win the write (documented last-writer-wins) AND emit
+// the ServiceAccountAnnotationConflict warning so the fight is visible.
+func TestEnsureRestoreServiceAccount_ConflictEmitsWarning(t *testing.T) {
+	existingSA := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      restoreServiceAccountName,
+			Namespace: "default",
+			Annotations: map[string]string{
+				"eks.amazonaws.com/role-arn": "arn:aws:iam::1:role/other-restore",
+			},
+		},
+	}
+	restore := restoreWithBackupRef("r1", "default", "nightly")
+	restore.Spec.Source.Type = "storage"
+	restore.Spec.Source.Storage = &neo4jv1beta1.StorageLocation{
+		Type: "s3",
+		Cloud: &neo4jv1beta1.CloudBlock{
+			Provider: "aws",
+			Identity: &neo4jv1beta1.CloudIdentity{
+				AutoCreate: &neo4jv1beta1.AutoCreateSpec{
+					Annotations: map[string]string{
+						"eks.amazonaws.com/role-arn": "arn:aws:iam::1:role/this-restore",
+					},
+				},
+			},
+		},
+	}
+
+	r := newResolvedSourceReconciler(t, restore, existingSA)
+	require.NoError(t, r.ensureRestoreServiceAccount(context.Background(), restore))
+
+	rec := r.Recorder.(*record.FakeRecorder)
+	select {
+	case ev := <-rec.Events:
+		assert.Contains(t, ev, EventReasonServiceAccountAnnotationConflict)
+		assert.Contains(t, ev, "other-restore")
+		assert.Contains(t, ev, "this-restore")
+		assert.True(t, strings.HasPrefix(ev, corev1.EventTypeWarning), "must be a Warning event: %s", ev)
+	default:
+		t.Fatal("expected a ServiceAccountAnnotationConflict warning event")
+	}
+
+	// Same identity re-applied: no conflict, no event. (The previous ensure
+	// already wrote this-restore's value onto the SA.)
+	require.NoError(t, r.ensureRestoreServiceAccount(context.Background(), restore))
+	select {
+	case ev := <-rec.Events:
+		t.Fatalf("no event expected for an identical re-apply, got: %s", ev)
+	default:
+	}
+}

--- a/internal/controller/serviceaccount_conflict_test.go
+++ b/internal/controller/serviceaccount_conflict_test.go
@@ -84,7 +84,8 @@ func TestEnsureRestoreServiceAccount_ConflictEmitsWarning(t *testing.T) {
 	r := newResolvedSourceReconciler(t, restore, existingSA)
 	require.NoError(t, r.ensureRestoreServiceAccount(context.Background(), restore))
 
-	rec := r.Recorder.(*record.FakeRecorder)
+	rec, ok := r.Recorder.(*record.FakeRecorder)
+	require.True(t, ok, "test reconciler must use a FakeRecorder")
 	select {
 	case ev := <-rec.Events:
 		assert.Contains(t, ev, EventReasonServiceAccountAnnotationConflict)
@@ -118,8 +119,10 @@ func TestWarnIfSeedEndpointNotProjected(t *testing.T) {
 	}
 	drainEvent := func(t *testing.T, r *Neo4jRestoreReconciler) (string, bool) {
 		t.Helper()
+		rec, ok := r.Recorder.(*record.FakeRecorder)
+		require.True(t, ok, "test reconciler must use a FakeRecorder")
 		select {
-		case ev := <-r.Recorder.(*record.FakeRecorder).Events:
+		case ev := <-rec.Events:
 			return ev, true
 		default:
 			return "", false

--- a/internal/controller/serviceaccount_conflict_test.go
+++ b/internal/controller/serviceaccount_conflict_test.go
@@ -104,3 +104,85 @@ func TestEnsureRestoreServiceAccount_ConflictEmitsWarning(t *testing.T) {
 	default:
 	}
 }
+
+// #252: a cluster Cypher restore from a custom-endpoint S3 store (MinIO)
+// warns when AWS_ENDPOINT_URL_S3 is verifiably absent from the server pods'
+// env — and stays silent when the endpoint IS provided via spec.env, via a
+// projected Secret key, or when a referenced source is unreadable.
+func TestWarnIfSeedEndpointNotProjected(t *testing.T) {
+	cloud := &neo4jv1beta1.CloudBlock{EndpointURL: "http://minio.minio.svc:9000"}
+	baseCluster := func() *neo4jv1beta1.Neo4jEnterpriseCluster {
+		return &neo4jv1beta1.Neo4jEnterpriseCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "ec", Namespace: "default"},
+		}
+	}
+	drainEvent := func(t *testing.T, r *Neo4jRestoreReconciler) (string, bool) {
+		t.Helper()
+		select {
+		case ev := <-r.Recorder.(*record.FakeRecorder).Events:
+			return ev, true
+		default:
+			return "", false
+		}
+	}
+
+	t.Run("warns when absent everywhere", func(t *testing.T) {
+		restore := restoreWithBackupRef("r1", "default", "nightly")
+		r := newResolvedSourceReconciler(t, restore)
+		r.warnIfSeedEndpointNotProjected(context.Background(), restore, baseCluster(), cloud)
+		ev, ok := drainEvent(t, r)
+		require.True(t, ok, "expected a SeedEndpointNotProjected warning")
+		assert.Contains(t, ev, EventReasonSeedEndpointNotProjected)
+		assert.Contains(t, ev, "minio.minio.svc:9000")
+	})
+
+	t.Run("silent when in spec.env", func(t *testing.T) {
+		restore := restoreWithBackupRef("r1", "default", "nightly")
+		r := newResolvedSourceReconciler(t, restore)
+		cluster := baseCluster()
+		cluster.Spec.Env = []corev1.EnvVar{{Name: "AWS_ENDPOINT_URL_S3", Value: "http://minio.minio.svc:9000"}}
+		r.warnIfSeedEndpointNotProjected(context.Background(), restore, cluster, cloud)
+		if ev, ok := drainEvent(t, r); ok {
+			t.Fatalf("no event expected, got %s", ev)
+		}
+	})
+
+	t.Run("silent when projected via extraEnvFrom Secret key", func(t *testing.T) {
+		restore := restoreWithBackupRef("r1", "default", "nightly")
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "minio-creds", Namespace: "default"},
+			Data:       map[string][]byte{"AWS_ENDPOINT_URL_S3": []byte("http://minio.minio.svc:9000")},
+		}
+		r := newResolvedSourceReconciler(t, restore, secret)
+		cluster := baseCluster()
+		cluster.Spec.ExtraEnvFrom = []corev1.EnvFromSource{{SecretRef: &corev1.SecretEnvSource{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "minio-creds"},
+		}}}
+		r.warnIfSeedEndpointNotProjected(context.Background(), restore, cluster, cloud)
+		if ev, ok := drainEvent(t, r); ok {
+			t.Fatalf("no event expected, got %s", ev)
+		}
+	})
+
+	t.Run("silent when a referenced Secret is unreadable", func(t *testing.T) {
+		restore := restoreWithBackupRef("r1", "default", "nightly")
+		r := newResolvedSourceReconciler(t, restore) // Secret NOT in client
+		cluster := baseCluster()
+		cluster.Spec.ExtraEnvFrom = []corev1.EnvFromSource{{SecretRef: &corev1.SecretEnvSource{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "missing-secret"},
+		}}}
+		r.warnIfSeedEndpointNotProjected(context.Background(), restore, cluster, cloud)
+		if ev, ok := drainEvent(t, r); ok {
+			t.Fatalf("must stay silent on an incomplete view, got %s", ev)
+		}
+	})
+
+	t.Run("no-op without a custom endpoint", func(t *testing.T) {
+		restore := restoreWithBackupRef("r1", "default", "nightly")
+		r := newResolvedSourceReconciler(t, restore)
+		r.warnIfSeedEndpointNotProjected(context.Background(), restore, baseCluster(), &neo4jv1beta1.CloudBlock{})
+		if ev, ok := drainEvent(t, r); ok {
+			t.Fatalf("no event expected, got %s", ev)
+		}
+	})
+}

--- a/internal/neo4j/client.go
+++ b/internal/neo4j/client.go
@@ -2537,6 +2537,13 @@ func buildConnectionURIForStandalone(standalone *neo4jv1beta1.Neo4jEnterpriseSta
 //
 // See CLAUDE.md regression checklist item on routing scheme; do not revert
 // to `bolt://` without an explicit replacement for leader routing.
+// ConnectionURIForEnterprise exposes the cluster connection URI for
+// diagnostics (e.g. connectivity-failure logging in the cluster controller,
+// #263) without constructing a client.
+func ConnectionURIForEnterprise(cluster *neo4jv1beta1.Neo4jEnterpriseCluster) string {
+	return buildConnectionURIForEnterprise(cluster)
+}
+
 func buildConnectionURIForEnterprise(cluster *neo4jv1beta1.Neo4jEnterpriseCluster) string {
 	scheme := "neo4j"
 	if cluster.Spec.TLS != nil && cluster.Spec.TLS.Mode == "cert-manager" {

--- a/scripts/install-confidence.sh
+++ b/scripts/install-confidence.sh
@@ -11,6 +11,12 @@
 #   5. kubectl-apply (kustomize-built complete manifest) install ->
 #      re-apply upgrade -> ordered uninstall
 #
+# Output contract (#247): every sub-step is pre-announced with a timestamp
+# and, for waits, its timeout — so a watcher can always tell "slow" from
+# "stuck". Failures dump cluster diagnostics (pods, operator logs, events)
+# before exiting, and a verdict table lands in $GITHUB_STEP_SUMMARY when run
+# in Actions.
+#
 # Requires: kind, helm, kubectl, docker. Creates/deletes its own Kind cluster
 # (neo4j-install-confidence). ~10-15 min. Run via `make install-confidence`.
 set -euo pipefail
@@ -22,34 +28,78 @@ IMG=neo4j-operator:install-confidence
 PREV_CHART_VERSION="${PREV_CHART_VERSION:-}" # empty = latest published
 HELM_REPO_URL="https://neo4j-partners.github.io/neo4j-kubernetes-operator/charts"
 PASS=()
-fail() { echo "FAIL: $*" >&2; exit 1; }
-ok()   { PASS+=("$1"); echo "PASS: $1"; }
+START_EPOCH=$(date +%s)
+
+ts() { date '+%H:%M:%S'; }
+elapsed() { echo "$(( $(date +%s) - START_EPOCH ))s"; }
+step() { echo "[$(ts) +$(elapsed)] $*"; }
+
+summary() { # append the verdict table to the Actions step summary, if present
+  [ -n "${GITHUB_STEP_SUMMARY:-}" ] || return 0
+  {
+    echo "## Install confidence — $1"
+    echo ""
+    echo "| # | Check |"
+    echo "|---|-------|"
+    local i=1
+    for p in ${PASS[@]+"${PASS[@]}"}; do echo "| $i | ✅ $p |"; i=$((i+1)); done
+    if [ "$1" != "PASSED" ]; then echo "| $i | ❌ $2 |"; fi
+  } >> "$GITHUB_STEP_SUMMARY"
+}
+
+diagnostics() { # best-effort cluster state dump so a CI failure is diagnosable from the log alone
+  echo ""
+  echo "================ DIAGNOSTICS (failure state dump) ================"
+  echo "--- pods (all namespaces)"
+  kubectl get pods -A -o wide 2>&1 || true
+  echo "--- operator deployment"
+  kubectl -n "$NS" describe deploy 2>&1 | tail -40 || true
+  echo "--- operator logs (last 60 lines)"
+  kubectl -n "$NS" logs deploy/neo4j-operator-controller-manager --tail=60 2>&1 || true
+  echo "--- recent events"
+  kubectl get events -A --sort-by=.lastTimestamp 2>&1 | tail -25 || true
+  echo "--- helm releases"
+  helm list -A 2>&1 || true
+  echo "==================================================================="
+}
+
+fail() {
+  echo "[$(ts) +$(elapsed)] FAIL: $*" >&2
+  diagnostics
+  summary "FAILED" "$*"
+  exit 1
+}
+ok() { PASS+=("$1"); echo "[$(ts) +$(elapsed)] PASS: $1"; }
 
 cleanup() { kind delete cluster --name "$CLUSTER" >/dev/null 2>&1 || true; }
 trap cleanup EXIT
 
-echo "=== building operator image from working tree"
-docker build -t "$IMG" . >/dev/null
+step "=== building operator image from working tree (output in /tmp/ic-build.log; ~1-3 min)"
+docker build -t "$IMG" . > /tmp/ic-build.log 2>&1 \
+  || { tail -30 /tmp/ic-build.log; fail "docker build failed (full log: /tmp/ic-build.log)"; }
+step "image built"
 
-echo "=== creating Kind cluster"
+step "=== creating Kind cluster '$CLUSTER' (timeout 120s)"
 cleanup
 kind create cluster --name "$CLUSTER" --wait 120s >/dev/null
+step "loading image into Kind (~30-60s)"
 kind load docker-image "$IMG" --name "$CLUSTER"
 
-wait_operator() { # $1 = namespace
-  kubectl -n "$1" rollout status deploy -l control-plane=controller-manager --timeout=180s >/dev/null \
-    || kubectl -n "$1" rollout status deploy/neo4j-operator-controller-manager --timeout=180s >/dev/null
+wait_operator() { # $1 = namespace — visible rollout wait, 180s timeout
+  step "waiting for operator rollout in '$1' (timeout 180s)"
+  kubectl -n "$1" rollout status deploy -l control-plane=controller-manager --timeout=180s \
+    || kubectl -n "$1" rollout status deploy/neo4j-operator-controller-manager --timeout=180s
 }
 
 # ---------------------------------------------------------------- 1. helm install (cluster mode)
-echo "=== [1] helm install, operatorMode=cluster"
+step "=== [1] helm install, operatorMode=cluster (helm --wait, timeout 180s)"
 helm install op "$CHART" -n "$NS" --create-namespace \
   --set image.repository="${IMG%%:*}" --set image.tag="${IMG##*:}" \
-  --set image.pullPolicy=Never --wait --timeout 180s >/dev/null
+  --set image.pullPolicy=Never --wait --timeout 180s
 wait_operator "$NS"
 ok "helm install (cluster mode) — operator Ready"
 
-echo "=== [1b] smoke CR reconciles"
+step "=== [1b] smoke CR reconciles"
 kubectl create secret generic neo4j-admin-secret \
   --from-literal=username=neo4j --from-literal=password='InstallConf1!' >/dev/null
 cat <<EOF | kubectl apply -f - >/dev/null
@@ -63,63 +113,73 @@ spec:
 EOF
 # Reconciliation evidence, not full readiness (no Neo4j image pull needed):
 # the controller must create the ConfigMap + StatefulSet.
+step "polling for the smoke StatefulSet (up to 60s)"
 for i in $(seq 1 30); do
-  kubectl get sts smoke >/dev/null 2>&1 && break; sleep 2
+  kubectl get sts smoke >/dev/null 2>&1 && break
+  [ $((i % 5)) -eq 0 ] && step "  still waiting (${i}/30 polls)"
+  sleep 2
 done
 kubectl get sts smoke >/dev/null 2>&1 || fail "operator never reconciled the smoke CR (no StatefulSet)"
 ok "smoke CR reconciled (ConfigMap+StatefulSet created)"
 
 # ---------------------------------------------------------------- 4. uninstall with live CR (documented order)
-echo "=== [4] documented uninstall order with a live CR"
+step "=== [4] documented uninstall order with a live CR (CR delete timeout 120s)"
 kubectl delete neo4jenterprisestandalone smoke --timeout=120s >/dev/null \
   || fail "CR deletion blocked — finalizer not stripped while operator alive"
+step "helm uninstall (--wait)"
 helm uninstall op -n "$NS" --wait >/dev/null
 kubectl get crd neo4jenterprisestandalones.neo4j.neo4j.com >/dev/null \
   || fail "CRDs must survive helm uninstall"
 ok "ordered uninstall: CR -> operator; CRDs retained; nothing wedged"
 
 # ---------------------------------------------------------------- 2. namespaces mode + per-namespace Roles
-echo "=== [2] helm install, operatorMode=namespaces + perNamespaceRoles"
+step "=== [2] helm install, operatorMode=namespaces + perNamespaceRoles (helm --wait, timeout 180s)"
 kubectl create ns watched-a >/dev/null; kubectl create ns watched-b >/dev/null
 helm install op "$CHART" -n "$NS" \
   --set image.repository="${IMG%%:*}" --set image.tag="${IMG##*:}" \
   --set image.pullPolicy=Never \
   --set operatorMode=namespaces \
   --set 'watchNamespaces={watched-a,watched-b}' \
-  --set rbac.perNamespaceRoles=true --wait --timeout 180s >/dev/null
+  --set rbac.perNamespaceRoles=true --wait --timeout 180s
 wait_operator "$NS"
 kubectl get role -n watched-a -o name | grep -q neo4j || fail "per-namespace Role missing in watched-a"
 kubectl get clusterrole | grep -qE "op-neo4j-operator-manager" && fail "manager ClusterRole must NOT exist with perNamespaceRoles"
 ok "namespaces mode + perNamespaceRoles: Roles present, no manager ClusterRole"
+step "helm uninstall (--wait)"
 helm uninstall op -n "$NS" --wait >/dev/null
 
 # ---------------------------------------------------------------- 3. helm upgrade from previous release
-echo "=== [3] helm upgrade from previous released chart (+ CRD refresh)"
+step "=== [3] helm upgrade from previous released chart (+ CRD refresh)"
 helm repo add neo4j-operator-rel "$HELM_REPO_URL" >/dev/null 2>&1 || true
 helm repo update >/dev/null 2>&1
+step "installing previous released chart ${PREV_CHART_VERSION:-(latest)} — pulls the RELEASED operator image from ghcr, can take a few minutes (helm --wait, timeout 300s)"
 if helm install op neo4j-operator-rel/neo4j-operator -n "$NS" \
      ${PREV_CHART_VERSION:+--version "$PREV_CHART_VERSION"} \
-     --wait --timeout 300s >/dev/null 2>&1; then
+     --wait --timeout 300s; then
   # CRD refresh (the documented mandatory step), then chart upgrade.
+  step "applying CRD refresh (server-side)"
   kubectl apply --server-side --force-conflicts -f config/crd/bases/ >/dev/null
+  step "helm upgrade to the working-tree chart (helm --wait, timeout 180s)"
   helm upgrade op "$CHART" -n "$NS" \
     --set image.repository="${IMG%%:*}" --set image.tag="${IMG##*:}" \
-    --set image.pullPolicy=Never --wait --timeout 180s >/dev/null
+    --set image.pullPolicy=Never --wait --timeout 180s
   wait_operator "$NS"
   # NEW-field acceptance probe: status.upgradeStatus.currentPartition exists
   # only post-refresh; a stale stored CRD would prune it.
   kubectl get crd neo4jenterpriseclusters.neo4j.neo4j.com -o json \
     | grep -q currentPartition || fail "CRD refresh did not land (currentPartition missing — stale stored CRD)"
   ok "helm upgrade from previous release with CRD refresh — new CRD fields present"
+  step "helm uninstall (--wait)"
   helm uninstall op -n "$NS" --wait >/dev/null
 else
-  echo "SKIP: previous released chart not reachable (offline?) — upgrade leg skipped"
+  step "SKIP: previous released chart not reachable (offline?) — upgrade leg skipped"
 fi
 
 # ---------------------------------------------------------------- 5. kubectl-apply path
-echo "=== [5] kubectl-apply install / re-apply upgrade / ordered uninstall"
+step "=== [5] kubectl-apply install / re-apply upgrade / ordered uninstall"
 ./bin/kustomize build config/default > /tmp/ic-complete.yaml
 # pin to the local image (mirrors the release overlay's images stanza)
+step "kubectl apply (server-side) + pin local image"
 kubectl apply --server-side --force-conflicts -f /tmp/ic-complete.yaml >/dev/null
 kubectl -n "$NS" set image deploy/neo4j-operator-controller-manager manager="$IMG" >/dev/null
 kubectl -n "$NS" patch deploy neo4j-operator-controller-manager \
@@ -127,9 +187,11 @@ kubectl -n "$NS" patch deploy neo4j-operator-controller-manager \
 wait_operator "$NS"
 ok "kubectl-apply (server-side) install — operator Ready"
 # upgrade = re-apply (idempotent against the same manifest)
+step "kubectl re-apply (idempotent upgrade)"
 kubectl apply --server-side --force-conflicts -f /tmp/ic-complete.yaml >/dev/null
 ok "kubectl re-apply upgrade — no immutable-field conflicts"
 # ordered uninstall: no CRs exist; delete operator resources EXCEPT CRDs+ns first
+step "ordered uninstall (operator first, CRDs last)"
 kubectl delete -f /tmp/ic-complete.yaml --dry-run=client -o name \
   | grep -vE '^customresourcedefinition|^namespace/' \
   | xargs -r kubectl delete --ignore-not-found >/dev/null
@@ -138,5 +200,6 @@ kubectl delete -f /tmp/ic-complete.yaml --ignore-not-found >/dev/null 2>&1 || tr
 ok "kubectl ordered uninstall — operator removed first, CRDs last, nothing wedged"
 
 echo ""
-echo "=== INSTALL CONFIDENCE: ${#PASS[@]} checks passed ==="
+step "=== INSTALL CONFIDENCE: ${#PASS[@]} checks passed (total $(elapsed)) ==="
 printf ' - %s\n' "${PASS[@]}"
+summary "PASSED" ""


### PR DESCRIPTION
## Summary

v1.12.1 readiness: the approved second wave of hardening — #263 instrumentation, four #227 remainder items, #242, #252, and #247. Closes #242, closes #247, closes #252. Progresses #227 (items 2/5/6/7; item 1 and the per-CR SA redesign stay v1.13) and #263 (instrumentation + flake-watch; no repro on this build).

**#263 — connectivity forensics, not a speculative fix.** A live repro attempt on the fixed build produced only one expected mid-roll transient, so this adds what the next occurrence needs: the not-ready log now carries the resolved Bolt target URI + consecutive-failure streak + start time, a `ConnectivityDegraded` Warning event fires once per streak at 10 consecutive failures (~5 min), and recovery logs the outage duration.

**#227 item 2 — stale-online guard.** `dbms.recreateDatabase` is async; a poll landing before the old allocations went offline saw `online == total` and could declare false `Completed`. All-online is now accepted only after a poll observed the database offline (new `cypher-restore-observed-offline` annotation) or 30s past issue. Both markers clear on fresh attempts.

**#227 item 5 — bounded seed-proxy wait + URL escaping.** A proxy that can never start (RWO backup PVC attached elsewhere, unpullable image) kept the restore `Pending` forever with a static message. The wait is now anchored and bounded (3m default, `spec.timeout` honored); the Pending message carries the proxy pod's live condition and the deadline `Failed` carries the diagnosis + re-trigger hint. Separately, user-supplied `source.backupPath` segments are percent-escaped in proxy URLs.

**#227 item 6 — shared-SA identity conflicts made visible.** Two CRs declaring different `identity.autoCreate.annotations` fight last-writer-wins on `neo4j-backup-sa`/`neo4j-restore-sa`. Write behavior is unchanged (IRSA trust policies bind to the SA *name*; per-CR SAs are a v1.13 design) but overwriting a different value now emits a `ServiceAccountAnnotationConflict` Warning naming both values.

**#227 item 7 — chain-dir flock.** The Job-creation concurrency gate can't stop two CronJob children firing into the same reconcile gap. PVC backup Jobs now take an fd-based `flock` on `<chain-root>/.chain.lock` (1h wait, auto-released on exit); `flock` verified present in both 5.26 and CalVer enterprise images.

**#242 — `backupPath` discoverability.** The validation error now names where the value lives (`status.history[*].backupsPath`, with the kubectl one-liner) and the `backupRef` alternative; bare `/` is rejected. Docs lead with the discovery snippet.

**#252 — MinIO endpoint warning.** Cluster Cypher restores make the *server* JVM fetch the seed; `endpointURL` only reaches Job pods. The controller now checks `spec.env` and reads `extraEnvFrom`-referenced Secret/ConfigMap contents, emitting `SeedEndpointNotProjected` with the copy-pasteable fix when the endpoint is verifiably absent — and staying silent when it can't be sure (no false failures).

**#247 — verbose install-confidence gate.** Timestamped pre-announced sub-steps with timeouts, visible helm/rollout output, failure diagnostics dump (pods/operator logs/events), and a `GITHUB_STEP_SUMMARY` verdict table. Check semantics unchanged.

**Docs** updated to the v1.12.1 behavior: fail-fast seed errors and Job-free retries (v1.12.0 behavior kept as version-scoped notes since `/v1.12/` docs serve both patches), plus new entries for the proxy deadline, identity conflicts, chain lock, and gate output contract.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [x] Refactor / chore / CI

## Testing

- [x] `make test-unit` passes locally (new pins: stale-online guard, proxy URL escaping + wait anchor, SA conflicts, endpoint warning matrix, chain flock, connectivity streak, backupPath validation)
- [x] `make lint` — new code clean; remaining findings pre-date the branch (main fails identically)
- [x] Live-verified on a Kind rig running this build: flock backup Job succeeded with the lock wrapper; `backupPath: "/"` → actionable Failed; nonexistent-PVC restore surfaced the scheduler diagnosis in Pending then Failed at the deadline; MinIO restore over an existing DB completed through the recreate path with the observed-offline marker set and **no** spurious endpoint warning
- [ ] Extended Integration Tests run — please add the `run-integration-tests` label (backup/restore controllers changed)

## Checklist

- [x] Conventional Commit title
- [x] `make sync-all` — no API type/marker changes; `check-drift` green in pre-commit
- [x] Updated docs (API reference / user guides)
- [x] Respected the project invariants in `CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch critical backup/restore reconciliation paths (cluster Cypher completion, PVC proxy deadlines, chained backup locking) and shared namespace ServiceAccounts; behavior is heavily unit-tested but extended integration is recommended for backup/restore controllers.
> 
> **Overview**
> **v1.12.1 readiness** bundles operator hardening and documentation for backup/restore and cluster connectivity, without API schema changes.
> 
> **Cluster connectivity (#263):** When Bolt is unreachable, logs now include the target URI, consecutive failure count, and streak start time. After ~10 failed reconciles (~5 min), a one-per-streak **`ConnectivityDegraded`** Warning is emitted; recovery logs outage duration. **`ConnectionURIForEnterprise`** is exposed for diagnostics.
> 
> **Backup (#227):** PVC backup Jobs **`flock`** the chain directory (`.chain.lock`, 1h wait) so concurrent FULL/DIFF CronJob children cannot corrupt shared dirs; cloud targets skip flock.
> 
> **Restore (#227, #242, #252):** Cluster Cypher restore avoids false **`Completed`** via an **observed-offline** annotation and a 30s grace before trusting all-online **`SHOW DATABASE`**. PVC restores get a **bounded seed-proxy wait** (3m default, **`spec.timeout`** override) with live pod/deployment diagnosis and Failed status on expiry; proxy URLs **percent-escape** user **`backupPath`** segments. Shared **`neo4j-backup-sa` / `neo4j-restore-sa`** identity overwrites emit **`ServiceAccountAnnotationConflict`**; custom S3 endpoints missing on server pods emit **`SeedEndpointNotProjected`**. Empty or **`/`** **`backupPath`** validation errors point at **`Neo4jBackup.status.history`** and **`backupRef`**.
> 
> **CI (#247):** **`install-confidence.sh`** adds timestamped steps, announced timeouts, failure diagnostics, and a GitHub Actions verdict table.
> 
> **Docs** align with the above (timeout semantics, identity conflicts, chain lock, troubleshooting for seed failures and proxy Pending).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a6c8a3a28b6785ae4c9188ca6d9fb43c78ff194. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->