### PR TITLE
docs(backup): note options.validate requires CalVer (2025.x+) (#285)

### DIFF
--- a/docs/user_guide/guides/backup_restore.md
+++ b/docs/user_guide/guides/backup_restore.md
@@ -1359,7 +1359,7 @@ kubectl get events --field-selector involvedObject.name=restore-operation
 
 ## Operational Notes
 
-- Enable `validate: true` to run `neo4j-admin backup validate` after each backup, so recoverability issues are surfaced at backup time (on `status.history[].validation`) rather than discovered at restore time.
+- Enable `validate: true` to run `neo4j-admin backup validate` after each backup, so recoverability issues are surfaced at backup time (on `status.history[].validation`) rather than discovered at restore time. **Requires a CalVer (2025.x+) Neo4j image** — the `neo4j-admin backup validate` subcommand does not exist on 5.26, so on a 5.26 target the option has no effect (`status.history[].validation` stays empty) and the operator emits a one-time `BackupValidateUnsupported` warning event. The backup itself still succeeds either way.
 - For cloud destinations, set `tempStorage` (PVC for staging) on large databases — without it `neo4j-admin` buffers in the Pod's filesystem.
 - The operator doesn't manage cloud object expiry — configure bucket lifecycle rules to delete old backups.
 - Restore is non-trivial post-incident; rehearse it against a staging cluster at least once.
@@ -1442,6 +1442,8 @@ options:
   # Validate backup recoverability after creation by running
   # `neo4j-admin backup validate`. Failures are recorded on
   # status.history[].validation but do NOT fail the Job.
+  # Requires a CalVer (2025.x+) image — no effect on 5.26 (subcommand
+  # does not exist); the operator emits a BackupValidateUnsupported warning.
   validate: true
 
   # Operator-managed staging PVC for cloud operations (recommended for large databases)


### PR DESCRIPTION
## Summary

Closes the documentation gap reported in #285. The user-guide **Operational Notes** bullet and the YAML config sample promoted `validate: true` with **no version caveat**, while the API reference (`docs/api_reference/neo4jbackup.md`) already documents that `neo4j-admin backup validate` is **CalVer-only**. A user on a `5.26.0-enterprise` target enabled it and was surprised by the `BackupValidateUnsupported` warning (validation has no effect on 5.26).

This aligns the user guide with the API reference and the runtime behavior.

## Changes (docs-only)

- `docs/user_guide/guides/backup_restore.md`
  - Operational Notes bullet: add the **CalVer (2025.x+) requirement**, that on 5.26 the option has no effect (`status.history[].validation` stays empty) and the operator emits a one-time `BackupValidateUnsupported` warning, and that **the backup itself still succeeds either way**.
  - YAML sample comment: add a brief version note (mirrors the `preferDiffAsParent` CalVer note just above it).

## Why this is the right scope

The runtime behavior is **already correct and deliberate** (verified in `internal/controller/neo4jbackup_controller.go`):
- `validate` is gated on `version.IsCalver`; on 5.26 the validate clause is omitted and a one-time `BackupValidateUnsupported` warning is emitted (the #255 "loud skip" fix). Confirmed this fires for **both cluster and standalone** targets (`standaloneAsCluster` copies `Spec.Image`), so there is no silent-skip gap.
- Skip-with-warning is the intended additive/non-fatal behavior — this PR does **not** change it.

## Notes / out of scope

- The issue title frames this as "Workload Identity fails," but the validate gate is independent of cloud identity — the only surfaced event is the (non-fatal, now-documented) version warning. Whether the backup Job itself failed under Azure WI is a **separate** question pending reporter evidence (status/Job logs); see the issue thread.

Refs #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or schema impact.
> 
> **Overview**
> Closes the user-guide gap for **`options.validate`** (#285): the guide previously recommended `validate: true` without noting that **`neo4j-admin backup validate` exists only on CalVer (2025.x+) images**, which surprised 5.26 users who saw **`BackupValidateUnsupported`** while backups still succeeded.
> 
> **`backup_restore.md`** now states in **Operational Notes** that on **5.26** validation is skipped (`status.history[].validation` stays empty), the operator emits a **one-time** warning event, and **backups are unaffected**. The **Advanced Configuration** YAML comment beside `validate: true` repeats the same caveat, consistent with the existing **`preferDiffAsParent`** CalVer note and the **API reference**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 591f71e2c9ef5c7af7271705f15da630a92a3a87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->