### PR TITLE
docs: fix sharded backup target.name + add Release Verification matrix

### DIFF
--- a/.claude/skills/verify-journey/SKILL.md
+++ b/.claude/skills/verify-journey/SKILL.md
@@ -1,96 +1,88 @@
 ---
 name: verify-journey
-description: Fresh-eyes verification — build the operator from current main, install it per the published docs on a clean Kind cluster, and walk the real user scenarios end to end.
+description: Fresh-eyes pre-release verification — build the operator from current main, install it on a clean Kind cluster, and walk the documented standalone → cluster → sharding phase plan end to end, following docs/developer_guide/release_verification.md.
 ---
 
 # Verify the user journey (fresh eyes)
 
-Pretend you are a new user who only has the published docs. Build from the
-current tree, follow the docs **verbatim**, and report every place reality
-diverges from the docs. This pass has historically caught a dead image tag, a
-`kind: Cluster` restore gap, and a tutorial ordering bug — bugs that unit/
-integration tests did not surface because they don't read the docs.
+Pretend you are a new user who only has the published docs. Build from current
+`main`, follow the docs **verbatim**, and report every place reality diverges
+from the docs. Automated tests validate the code against itself; this validates
+the *published instructions* against a clean machine — the only check that
+catches docs that lie. Past passes caught a dead image tag, a `kind: Cluster`
+restore gap, a tutorial ordering bug, and a sharded CR-name/logical-name backup
+mismatch.
 
-## Ground rules
+## What to test — follow the canonical matrix
 
-- **KIND ONLY.** Never minikube/k3s. **Enterprise images only**
-  (`neo4j:*-enterprise`), never community.
-- **Follow the docs literally.** If a step is wrong or out of order, that IS the
-  finding — do not silently "fix" it in your head. Note the exact doc location
-  and what actually had to happen.
-- Treat `docs/user_guide/` as read-only reference here (you verify against it;
-  you do not edit it).
+**The phase plan, the capability routing (which scenario runs on standalone vs.
+cluster vs. sharding), the sizes, and the per-scenario in-DB checks live in
+[`docs/developer_guide/release_verification.md`](../../../docs/developer_guide/release_verification.md).**
+Read it and follow it verbatim — it is the single source of truth and is kept
+current as the product evolves. This SKILL holds only the *mechanics* below.
 
-## Procedure
+Non-negotiables from that doc (repeated here because they bite hardest):
 
-1. **Wipe the slate.**
-   ```bash
-   kind delete clusters --all
-   ```
+- **KIND only. Enterprise images only** (`neo4j:*-enterprise`).
+- **One Enterprise deployment in the cluster at a time** — phases run
+  sequentially with **full teardown between them**. Concurrent standalone +
+  cluster + sharding JVMs wedge Bolt on a laptop VM (HTTP probe says `Ready`,
+  ports 7687/6362 time out).
+- **Follow the published docs literally** for Phases 1–2; a wrong/out-of-order
+  step *is* a finding — record the exact doc location, don't silently fix it.
+- Treat `docs/user_guide/` as read-only here.
 
-2. **Build the operator image from the current `main`.**
+## Build & install (once, before Phase 1)
+
+1. **Wipe the slate.** `kind delete clusters --all`
+
+2. **Bring up a Kind cluster + operator built from current `main`.** The
+   reliable path is the project's own bootstrap, which also installs
+   cert-manager + the `ca-cluster-issuer` the TLS scenarios need:
+
    ```bash
    git switch main && git pull --ff-only
-   docker build -t neo4j-operator:journey .
+   make dev-up        # creates the neo4j-operator-dev Kind cluster, installs
+                      # cert-manager + CRDs, builds & deploys the main operator
    ```
 
-3. **Create a Kind cluster and load the image — RETRY the load.** Kind/
-   containerd restarts inside the node right after the cluster reports Ready,
-   so the first `kind load` often fails with
-   `containerd.sock: connection refused` (or `content digest not found`). Retry
-   up to 3x with a settle sleep — the same pattern `scripts/install-confidence.sh`
-   uses:
-   ```bash
-   kind create cluster --name neo4j-journey --wait 120s
-   for attempt in 1 2 3; do
-     kind load docker-image neo4j-operator:journey --name neo4j-journey && break
-     [ "$attempt" = 3 ] && { echo "kind load failed after 3 attempts"; exit 1; }
-     echo "load attempt $attempt failed (containerd settling); retrying in 10s"; sleep 10
-   done
-   ```
+   We test `main`, so the operator is built from the working tree (the published
+   Helm chart is the *previous* release). If you instead follow
+   `installation.md` Helm steps verbatim, point them at the locally built image
+   — a dead/typo'd tag in those docs is still a real finding.
 
