### PR TITLE
test: fix flaky backup ServiceAccount spec (30s requeue penalty)

### DIFF
--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -156,12 +156,25 @@ var _ = BeforeSuite(func() {
 		Expect(err).NotTo(HaveOccurred())
 	}
 
+	// testRequeueAfter: backup/restore reconcilers requeue transient states
+	// (e.g. "target cluster not ready yet") after this delay. Production uses
+	// 30s, but in envtest that turned a single stale-cache read into a 30s
+	// stall: the flaky "Should create the backup ServiceAccount automatically"
+	// spec creates the cluster, patches its status to Ready, then creates the
+	// backup — but if the backup's first reconcile observes the cluster before
+	// the manager cache has caught up to the Ready patch, it returns
+	// Waiting+RequeueAfter and does not create the ServiceAccount until the next
+	// pass 30s later. Under CI -race on 2 cores that pushed SA creation past the
+	// 60s spec timeout. A short test requeue recovers from the transient read in
+	// ~2s instead of 30s; production behaviour is unchanged.
+	const testRequeueAfter = 2 * time.Second
+
 	// Set up Neo4jBackup controller
 	if err := (&controller.Neo4jBackupReconciler{
 		Client:       mgr.GetClient(),
 		Scheme:       mgr.GetScheme(),
 		Recorder:     mgr.GetEventRecorderFor("neo4j-backup-controller"),
-		RequeueAfter: 30 * time.Second,
+		RequeueAfter: testRequeueAfter,
 	}).SetupWithManager(mgr); err != nil {
 		Expect(err).NotTo(HaveOccurred())
 	}
@@ -171,7 +184,7 @@ var _ = BeforeSuite(func() {
 		Client:       mgr.GetClient(),
 		Scheme:       mgr.GetScheme(),
 		Recorder:     mgr.GetEventRecorderFor("neo4j-restore-controller"),
-		RequeueAfter: 30 * time.Second,
+		RequeueAfter: testRequeueAfter,
 	}).SetupWithManager(mgr); err != nil {
 		Expect(err).NotTo(HaveOccurred())
 	}


### PR DESCRIPTION
## Problem

`Neo4jBackup Controller > When creating a PVC backup > Should create the backup ServiceAccount automatically` intermittently times out at 60s in CI (observed on #298 and #299).

## Root cause

The spec patches the target cluster's status to `Ready`, then creates the backup. If the backup's **first** reconcile reads the cluster from the manager cache *before* it has caught up to the Ready patch, the reconcile hits the cluster-ready gate (`neo4jbackup_controller.go:185`), returns `Waiting` + `RequeueAfter`, and does **not** create the ServiceAccount until the next pass. The envtest suite set the backup/restore `RequeueAfter` to the production **30s**, so that single stale-cache read stalled SA creation by 30s — and under CI `-race` on 2 cores the extra queue latency pushed it past the 60s spec timeout.

No blocking I/O and `MaxConcurrentReconciles=1` ruled out worker-blocking; the ready-gate + 30s requeue is the only 30s-scale delay between backup creation and SA creation.

## Fix

Lower the backup/restore reconcilers' `RequeueAfter` to **2s** in the envtest suite (`testRequeueAfter` const). A transient not-ready read now recovers in ~2s instead of 30s. **Test-only — production keeps 30s.**

## Validation

- Backup controller suite: **3/3 green** under `-race` locally (~27s each).
- The shorter requeue also slightly *strengthens* the "does not recreate Job for Completed/Failed backup" specs, which now reconcile several times within their `Consistently` windows.

Independent of the dead-code cleanup (#299) — touches only `suite_test.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)