### PR TITLE
v1.12.2: get-ahead patch (#270, #269, #268, #260, #250)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,6 @@ update-alm-examples
 # gotestsum CI outputs
 unit-tests.json
 unit-junit.xml
+
+# Local-only Claude Code instructions (per-developer, never committed)
+CLAUDE.local.md

--- a/Makefile
+++ b/Makefile
@@ -941,6 +941,10 @@ demo-fast: demo-setup ## Run fast automated demo (no confirmations)
 	@echo "Starting fast automated demo..."
 	@./scripts/demo.sh --skip-confirmations --speed fast
 
+.PHONY: demo-release
+demo-release: ## Fast demo against the PUBLISHED operator chart (no build); pin with DEMO_VERSION=1.12.1
+	@$(MAKE) demo-fast DEMO_OPERATOR=release$(if $(DEMO_VERSION),:$(DEMO_VERSION),)
+
 .PHONY: demo-only
 demo-only: ## Run fast demo without environment setup (assumes cluster exists)
 	@echo "Running fast demo on existing environment..."

--- a/api/v1beta1/neo4jbackup_types.go
+++ b/api/v1beta1/neo4jbackup_types.go
@@ -97,9 +97,11 @@ type BackupTarget struct {
 	Kind string `json:"kind"`
 
 	// +kubebuilder:validation:Required
-	// Name of the target resource. For Kind=ShardedDatabase, this is the logical
-	// sharded-database name (e.g. "products"); the operator backs up all shards
-	// (products-g000, products-p000, …) in one neo4j-admin invocation via a glob.
+	// Name of the target resource. For Kind=ShardedDatabase, this is the
+	// Neo4jShardedDatabase CR (metadata) name; the operator resolves the logical
+	// sharded-database name from that CR's spec.name and backs up all shards
+	// (e.g. products-g000, products-p000, …) in one neo4j-admin invocation via a
+	// glob. The CR name and spec.name often differ.
 	Name string `json:"name"`
 
 	// ClusterRef is the name of the Neo4jEnterpriseCluster (or Neo4jEnterpriseStandalone)

--- a/bundle/manifests/neo4j.neo4j.com_neo4jbackups.yaml
+++ b/bundle/manifests/neo4j.neo4j.com_neo4jbackups.yaml
@@ -492,9 +492,11 @@ spec:
                     type: string
                   name:
                     description: |-
-                      Name of the target resource. For Kind=ShardedDatabase, this is the logical
-                      sharded-database name (e.g. "products"); the operator backs up all shards
-                      (products-g000, products-p000, …) in one neo4j-admin invocation via a glob.
+                      Name of the target resource. For Kind=ShardedDatabase, this is the
+                      Neo4jShardedDatabase CR (metadata) name; the operator resolves the logical
+                      sharded-database name from that CR's spec.name and backs up all shards
+                      (e.g. products-g000, products-p000, …) in one neo4j-admin invocation via a
+                      glob. The CR name and spec.name often differ.
                     type: string
                   namespace:
                     description: Namespace of the target resource (defaults to backup

--- a/charts/neo4j-operator/crds/neo4j.neo4j.com_neo4jbackups.yaml
+++ b/charts/neo4j-operator/crds/neo4j.neo4j.com_neo4jbackups.yaml
@@ -492,9 +492,11 @@ spec:
                     type: string
                   name:
                     description: |-
-                      Name of the target resource. For Kind=ShardedDatabase, this is the logical
-                      sharded-database name (e.g. "products"); the operator backs up all shards
-                      (products-g000, products-p000, …) in one neo4j-admin invocation via a glob.
+                      Name of the target resource. For Kind=ShardedDatabase, this is the
+                      Neo4jShardedDatabase CR (metadata) name; the operator resolves the logical
+                      sharded-database name from that CR's spec.name and backs up all shards
+                      (e.g. products-g000, products-p000, …) in one neo4j-admin invocation via a
+                      glob. The CR name and spec.name often differ.
                     type: string
                   namespace:
                     description: Namespace of the target resource (defaults to backup

--- a/config/crd/bases/neo4j.neo4j.com_neo4jbackups.yaml
+++ b/config/crd/bases/neo4j.neo4j.com_neo4jbackups.yaml
@@ -492,9 +492,11 @@ spec:
                     type: string
                   name:
                     description: |-
-                      Name of the target resource. For Kind=ShardedDatabase, this is the logical
-                      sharded-database name (e.g. "products"); the operator backs up all shards
-                      (products-g000, products-p000, …) in one neo4j-admin invocation via a glob.
+                      Name of the target resource. For Kind=ShardedDatabase, this is the
+                      Neo4jShardedDatabase CR (metadata) name; the operator resolves the logical
+                      sharded-database name from that CR's spec.name and backs up all shards
+                      (e.g. products-g000, products-p000, …) in one neo4j-admin invocation via a
+                      glob. The CR name and spec.name often differ.
                     type: string
                   namespace:
                     description: Namespace of the target resource (defaults to backup

--- a/examples/users-roles/02-custom-role-with-user.yaml
+++ b/examples/users-roles/02-custom-role-with-user.yaml
@@ -30,8 +30,10 @@ spec:
   clusterRef: prod-cluster
   # Neo4j role names may contain only letters, digits and underscores —
   # hyphens (the Kubernetes naming convention used by metadata.name above)
-  # are NOT valid. Set spec.name to the underscore form explicitly; users
-  # then reference THIS name (not the CR name) in their spec.roles.
+  # are NOT valid, so the Neo4j role name (spec.name) is the underscore form.
+  # Users may reference EITHER this spec.name OR the CR's metadata.name
+  # (analytics-reader) in their spec.roles: the operator resolves a
+  # same-namespace, same-clusterRef Neo4jRole CR name to its spec.name (#260).
   name: analytics_reader
   # Each privilege MUST end with `TO <spec.name>` so the controller can
   # derive the matching REVOKE if the privilege is later removed.
@@ -62,4 +64,7 @@ spec:
   passwordSecretRef:
     name: analytics-reader-creds
   roles:
-    - analytics_reader   # the Neo4j role name (the Neo4jRole's spec.name, NOT its metadata.name)
+    # Reference the Neo4jRole by its CR metadata.name — the operator resolves
+    # it to the role's spec.name (analytics_reader) automatically (#260). The
+    # underscore form (analytics_reader) also works.
+    - analytics-reader

--- a/examples/users-roles/06-rolebinding-sso-user.yaml
+++ b/examples/users-roles/06-rolebinding-sso-user.yaml
@@ -20,6 +20,6 @@ spec:
   clusterRef: prod-cluster
   username: alice   # RoleBinding usernames must match ^[a-zA-Z][a-zA-Z0-9_.\-]*$ (no @)
   roles:
-    - editor
-    - analytics_reader          # the Neo4j role name (a Neo4jRole's spec.name); pending until it exists
+    - editor                    # a built-in Neo4j role
+    - analytics-reader          # a Neo4jRole CR name — resolved to its spec.name (#260); pending until it exists
   # enforceExclusive: true      # uncomment to revoke any role not in .spec.roles

--- a/internal/controller/events.go
+++ b/internal/controller/events.go
@@ -134,6 +134,7 @@ const (
 	EventReasonPasswordRotated     = "PasswordRotated"
 	EventReasonRolesGranted        = "RolesGranted"
 	EventReasonRolesRevoked        = "RolesRevoked"
+	EventReasonRolesResolved       = "RolesResolved"
 	EventReasonRolePending         = "RolePending"
 	EventReasonRoleCreated         = "RoleCreated"
 	EventReasonRoleDeleted         = "RoleDeleted"

--- a/internal/controller/neo4jenterprisestandalone_controller.go
+++ b/internal/controller/neo4jenterprisestandalone_controller.go
@@ -1719,8 +1719,18 @@ func (r *Neo4jEnterpriseStandaloneReconciler) createStatefulSet(ctx context.Cont
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
+					// `app: <name>` is the immutable StatefulSet selector key and
+					// must stay. The app.kubernetes.io/* labels are ADDED to the
+					// template only (never the selector) so standard tooling and the
+					// documented `-l app.kubernetes.io/name=neo4j` selector match
+					// standalone pods the way they already match cluster server pods
+					// (getLabelsForEnterpriseServer). Adding template labels triggers a
+					// one-time rolling restart on upgrade. (#268)
 					Labels: map[string]string{
-						"app": standalone.Name,
+						"app":                          standalone.Name,
+						"app.kubernetes.io/name":       "neo4j",
+						"app.kubernetes.io/instance":   standalone.Name,
+						"app.kubernetes.io/managed-by": "neo4j-operator",
 					},
 					Annotations: annotations,
 				},

--- a/internal/controller/neo4jrestore_controller.go
+++ b/internal/controller/neo4jrestore_controller.go
@@ -824,6 +824,14 @@ func (r *Neo4jRestoreReconciler) validateRestore(ctx context.Context, restore *n
 	if restore.Spec.DatabaseName == "" {
 		return fmt.Errorf("databaseName is required")
 	}
+	// The `system` database holds cluster topology, users, roles, and
+	// privileges — it is owned by Neo4j itself and is never a user-restorable
+	// database. Restoring over it would corrupt the deployment's identity and
+	// membership. neo4j-admin restore of `system` is unsupported here and the
+	// in-place Cypher path can't drop/recreate it; reject up front. (#269)
+	if strings.EqualFold(restore.Spec.DatabaseName, "system") {
+		return fmt.Errorf("databaseName %q is not restorable: the system database is managed by Neo4j and holds cluster topology, users, and roles — restoring it via Neo4jRestore is unsupported", restore.Spec.DatabaseName)
+	}
 	// The database name is interpolated into the restore Job's shell command
 	// and Cypher; restrict it to the Neo4j database-name grammar (no shell or
 	// Cypher metacharacters) so it can't inject either. Defense-in-depth on top

--- a/internal/controller/neo4jrestore_resolvedsource_test.go
+++ b/internal/controller/neo4jrestore_resolvedsource_test.go
@@ -208,6 +208,28 @@ func TestValidateRestore_PinnedSnapshotSurvivesMissingCR(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// #269: the system database holds cluster topology, users, and roles and is
+// owned by Neo4j — restoring over it is unsupported and must be rejected up
+// front (case-insensitively), regardless of source. A pinned snapshot lets
+// validateRestore get past source resolution to the databaseName check.
+func TestValidateRestore_RejectsSystemDatabase(t *testing.T) {
+	for _, name := range []string{"system", "System", "SYSTEM"} {
+		r := restoreWithBackupRef("simple-restore", "default", "deleted-backup")
+		r.Spec.DatabaseName = name
+		r.Status.ResolvedSource = &neo4jv1beta1.ResolvedRestoreSource{
+			BackupRef:  "deleted-backup",
+			Storage:    pvcStorage("backup-storage"),
+			BackupPath: "deleted-backup/",
+		}
+		rec := newResolvedSourceReconciler(t, r)
+
+		err := rec.validateRestore(context.Background(), r)
+		require.Error(t, err, "databaseName %q must be rejected", name)
+		assert.Contains(t, err.Error(), "system database",
+			"the error must explain why system is not restorable")
+	}
+}
+
 func TestValidateRestore_MissingCRWithoutSnapshotPointsAtStorage(t *testing.T) {
 	r := restoreWithBackupRef("simple-restore", "default", "deleted-backup")
 	rec := newResolvedSourceReconciler(t, r) // backup CR absent, no snapshot

--- a/internal/controller/neo4jrolebinding_controller.go
+++ b/internal/controller/neo4jrolebinding_controller.go
@@ -155,7 +155,15 @@ func (r *Neo4jRoleBindingReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 	r.setNamedCondition(ctx, rb, ConditionTypeUserNotFound, metav1.ConditionFalse, "UserPresent", "")
 
+	// Resolve same-namespace Neo4jRole CR names in spec.roles to their
+	// effective Neo4j role name (#260); literal Neo4j names pass through.
 	desiredRoles := normaliseRoles(rb.Spec.Roles)
+	desiredRoles, resolvedRoles := resolveRoleNames(ctx, r.Client, rb.Namespace, rb.Spec.ClusterRef, desiredRoles)
+	desiredRoles = normaliseRoles(desiredRoles) // dedupe any CR-name/spec.name collisions
+	if len(resolvedRoles) > 0 {
+		r.Recorder.Eventf(rb, corev1.EventTypeNormal, EventReasonRolesResolved,
+			"resolved Neo4jRole CR names to Neo4j role names: %v", resolvedRoles)
+	}
 	currentRoles := normaliseRoles(info.Roles)
 
 	addRoles, dropRoles, missing := r.diffRoles(ctx, rb, desiredRoles, currentRoles)
@@ -371,25 +379,10 @@ func (r *Neo4jRoleBindingReconciler) diffRoles(ctx context.Context, rb *neo4jv1b
 	return add, drop, missing
 }
 
+// roleResourceExists delegates to the shared roleNameExists (role_resolution.go)
+// — same index used by #260 CR-name resolution.
 func (r *Neo4jRoleBindingReconciler) roleResourceExists(ctx context.Context, namespace, clusterRef, roleName string) bool {
-	list := &neo4jv1beta1.Neo4jRoleList{}
-	if err := r.List(ctx, list, client.InNamespace(namespace)); err != nil {
-		return false
-	}
-	for i := range list.Items {
-		role := &list.Items[i]
-		if role.Spec.ClusterRef != clusterRef {
-			continue
-		}
-		name := role.Spec.Name
-		if name == "" {
-			name = role.Name
-		}
-		if name == roleName {
-			return true
-		}
-	}
-	return false
+	return roleNameExists(ctx, r.Client, namespace, clusterRef, roleName)
 }
 
 func (r *Neo4jRoleBindingReconciler) requeueAfter() time.Duration {
@@ -483,6 +476,9 @@ func (r *Neo4jRoleBindingReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			if !ok {
 				return nil
 			}
+			// Match a binding's spec.roles against BOTH the role's effective
+			// Neo4j name AND its CR metadata.name, so a binding that referenced
+			// the role by either form re-reconciles when the role lands (#260).
 			roleName := role.Spec.Name
 			if roleName == "" {
 				roleName = role.Name
@@ -498,7 +494,7 @@ func (r *Neo4jRoleBindingReconciler) SetupWithManager(mgr ctrl.Manager) error {
 					continue
 				}
 				for _, rname := range b.Spec.Roles {
-					if rname == roleName {
+					if rname == roleName || rname == role.Name {
 						reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: b.Namespace, Name: b.Name}})
 						break
 					}

--- a/internal/controller/neo4juser_controller.go
+++ b/internal/controller/neo4juser_controller.go
@@ -211,8 +211,16 @@ func (r *Neo4jUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 	}
 
-	// Role binding diff
+	// Role binding diff. Resolve same-namespace Neo4jRole CR names in
+	// spec.roles to their effective Neo4j role name first (#260) — literal
+	// Neo4j names (built-ins, externally-created roles) pass through unchanged.
 	desiredRoles := normaliseRoles(user.Spec.Roles)
+	desiredRoles, resolvedRoles := resolveRoleNames(ctx, r.Client, user.Namespace, user.Spec.ClusterRef, desiredRoles)
+	desiredRoles = normaliseRoles(desiredRoles) // dedupe any CR-name/spec.name collisions
+	if len(resolvedRoles) > 0 {
+		r.Recorder.Eventf(user, corev1.EventTypeNormal, EventReasonRolesResolved,
+			"resolved Neo4jRole CR names to Neo4j role names: %v", resolvedRoles)
+	}
 	currentRoles := normaliseRoles(info.Roles) // Note: may be slightly stale after CREATE; re-read just below.
 	// info is non-nil here: the create branch above re-reads it (and bails if
 	// still nil) and the else branch only runs when it was already non-nil.
@@ -475,26 +483,11 @@ func (r *Neo4jUserReconciler) diffRoles(ctx context.Context, user *neo4jv1beta1.
 
 // roleResourceExists reports whether a Neo4jRole CR with .spec.name (or
 // metadata.name when spec.name is empty) equals roleName, in the same
-// namespace and pointing at the same clusterRef.
+// namespace and pointing at the same clusterRef. Delegates to the shared
+// roleNameExists (see role_resolution.go) — same index used by #260
+// CR-name resolution.
 func (r *Neo4jUserReconciler) roleResourceExists(ctx context.Context, namespace, clusterRef, roleName string) bool {
-	list := &neo4jv1beta1.Neo4jRoleList{}
-	if err := r.List(ctx, list, client.InNamespace(namespace)); err != nil {
-		return false
-	}
-	for i := range list.Items {
-		role := &list.Items[i]
-		if role.Spec.ClusterRef != clusterRef {
-			continue
-		}
-		name := role.Spec.Name
-		if name == "" {
-			name = role.Name
-		}
-		if name == roleName {
-			return true
-		}
-	}
-	return false
+	return roleNameExists(ctx, r.Client, namespace, clusterRef, roleName)
 }
 
 func (r *Neo4jUserReconciler) readPasswordSecret(ctx context.Context, user *neo4jv1beta1.Neo4jUser) (string, error) {
@@ -617,6 +610,9 @@ func (r *Neo4jUserReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			if !ok {
 				return nil
 			}
+			// Match a user's spec.roles against BOTH the role's effective Neo4j
+			// name AND its CR metadata.name, so a user that referenced the role
+			// by either form re-reconciles when the role lands (#260).
 			roleName := role.Spec.Name
 			if roleName == "" {
 				roleName = role.Name
@@ -632,7 +628,7 @@ func (r *Neo4jUserReconciler) SetupWithManager(mgr ctrl.Manager) error {
 					continue
 				}
 				for _, rname := range u.Spec.Roles {
-					if rname == roleName {
+					if rname == roleName || rname == role.Name {
 						reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: u.Namespace, Name: u.Name}})
 						break
 					}

--- a/internal/controller/role_resolution.go
+++ b/internal/controller/role_resolution.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
+	"github.com/neo4j-partners/neo4j-kubernetes-operator/internal/validation"
+)
+
+// Role-name resolution shared by the Neo4jUser and Neo4jRoleBinding
+// controllers (#260). A Neo4jRole CR's metadata.name is Kubernetes-style
+// (hyphens allowed) while its effective Neo4j role name (spec.name, or
+// metadata.name when spec.name is empty) cannot contain hyphens — so for
+// virtually every real custom role the two differ. Users naturally reference
+// the CR (the GitOps object) in spec.roles, which previously left them stuck
+// in RolesPending forever. These helpers let the CR name resolve to the Neo4j
+// role name while keeping plain Neo4j names (built-ins, externally-created
+// roles) working unchanged.
+
+// roleCRIndex lists same-namespace Neo4jRole CRs whose spec.clusterRef matches
+// clusterRef and returns two views used by role-name resolution:
+//
+//	effective:       the set of effective Neo4j role names — spec.name, or
+//	                 metadata.name when spec.name is empty.
+//	metaToEffective: metadata.name -> effective name, only for CRs where the
+//	                 two differ (the GitOps CR-name -> Neo4j-name map).
+//
+// On a List error it returns empty maps, so callers degrade to literal
+// (no-resolution) behaviour rather than failing.
+func roleCRIndex(ctx context.Context, c client.Client, namespace, clusterRef string) (effective map[string]struct{}, metaToEffective map[string]string) {
+	effective = map[string]struct{}{}
+	metaToEffective = map[string]string{}
+	list := &neo4jv1beta1.Neo4jRoleList{}
+	if err := c.List(ctx, list, client.InNamespace(namespace)); err != nil {
+		return effective, metaToEffective
+	}
+	for i := range list.Items {
+		role := &list.Items[i]
+		if role.Spec.ClusterRef != clusterRef {
+			continue
+		}
+		name := role.Spec.Name
+		if name == "" {
+			name = role.Name
+		}
+		effective[name] = struct{}{}
+		if name != role.Name {
+			metaToEffective[role.Name] = name
+		}
+	}
+	return effective, metaToEffective
+}
+
+// roleNameExists reports whether roleName matches a same-namespace Neo4jRole
+// CR's effective Neo4j role name (spec.name, or metadata.name when spec.name
+// is empty) pointing at the same clusterRef. This is the existence pre-flight
+// shared by both controllers' diffRoles.
+func roleNameExists(ctx context.Context, c client.Client, namespace, clusterRef, roleName string) bool {
+	effective, _ := roleCRIndex(ctx, c, namespace, clusterRef)
+	_, ok := effective[roleName]
+	return ok
+}
+
+// resolveRoleNames maps each desired spec.roles entry to the Neo4j role name to
+// grant. Literal-first: an entry that is already a built-in or an effective
+// Neo4jRole name is kept as-is; only an entry that matches NO real role name but
+// DOES match a same-namespace Neo4jRole CR's metadata.name is resolved to that
+// CR's effective spec.name. Unknown entries pass through unchanged so diffRoles
+// can report them as missing. resolved maps any rewritten input -> output for
+// caller diagnostics (empty when nothing was rewritten).
+func resolveRoleNames(ctx context.Context, c client.Client, namespace, clusterRef string, desired []string) (out []string, resolved map[string]string) {
+	resolved = map[string]string{}
+	if len(desired) == 0 {
+		return desired, resolved
+	}
+	effective, metaToEffective := roleCRIndex(ctx, c, namespace, clusterRef)
+	out = make([]string, 0, len(desired))
+	for _, d := range desired {
+		switch {
+		case validation.IsBuiltInRole(d):
+			out = append(out, d)
+		default:
+			if _, isEffective := effective[d]; isEffective {
+				// d is already a real Neo4j role name — keep literal.
+				out = append(out, d)
+			} else if eff, ok := metaToEffective[d]; ok {
+				// d is a CR metadata.name; resolve to its Neo4j role name.
+				out = append(out, eff)
+				resolved[d] = eff
+			} else {
+				out = append(out, d)
+			}
+		}
+	}
+	return out, resolved
+}

--- a/internal/controller/role_resolution_test.go
+++ b/internal/controller/role_resolution_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	neo4jv1beta1 "github.com/neo4j-partners/neo4j-kubernetes-operator/api/v1beta1"
+)
+
+func roleResolutionClient(t *testing.T, objs ...client.Object) client.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, neo4jv1beta1.AddToScheme(scheme))
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+}
+
+func roleCR(metaName, ns, clusterRef, specName string) *neo4jv1beta1.Neo4jRole {
+	return &neo4jv1beta1.Neo4jRole{
+		ObjectMeta: metav1.ObjectMeta{Name: metaName, Namespace: ns},
+		Spec:       neo4jv1beta1.Neo4jRoleSpec{ClusterRef: clusterRef, Name: specName},
+	}
+}
+
+// #260: a hyphenated CR metadata.name resolves to the role's underscore
+// spec.name; literal Neo4j names (built-ins, the spec.name itself, unknowns)
+// pass through unchanged.
+func TestResolveRoleNames_CRNameResolvesToSpecName(t *testing.T) {
+	c := roleResolutionClient(t, roleCR("analytics-reader", "prod", "prod-cluster", "analytics_reader"))
+
+	out, resolved := resolveRoleNames(context.Background(), c, "prod", "prod-cluster",
+		[]string{"analytics-reader", "editor", "externally_made"})
+
+	assert.ElementsMatch(t, []string{"analytics_reader", "editor", "externally_made"}, out)
+	assert.Equal(t, map[string]string{"analytics-reader": "analytics_reader"}, resolved,
+		"only the CR-name entry should be reported as resolved")
+}
+
+// The spec.name itself (the real Neo4j role name) must pass through literally —
+// literal-first means an entry that is already an effective role name is never
+// rewritten, even though a CR with a different metadata.name exists.
+func TestResolveRoleNames_SpecNamePassesThroughLiterally(t *testing.T) {
+	c := roleResolutionClient(t, roleCR("analytics-reader", "prod", "prod-cluster", "analytics_reader"))
+
+	out, resolved := resolveRoleNames(context.Background(), c, "prod", "prod-cluster",
+		[]string{"analytics_reader"})
+
+	assert.Equal(t, []string{"analytics_reader"}, out)
+	assert.Empty(t, resolved)
+}
+
+// A CR with no spec.name uses its metadata.name as the effective name — there
+// is nothing to resolve, so the name passes through and existence holds.
+func TestResolveRoleNames_NoSpecNameIsIdentity(t *testing.T) {
+	c := roleResolutionClient(t, roleCR("plainrole", "prod", "prod-cluster", ""))
+
+	out, resolved := resolveRoleNames(context.Background(), c, "prod", "prod-cluster", []string{"plainrole"})
+	assert.Equal(t, []string{"plainrole"}, out)
+	assert.Empty(t, resolved)
+
+	assert.True(t, roleNameExists(context.Background(), c, "prod", "prod-cluster", "plainrole"))
+}
+
+// Resolution is scoped: a CR in another namespace or pointing at another
+// clusterRef must NOT resolve, and the name passes through (to be reported
+// missing downstream).
+func TestResolveRoleNames_ScopedByNamespaceAndClusterRef(t *testing.T) {
+	c := roleResolutionClient(t,
+		roleCR("analytics-reader", "other-ns", "prod-cluster", "analytics_reader"),
+		roleCR("billing-reader", "prod", "other-cluster", "billing_reader"),
+	)
+
+	out, resolved := resolveRoleNames(context.Background(), c, "prod", "prod-cluster",
+		[]string{"analytics-reader", "billing-reader"})
+
+	assert.ElementsMatch(t, []string{"analytics-reader", "billing-reader"}, out,
+		"out-of-scope CRs must not resolve")
+	assert.Empty(t, resolved)
+}
+
+// roleNameExists matches the effective Neo4j name (spec.name) but NOT the CR
+// metadata.name — existence is about the Neo4j role, while resolution bridges
+// the CR name to it.
+func TestRoleNameExists_MatchesEffectiveNameOnly(t *testing.T) {
+	c := roleResolutionClient(t, roleCR("analytics-reader", "prod", "prod-cluster", "analytics_reader"))
+
+	assert.True(t, roleNameExists(context.Background(), c, "prod", "prod-cluster", "analytics_reader"))
+	assert.False(t, roleNameExists(context.Background(), c, "prod", "prod-cluster", "analytics-reader"),
+		"the CR metadata.name is not itself a Neo4j role name")
+}

--- a/internal/controller/standalone_selectors_test.go
+++ b/internal/controller/standalone_selectors_test.go
@@ -55,6 +55,41 @@ func TestStandalonePodSelector_MatchesStatefulSetPodTemplate(t *testing.T) {
 	}
 }
 
+// #268: standalone pods must carry the standard app.kubernetes.io/* labels so
+// the documented `-l app.kubernetes.io/name=neo4j` selector (which already
+// matches cluster server pods) also matches standalone pods. The labels go on
+// the pod TEMPLATE only — the StatefulSet selector is immutable, so it must
+// stay the original `app: <name>` and never gain these keys.
+func TestStandalonePodTemplate_HasRecommendedLabels(t *testing.T) {
+	standalone := &neo4jv1beta1.Neo4jEnterpriseStandalone{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-standalone", Namespace: "default"},
+		Spec: neo4jv1beta1.Neo4jEnterpriseStandaloneSpec{
+			Image:   neo4jv1beta1.ImageSpec{Repo: "neo4j", Tag: "5.26-enterprise"},
+			Storage: neo4jv1beta1.StorageSpec{ClassName: "standard", Size: "10Gi"},
+		},
+	}
+
+	r := &Neo4jEnterpriseStandaloneReconciler{}
+	sts := r.createStatefulSet(context.Background(), standalone)
+	require.NotNil(t, sts)
+
+	want := map[string]string{
+		"app.kubernetes.io/name":       "neo4j",
+		"app.kubernetes.io/instance":   standalone.Name,
+		"app.kubernetes.io/managed-by": "neo4j-operator",
+	}
+	for k, v := range want {
+		assert.Equal(t, v, sts.Spec.Template.Labels[k], "pod template must carry %q", k)
+	}
+	// The original selector key must remain on the template…
+	assert.Equal(t, standalone.Name, sts.Spec.Template.Labels["app"])
+
+	// …and the immutable selector must stay app-only — adding any
+	// app.kubernetes.io/* key to it would make the STS unupgradable.
+	assert.Equal(t, map[string]string{"app": standalone.Name}, sts.Spec.Selector.MatchLabels,
+		"selector must remain immutable app=<name> only")
+}
+
 // Guards the (now-fixed) cleanupPVCs regression: the standalone PVC cleanup
 // was selecting on "app=<name>", which is a pod label, never a PVC label.
 func TestPVCSelectorByInstance_MatchesStandaloneVolumeClaimTemplate(t *testing.T) {

--- a/scripts/demo-setup.sh
+++ b/scripts/demo-setup.sh
@@ -34,13 +34,51 @@ log_success() {
     echo -e "${GREEN}[SUCCESS]${NC} $1"
 }
 
+# Published Helm repo for release-mode installs (mirrors docs/user_guide/installation.md).
+readonly DEMO_HELM_REPO_URL="https://neo4j-partners.github.io/neo4j-kubernetes-operator/charts"
+readonly DEMO_RELEASE_NS="neo4j-operator-system"
+
+# Parse DEMO_OPERATOR=source|release|release:<version> into OPERATOR_MODE +
+# RELEASE_VERSION. Default is source (build + deploy from the working tree).
+OPERATOR_MODE="source"
+RELEASE_VERSION=""
+parse_operator_mode() {
+    local val="${DEMO_OPERATOR:-source}"
+    case "${val}" in
+        source|"")  OPERATOR_MODE="source" ;;
+        release)    OPERATOR_MODE="release" ;;
+        release:*)  OPERATOR_MODE="release"; RELEASE_VERSION="${val#release:}" ;;
+        *)
+            log_info "Unknown DEMO_OPERATOR='${val}'; falling back to source build"
+            OPERATOR_MODE="source"
+            ;;
+    esac
+}
+
+# Install the published operator chart instead of building from source.
+deploy_released_operator() {
+    log_info "Installing the PUBLISHED operator chart${RELEASE_VERSION:+ (version ${RELEASE_VERSION})} — no build, mirrors 'helm install' from the docs"
+    helm repo add neo4j-operator "${DEMO_HELM_REPO_URL}" >/dev/null 2>&1 || true
+    helm repo update >/dev/null 2>&1
+    helm install neo4j-operator neo4j-operator/neo4j-operator \
+        --namespace "${DEMO_RELEASE_NS}" --create-namespace \
+        ${RELEASE_VERSION:+--version "${RELEASE_VERSION}"} \
+        --wait --timeout 300s
+}
+
 main() {
     log_header "Neo4j Kubernetes Operator Demo Setup"
+
+    parse_operator_mode
 
     log_info "This script will set up a complete demo environment including:"
     log_info "  • Fresh Kind development cluster (neo4j-operator-dev)"
     log_info "  • cert-manager with self-signed ClusterIssuer"
-    log_info "  • Neo4j Kubernetes Operator"
+    if [[ "${OPERATOR_MODE}" == "release" ]]; then
+        log_info "  • Neo4j Kubernetes Operator — PUBLISHED chart${RELEASE_VERSION:+ ${RELEASE_VERSION}} (no build)"
+    else
+        log_info "  • Neo4j Kubernetes Operator — built + deployed from the working tree"
+    fi
     log_info "  • All prerequisites for the demo"
     echo
 
@@ -84,10 +122,14 @@ main() {
     log_section "Creating Development Cluster"
     make dev-cluster
 
-    # Step 3: Deploy operator using flexible setup
+    # Step 3: Deploy operator — published chart (release) or build-from-source.
     log_section "Deploying Neo4j Operator"
-    log_info "Using flexible operator setup (auto-detects available clusters)..."
-    make operator-setup
+    if [[ "${OPERATOR_MODE}" == "release" ]]; then
+        deploy_released_operator
+    else
+        log_info "Using flexible operator setup (auto-detects available clusters)..."
+        make operator-setup
+    fi
 
     # Step 4: Verify setup
     log_section "Verifying Setup"
@@ -98,12 +140,16 @@ main() {
     log_info "Checking cert-manager..."
     kubectl get clusterissuer ca-cluster-issuer
 
-    # Detect which namespace the operator was deployed to
+    # Detect which namespace the operator was deployed to. The source build
+    # deploys neo4j-operator-controller-manager; the published Helm chart names
+    # its Deployment neo4j-operator (release name) in neo4j-operator-system.
     local operator_namespace=""
     if kubectl get deployment neo4j-operator-controller-manager -n neo4j-operator-dev >/dev/null 2>&1; then
         operator_namespace="neo4j-operator-dev"
     elif kubectl get deployment neo4j-operator-controller-manager -n neo4j-operator-system >/dev/null 2>&1; then
         operator_namespace="neo4j-operator-system"
+    elif kubectl get deployment neo4j-operator -n "${DEMO_RELEASE_NS}" >/dev/null 2>&1; then
+        operator_namespace="${DEMO_RELEASE_NS}"
     fi
 
     if [[ -n "${operator_namespace}" ]]; then
@@ -121,7 +167,11 @@ main() {
     log_info "Environment details:"
     log_info "  • Cluster: neo4j-operator-dev (Kind)"
     log_info "  • Context: kind-neo4j-operator-dev"
-    log_info "  • Operator: Deployed in ${operator_namespace:-unknown} namespace"
+    if [[ "${OPERATOR_MODE}" == "release" ]]; then
+        log_info "  • Operator: PUBLISHED chart${RELEASE_VERSION:+ ${RELEASE_VERSION}} in ${operator_namespace:-unknown} namespace"
+    else
+        log_info "  • Operator: built from source, deployed in ${operator_namespace:-unknown} namespace"
+    fi
     log_info "  • cert-manager: ClusterIssuer 'ca-cluster-issuer' ready"
     echo
     log_info "Ready to run the demo:"


### PR DESCRIPTION
## Summary

The v1.12.2 "get ahead / prepare for v1.13" patch — additive, backward-compatible fixes surfaced by the v1.12.0/v1.12.1 fresh-eyes journeys and issue hygiene. No API or behavior breaks; all five items are PATCH-grade.

## Items

- **#270 — `docs(backup)`**: correct the `BackupTarget.Name` doc-comment for `Kind=ShardedDatabase`. It claimed `target.name` is the *logical* sharded-database name; the reconciler (`shardedLogicalNameForBackup`) actually treats it as the **Neo4jShardedDatabase CR (metadata) name** and resolves the logical name from that CR's `spec.name`. Comment now matches the code; CRD description regenerated across `config/crd`, `bundle`, and the Helm chart.

- **#269 — `feat(restore)`**: reject `databaseName=system` in `validateRestore` (case-insensitive), between the empty check and the grammar check. `system` holds cluster topology/users/roles and is unrestorable via `Neo4jRestore`; previously it passed `IsValidDatabaseName` and entered an unsupported path. Unit-covered.

- **#268 — `feat(standalone)`**: add `app.kubernetes.io/{name,instance,managed-by}` to the standalone pod **template** so the documented `-l app.kubernetes.io/name=neo4j` selector matches standalone pods the way it already matches cluster server pods. Labels go on the template only — the StatefulSet selector is immutable and stays `app: <name>`. One-time rolling restart on upgrade (handled by the template-hash apply path). Unit-covered.

- **#260 — `feat(users,rolebinding)`**: transparently resolve same-namespace `Neo4jRole` **CR names** in `spec.roles` to their effective Neo4j role name. Literal-first: built-ins and real Neo4j names pass through unchanged; only a name that matches no real role but matches a same-namespace, same-`clusterRef` CR's `metadata.name` is resolved to its `spec.name`. Shared `role_resolution.go` (consolidates both controllers' duplicated `roleResourceExists`); `RolesResolved` event; `Neo4jRole` watch widened to enqueue dependents referencing by `metadata.name`; examples 02/06 updated to the natural CR-name reference (reverts the #258 workaround). Unit-covered.

- **#250 — `feat(demo)`**: `make demo-release` installs the **published** operator chart instead of building from the working tree — a release-acceptance artifact runnable from a shallow clone with no Go toolchain. Defaults to the latest published chart; `DEMO_VERSION=1.12.0` pins an older release. `demo-setup.sh` parses `DEMO_OPERATOR=source|release|release:<version>` and helm-installs into `neo4j-operator-system` mirroring the install docs.

## Verification

- `make test-unit` — all pass (new tests for #269, #268, #260)
- `make check-drift` — clean (CRD/bundle/chart regenerated for #270)
- `bash -n` on demo scripts; `make demo-release` dry-run verified (default → no `--version`, `DEMO_VERSION=X` → `--version X`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 5e731be8fcd120cbbdf0dc24693a205aab435a5c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


Closes #270
Closes #269
Closes #268
Closes #260
Closes #250