-4. **Install the operator following `docs/user_guide/installation.md` verbatim.**
-   Use the Helm path the docs lead with. Wait for the operator Deployment to be
-   Ready before proceeding. If the docs reference an image tag, use exactly
-   what they say (a dead/typo'd tag here is a real finding).
+   !!! note "Kind image-load race (manual `kind load` path)"
+       If you load an image manually rather than via `make dev-up`, containerd
+       restarts inside the node right after the cluster reports Ready, so the
+       first `kind load` often fails (`containerd.sock: connection refused` /
+       `content digest not found`). Retry up to 3× with a settle sleep — the
+       pattern `scripts/install-confidence.sh` uses.
 
-5. **Walk the common scenarios, each to `Ready`, following the published docs
-   in order.** Deploy and confirm each reconciles to Ready, then verify
-   *inside the database* (not just the CR status):
-   - **Standalone** (`Neo4jEnterpriseStandalone`) → Ready.
-   - **Cluster** (`Neo4jEnterpriseCluster`, ≥2 servers) → Ready; pods are
-     `{cluster}-server-0..N-1`.
-   - **Database** (`Neo4jDatabase`) → Ready; confirm via
-     `cypher-shell ... 'SHOW DATABASES'`.
-   - **Users / roles** (`Neo4jUser` / `Neo4jRole` / `Neo4jRoleBinding`) →
-     confirm via `SHOW USERS` / `SHOW ROLES`.
-   - **Plugin** (`Neo4jPlugin`, e.g. APOC) → confirm via
-     `RETURN apoc.version()`.
-   - **Backup → restore** following the published backup/restore tutorial
-     steps exactly. This is where ordering/gap bugs hide — note the exact step
-     where anything had to deviate.
+3. Confirm the operator Deployment is `Ready` and the `ca-cluster-issuer` is
+   `True` before starting Phase 1.
 
-   Useful in-DB check pattern (per CLAUDE.md):
-   ```bash
-   kubectl exec <pod> -c neo4j -- cypher-shell -u neo4j -p <password> "SHOW DATABASES"
-   ```
+## Phase 3 prerequisite (sharding)
 
-6. **Report findings as your final message** (not a file): for each scenario,
-   PASS/FAIL, and for every divergence the exact doc location + observed vs.
-   documented behavior. Flag dead image tags, missing/incorrect steps, wrong
-   ordering, and any scenario the docs imply works but doesn't (e.g. a
-   `kind: Cluster` restore path the docs don't actually cover).
+Before Phase 3, patch the operator to relax the sharding memory floor (DEV/TEST
+only) so it fits a laptop, per the matrix doc:
 
-7. **Tear down.**
-   ```bash
-   kind delete cluster --name neo4j-journey
-   ```
+```bash
+kubectl -n <operator-ns> set env deployment/<operator-deploy> NEO4J_SHARDING_RELAX_MEMORY_MIN=true
+kubectl -n <operator-ns> rollout status deployment/<operator-deploy>
+```
+
+## Report & tear down
+
+- **Report findings as your final message** (not a file): per phase/scenario
+  PASS/FAIL, and for every divergence the exact doc location + observed vs.
+  documented behavior.
+- Add a row to the **Verification log** table in the matrix doc for this run.
+- Final teardown: `make dev-down` (or `kind delete cluster --name <name>`).
 
 ## Why this exists / provenance
 
-Distilled from a real fresh-eyes verification pass that caught a dead image
-tag, a `kind: Cluster` restore gap, and a tutorial ordering bug. Automated
-tests validate the code against itself; this skill validates the *published
-instructions* against a clean machine — the only check that catches docs that
-lie. The 3x kind-load retry is not optional: it is a deterministic
-containerd-restart race reproduced on recent Docker + kind.
+Distilled from real fresh-eyes passes. The standalone → cluster(3) →
+sharding(2026.04) phase plan and the one-deployment-at-a-time anti-wedge rule
+were settled after a pass where concurrent standalone + cluster JVMs wedged Bolt
+on the laptop VM. The full, evolving catalog is the matrix doc linked above —
+update *that* (not just this SKILL) when the product grows.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,8 @@ Ginkgo/Gomega, Kind only, **300-second timeouts** for all integration tests.
 
 **Property sharding tests**: CI-runnable smoke test (`property_sharding_ci_smoke_test.go`) runs only when the integration-tests workflow is dispatched with `neo4j-version: 2025.12-enterprise+` — gated by `isPropertyShardingCompatible()`. Uses `NEO4J_SHARDING_RELAX_MEMORY_MIN=true` (set only via `config/overlays/integration-test/`) to bypass the 4Gi/1-core floor on a 2×1.5Gi/500m cluster. Richer sharded tests (F3/F4/F5, Phase 2a/2c, multi-property-shard) stay local-only — they need the production 4Gi/server floor.
 
+**Pre-release verification journey** (manual + LLM, complements the automated suites): `docs/developer_guide/release_verification.md` is the canonical matrix — what we verify, on standalone vs. cluster(3) vs. sharding(2026.04), at what size, and why. Run it from `main` before cutting a release via the `verify-journey` skill (`.claude/skills/verify-journey/`). Two durable rules: **one Enterprise deployment in the cluster at a time** (sequential phases, teardown between — concurrent JVMs wedge Bolt on a laptop) and **restore is walked on BOTH standalone (neo4j-admin path) and cluster (in-place Cypher path)**. When you add/change a capability, add its scenario to that doc in the same PR.
+
 **Troubleshooting**: timeout → image-pull delays. OOMKilled → Enterprise needs ≥ 1.5Gi. DB-create hangs → use `TOPOLOGY` not `OPTIONS`. Cluster won't form → check discovery RBAC.
 
 **MANDATORY AfterEach cleanup** (always remove finalizers before deletion; never rely on suite cleanup):

--- a/docs/developer_guide/release_verification.md
+++ b/docs/developer_guide/release_verification.md
@@ -1,0 +1,150 @@
+# Release Verification
+
+The **pre-release verification journey**: a manual + LLM-driven walk of the real
+user scenarios on a clean cluster, run from `main` before cutting any release.
+It is the canonical source of truth for **what we verify, on which deployment,
+at what size, and why** — keep it current as the product grows.
+
+!!! info "Why this exists alongside the automated suites"
+    Unit and integration tests ([Testing](testing.md)) validate the **code
+    against itself**. This journey validates the **published instructions and
+    end-to-end behaviour against a clean machine** — the only check that catches
+    a doc that lies, a dead image tag, a tutorial ordering bug, or a
+    CR-name/logical-name mismatch. Real passes have caught all of these
+    (most recently the sharded `target.name` doc bug, a `#270` follow-up).
+
+The [`verify-journey` skill](https://github.com/neo4j-partners/neo4j-kubernetes-operator/blob/main/.claude/skills/verify-journey/SKILL.md)
+executes this document. **LLM agents and developers should follow the matrix
+below verbatim**; the skill holds only the mechanics (build, kind-load retry,
+teardown, reporting) and defers to this page for *what* to test.
+
+## Ground rules
+
+- **KIND only. Enterprise images only** (`neo4j:*-enterprise`) — the project
+  [invariants](../knowledge/invariants.md).
+- **Follow the published docs literally** for Phases 1–2. A wrong/out-of-order
+  step *is* a finding — record the exact doc location, don't silently fix it.
+- **One Enterprise deployment in the cluster at a time** (the *anti-wedge*
+  rule). Running standalone + cluster + sharding JVMs concurrently on a laptop
+  VM wedges Bolt (the HTTP probe reports `Ready` but ports 7687/6362 time out).
+  Phases run **sequentially with full teardown between them**; the Kind cluster,
+  operator, and cert-manager stay up across phases.
+- **Restore must be walked on BOTH standalone and cluster** — the mechanism
+  differs (see the routing table) and one never covers the other.
+
+## Capability routing — why each lands where it does
+
+Each capability is verified on the **minimum deployment that actually exercises
+its code path**. Standalone is the cheap workhorse; a capability moves to the
+cluster only when it *needs* clustering.
+
+| Capability | Where | Why |
+|---|---|---|
+| Database lifecycle (create/show/drop) | Standalone | Same `CREATE DATABASE` Cypher everywhere |
+| Database **topology** (`n PRIMARIES m SECONDARIES`) | Cluster | Meaningless on standalone (validator only warns) |
+| Users / Roles / RoleBindings | Standalone | Auth model is deployment-independent |
+| Plugins (APOC, …) | Standalone (ConfigMap path) | Cluster uses the **env-var** path; ConfigMap path is the cheaper of the two to smoke |
+| **Backup → restore** | **Both** | Standalone restores via the `neo4j-admin` path (supports PITR `--restore-until`); cluster restores via the in-place **Cypher** path (PITR is *rejected* on clusters). Separate code paths. |
+| Property sharding | Cluster (CalVer) | Cluster-only by nature; needs a CalVer image and is memory-heavy |
+
+## The phase plan
+
+Run **all three phases every time** (Phase 3 included — sharding regularly
+surfaces issues the lighter phases miss).
+
+### Phase 1 — Standalone (1 pod, ~2Gi)
+
+`Neo4jEnterpriseStandalone` → `Ready`, then on it:
+
+| Scenario | Verify |
+|---|---|
+| Standalone reconciles | `status.phase=Ready`, pod `1/1` |
+| Database lifecycle | `Neo4jDatabase` Ready; `SHOW DATABASES` shows it `online` |
+| Users / Roles / RoleBinding | `Neo4jUser`/`Role`/`RoleBinding` Ready; `SHOW USERS`/`SHOW ROLES`. **Reference at least one role by its hyphenated CR `metadata.name`** (not `spec.name`) and confirm the grant lands (no `RolesPending`) and a `RolesResolved` event fires. |
+| Plugin (APOC) | `Neo4jPlugin` Ready; `RETURN apoc.version()` returns a version (standalone **ConfigMap** path) |
+| Backup → restore | `neo4j-admin` path with `stopCluster: true`: add a marker node → back up → delete the marker → restore → confirm the marker returns |
+| Standalone recommended labels | `kubectl get pods -l app.kubernetes.io/name=neo4j` returns the standalone pod (it carries `app.kubernetes.io/{name,instance,managed-by}`) |
+| `system` is not restorable | a `Neo4jRestore` with `databaseName: system` → `Failed` with an actionable message |
+
+→ **Tear down the standalone fully** before Phase 2.
+
+### Phase 2 — Cluster, 3 servers (~6Gi)
+
+`Neo4jEnterpriseCluster` with `servers: 3` → `Ready`; pods
+`{cluster}-server-0..2`; `SHOW SERVERS` lists 3 `Enabled`/`Available`. Then:
+
+| Scenario | Verify |
+|---|---|
+| Cluster forms | 3 members `Enabled`/`Available`; server-based pod names |
+| Database **with topology** | e.g. `3 PRIMARIES`; `SHOW DATABASE <db>` shows the primaries `online` |
+| Backup → restore (cluster) | in-place **Cypher** path: back up one DB (`kind: Database`), restore into a **new** database, confirm the data round-trips |
+
+3 servers (not 2) keeps split-brain / 3-primary quorum behaviour in the routine
+walk. → **Tear down the cluster fully** before Phase 3.
+
+### Phase 3 — Property sharding (cluster, `2026.04-enterprise`, 3 × 2Gi)
+
+Sharding's documented floor is **4Gi + 1 core per server**. To fit a laptop we
+deliberately relax it — **this phase is operator-mechanics verification, not
+doc-following**. The relax is operator-side and DEV/TEST only:
+
+```bash
+# Downgrades the 4Gi/1-core hard rejects to warnings.
+kubectl -n <operator-ns> set env deployment/<operator-deploy> \
+  NEO4J_SHARDING_RELAX_MEMORY_MIN=true
+kubectl -n <operator-ns> rollout status deployment/<operator-deploy>
+```
+
+Use **`2026.04-enterprise`** (the pinned CI anchor) so local sharding matches
+what the [extended suite](ci_and_workflows.md) validates. On a `servers: 3`
+cluster (~2Gi each):
+
+| Scenario | Verify |
+|---|---|
+| Sharding cluster | `CALL dbms.components()` → `2026.04.x` enterprise; `status.propertyShardingReady=true` |
+| Sharded database | `Neo4jShardedDatabase` whose **`metadata.name` differs from `spec.name`** (e.g. CR `products-sharded` / `spec.name: products`) → Ready; `SHOW DATABASES WHERE name STARTS WITH '<logical>'` lists the graph + property shards `online` |
+| Sharded backup **by CR name** | `Neo4jBackup` `kind=ShardedDatabase` with `target.name` = the **CR metadata name** → `Succeeded`; `status.history[].shardArtifacts` lists every shard. (Using the *logical* name fails preflight — the operator resolves the logical name from the CR's `spec.name`.) |
+
+→ **Tear down**, then delete the Kind cluster.
+
+## Coverage at a glance
+
+| | Standalone | Cluster (3) | Sharding (2026.04) |
+|---|:---:|:---:|:---:|
+| Reconcile → Ready | ✅ | ✅ | ✅ |
+| Database lifecycle | ✅ | | |
+| Database topology | | ✅ | |
+| Users / Roles / Bindings | ✅ | | |
+| Plugins (APOC) | ✅ (ConfigMap) | | |
+| Backup → restore | ✅ (neo4j-admin) | ✅ (Cypher) | ✅ (sharded) |
+| Property sharding | | | ✅ |
+
+## Keeping this current
+
+When you **add or change a capability**, update this page in the same PR:
+
+1. Add a row to the **routing table** (which deployment, and *why* there).
+2. Add the scenario + its in-DB check to the relevant **phase**.
+3. Tick the **coverage** matrix.
+4. If it changes the operator install or sizing, update the phase headers.
+
+When a release fixes a specific bug, add a one-line scenario that would have
+caught it (the v1.12.2 pass added the standalone-label, `system`-reject,
+role-CR-name, and sharded-backup-by-CR-name checks). Record each run below.
+
+## Verification log
+
+| Release | Date | Result | Findings |
+|---|---|---|---|
+| v1.12.2 | 2026-06-14 | ✅ all phases pass | Doc bug: `backup_restore.md` sharded `target.name` said *logical name*, must be *CR name* (fixed, `#270` follow-up). v1.12.2 surfaces (#260/#268/#269/#270) verified live. |
+
+## See also
+
+- [Testing](testing.md) — the automated unit/integration suites and the
+  core/extended label split.
+- [CI/CD & Workflows](ci_and_workflows.md) — what runs per-PR vs. nightly/extended.
+- [Backup & Restore](../user_guide/guides/backup_restore.md),
+  [Property Sharding](../user_guide/property_sharding.md) — the user docs this
+  journey follows.
+- [Project Invariants](../knowledge/invariants.md) — the hard constraints
+  (KIND-only, Enterprise-only, etc.) every phase respects.

--- a/docs/user_guide/guides/backup_restore.md
+++ b/docs/user_guide/guides/backup_restore.md
@@ -171,9 +171,9 @@ Backup Jobs run as the auto-created `neo4j-backup-sa` ServiceAccount in the same
 |---|---|---|---|
 | `Cluster` | the **instance** name — a `Neo4jEnterpriseCluster` **or** `Neo4jEnterpriseStandalone` (auto-detected) | *(unused — leave unset)* | every database on the instance (`neo4j-admin database backup "*"` — one `.backup` artifact per database) |
 | `Database` | the **database** name (e.g. `neo4j`) | the owning instance name | a single database |
-| `ShardedDatabase` | the logical sharded-DB name (e.g. `products`) | the owning cluster | all shards in one `neo4j-admin` run |
+| `ShardedDatabase` | the **`Neo4jShardedDatabase` CR (metadata) name** — the operator resolves the logical DB name from that CR's `spec.name` | the owning cluster | all shards in one `neo4j-admin` run |
 
-There is **no `kind: Standalone`** — a standalone is just an instance. To back one up, use `kind: Cluster` with `name: <standalone-name>` (whole instance), or `kind: Database` with `name: <database>` + `clusterRef: <standalone-name>` (one database). Key gotcha: for `kind: Cluster`, `name` is the **instance** name and `clusterRef` is unused; for `kind: Database`/`ShardedDatabase`, `name` is the **database** and `clusterRef` is the instance that owns it.
+There is **no `kind: Standalone`** — a standalone is just an instance. To back one up, use `kind: Cluster` with `name: <standalone-name>` (whole instance), or `kind: Database` with `name: <database>` + `clusterRef: <standalone-name>` (one database). Key gotcha: for `kind: Cluster`, `name` is the **instance** name and `clusterRef` is unused; for `kind: Database`, `name` is the **database** and `clusterRef` is the instance that owns it; for `kind: ShardedDatabase`, `name` is the **`Neo4jShardedDatabase` CR name** (the operator resolves the logical DB name from its `spec.name` — the two often differ) and `clusterRef` is the owning cluster.
 
 **Restore is single-database** even when the backup was cluster-wide: a `kind: Cluster` backup leaves one artifact per database in the chain directory, and you create one `Neo4jRestore` per database you want back. **How you reference it depends on the target:**
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -177,6 +177,7 @@ nav:
       - CI/CD & Workflows: developer_guide/ci_and_workflows.md
       - Architecture: developer_guide/architecture.md
       - Testing: developer_guide/testing.md
+      - Release Verification: developer_guide/release_verification.md
       - Makefile Reference: developer_guide/makefile_reference.md
       - OpenShift OLM: developer_guide/openshift_olm.md
       - AI-Assisted Contribution:


### PR DESCRIPTION
## Summary

Two docs changes that came out of the pre-release verification pass on `main` (post-v1.12.2):

1. **Fix a confirmed doc bug** (`#270` follow-up) — `backup_restore.md` told users the wrong `target.name` for sharded backups.
2. **Add the canonical Release Verification matrix** + wire it in for LLMs and developers, so the pre-release journey is reliable and repeatable as the product grows.

## 1. Sharded `target.name` doc fix (verified live)

`docs/user_guide/guides/backup_restore.md` (table at the "Backup targets" section + the kind-semantics gotcha line) said for `kind=ShardedDatabase`, `target.name` is "the logical sharded-DB name (e.g. `products`)". The verification pass proved this **fails**:

- `target.name=<logical-name>` → preflight **`Failed`: `Neo4jShardedDatabase "products" not found`**
- `target.name=<CR-metadata-name>` → **`Succeeded`**, all shards captured (operator resolves the logical name from the CR's `spec.name`)

`#270` corrected the API doc-comment and the `property-sharding-with-backup.yaml` example already used the CR name, but this user-guide table was missed. Now aligned.

## 2. Release Verification matrix

New `docs/developer_guide/release_verification.md` — the single source of truth for **what we verify, on which deployment, at what size, and why**:

- The standalone → cluster(3) → sharding(`2026.04`) phase plan, with per-scenario in-DB checks.
- Capability routing table (why each capability lands on standalone vs. cluster vs. sharding).
- The two durable rules: **one Enterprise deployment at a time** (anti-wedge), and **restore walked on both** the `neo4j-admin` and in-place-Cypher paths.
- The `NEO4J_SHARDING_RELAX_MEMORY_MIN` operator patch for fitting sharding on a laptop.
- A coverage-at-a-glance matrix, a "keep it current" rule, and a **verification log** seeded with the v1.12.2 run.

**Wired in so it's actually used:**
- **mkdocs nav**: Contribute → Release Verification (`mkdocs build --strict` passes).
- **CLAUDE.md**: pointer in the Testing section (the LLM constitution/index).
- **`verify-journey` skill**: trimmed to execution mechanics; now defers to the matrix doc as canonical — removes the skill↔plan duplication-drift.

## Verification

- `mkdocs build --strict` — clean (no broken nav/links).
- The sharded `target.name` behavior was confirmed live (both the CR-name success and the logical-name failure) during the v1.12.2 pre-release journey.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and contributor-process changes only; no runtime or API code paths modified.
> 
> **Overview**
> Corrects **`backup_restore.md`** so `Neo4jBackup` with `target.kind: ShardedDatabase` uses the **`Neo4jShardedDatabase` CR `metadata.name`** for `target.name` (logical name comes from that CR’s `spec.name`) — matching operator preflight/lookup behavior and closing the `#270` user-guide gap.
> 
> Adds **`docs/developer_guide/release_verification.md`** as the canonical pre-release matrix: standalone → 3-server cluster → sharding (`2026.04`) phases, capability routing, anti-wedge (one Enterprise deployment at a time), dual restore paths, and a verification log. **`verify-journey`** defers *what* to test to that doc and keeps **`make dev-up`** mechanics; **`CLAUDE.md`** and **mkdocs** Contribute nav point at the new page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b69f17089ea8cdc2992657e2a3605f3d3e19d95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->