### PR TITLE
chore: clear golangci-lint debt + run full lint in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,15 +70,13 @@ jobs:
         git --no-pager diff -I'^    createdAt:' >> $GITHUB_STEP_SUMMARY || true
         echo '```' >> $GITHUB_STEP_SUMMARY
 
-  go-lint-unused:
-    # Enforce staticcheck's `unused` analyzer as a real merge gate. Go
-    # golangci-lint is not otherwise run in CI (only helm-lint is), which is how
-    # unreachable code silently accumulated. Scoped to --enable=unused (not the
-    # full .golangci.yml) so it stays green today without pulling in the repo's
-    # pre-existing forcetypeassert/nilerr/staticcheck debt — that can be burned
-    # down separately. Catches unexported dead code (the common case); exported
-    # but-unreachable internal code needs `deadcode`, run ad hoc.
-    name: Go Lint (unused)
+  go-lint:
+    # Full golangci-lint as a merge gate. Go golangci-lint was not otherwise run
+    # in CI (only helm-lint is), which is how unreachable code and other lint debt
+    # silently accumulated. This started scoped to --enable=unused while the repo
+    # carried pre-existing forcetypeassert/nilerr/staticcheck debt; that debt has
+    # now been burned down, so the whole .golangci.yml runs here.
+    name: Go Lint
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -98,8 +96,8 @@ jobs:
       # rebuilds it against the current toolchain.
       run: make golangci-lint
 
-    - name: Run unused linter
-      run: ./bin/golangci-lint run --no-config --disable-all --enable=unused --timeout=5m ./...
+    - name: Run golangci-lint
+      run: ./bin/golangci-lint run --timeout=6m ./...
 
   unit-tests:
     name: Unit Tests

--- a/internal/controller/cache_manager.go
+++ b/internal/controller/cache_manager.go
@@ -62,7 +62,6 @@ type CacheManager struct {
 	// Namespace tracking
 	mutex             sync.RWMutex
 	watchedNamespaces map[string]time.Time
-	filteredResources map[string]bool
 
 	// Memory monitoring
 	memoryStats chan MemoryStats
@@ -79,14 +78,6 @@ type MemoryStats struct {
 	SysMB        float64
 	NumGC        uint32
 	Timestamp    time.Time
-}
-
-// MemoryAlert represents a memory usage alert
-type MemoryAlert struct {
-	Level     AlertLevel
-	Message   string
-	Stats     MemoryStats
-	Timestamp time.Time
 }
 
 // AlertLevel defines the severity of memory alerts
@@ -110,11 +101,9 @@ func NewCacheManager(scheme *runtime.Scheme, watchModePrefix string, watchAllMod
 		memoryThreshold:   DefaultMemoryThresholdMB,
 		warningThreshold:  WarningMemoryThresholdMB,
 		watchedNamespaces: make(map[string]time.Time),
-		filteredResources: make(map[string]bool),
 		memoryStats:       make(chan MemoryStats, 100),
 	}
 
-	cm.setupResourceFilters()
 	return cm
 }
 
@@ -283,24 +272,6 @@ func (cm *CacheManager) GetMemoryStats() MemoryStats {
 
 // Private methods
 
-func (cm *CacheManager) setupResourceFilters() {
-	cm.filteredResources = map[string]bool{
-		"Pod":                true,  // Filter unless labeled
-		"Endpoint":           true,  // Filter unless labeled
-		"Event":              true,  // Filter unless labeled
-		"ReplicaSet":         true,  // Filter unless labeled
-		"Deployment":         true,  // Filter unless labeled
-		"DaemonSet":          true,  // Filter unless labeled
-		"Ingress":            true,  // Filter unless labeled
-		"NetworkPolicy":      true,  // Filter unless labeled
-		"StorageClass":       false, // Always cache
-		"PersistentVolume":   false, // Always cache
-		"Node":               false, // Always cache
-		"ClusterRole":        false, // Always cache
-		"ClusterRoleBinding": false, // Always cache
-	}
-}
-
 func (cm *CacheManager) getWatchedNamespaces() map[string]cache.Config {
 	cm.mutex.RLock()
 	defer cm.mutex.RUnlock()
@@ -461,21 +432,14 @@ func (cm *CacheManager) isMemoryAboveThreshold() bool {
 }
 
 func (cm *CacheManager) triggerAlert(level AlertLevel, message string, stats MemoryStats) {
-	alert := MemoryAlert{
-		Level:     level,
-		Message:   message,
-		Stats:     stats,
-		Timestamp: time.Now(),
-	}
-
-	// Log the alert
+	// Log the alert at a severity matching its level.
 	switch level {
 	case AlertLevelCritical:
-		log.Log.Error(nil, alert.Message, "stats", alert.Stats)
+		log.Log.Error(nil, message, "stats", stats)
 	case AlertLevelWarning:
-		log.Log.Info(alert.Message, "stats", alert.Stats)
+		log.Log.Info(message, "stats", stats)
 	case AlertLevelInfo:
-		log.Log.V(1).Info(alert.Message, "stats", alert.Stats)
+		log.Log.V(1).Info(message, "stats", stats)
 	}
 }
 

--- a/internal/controller/neo4jbackup_controller.go
+++ b/internal/controller/neo4jbackup_controller.go
@@ -879,14 +879,12 @@ func (r *Neo4jBackupReconciler) ensureBackupPVC(ctx context.Context, backup *neo
 // Neo4jBackup CR from an existing backup PVC, protecting v1.12.0-created PVCs
 // from cascade-deletion when the CR is removed. No-op when no such ref exists.
 func (r *Neo4jBackupReconciler) stripBackupPVCOwnerRef(ctx context.Context, backup *neo4jv1beta1.Neo4jBackup, pvc *corev1.PersistentVolumeClaim) error {
-	kept := make([]metav1.OwnerReference, 0, len(pvc.OwnerReferences))
 	stripped := false
 	for _, ref := range pvc.OwnerReferences {
 		if ref.UID == backup.UID && ref.Kind == "Neo4jBackup" {
 			stripped = true
-			continue
+			break
 		}
-		kept = append(kept, ref)
 	}
 	if !stripped {
 		return nil

--- a/internal/controller/neo4jbackup_sharded.go
+++ b/internal/controller/neo4jbackup_sharded.go
@@ -113,13 +113,13 @@ func (r *Neo4jBackupReconciler) shardedPreflightGlobSafety(ctx context.Context, 
 	if err != nil {
 		// Connect failures are indistinguishable from a cluster that is
 		// momentarily unreachable — transient (#217), not a glob violation.
-		return fmt.Errorf("failed to open Neo4j client for glob-safety check: %v: %w", err, errBackupTransient)
+		return fmt.Errorf("failed to open Neo4j client for glob-safety check: %w: %w", err, errBackupTransient)
 	}
 	defer client.Close()
 
 	dbs, err := client.GetDatabases(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to list databases for glob-safety check: %v: %w", err, errBackupTransient)
+		return fmt.Errorf("failed to list databases for glob-safety check: %w: %w", err, errBackupTransient)
 	}
 
 	logical := r.shardedLogicalNameForBackup(ctx, backup)

--- a/internal/controller/neo4jenterprisecluster_controller.go
+++ b/internal/controller/neo4jenterprisecluster_controller.go
@@ -1557,13 +1557,19 @@ func (r *Neo4jEnterpriseClusterReconciler) reconcileMutableResource(ctx context.
 
 	switch d := desired.(type) {
 	case *corev1.Service:
-		e := existing.(*corev1.Service)
+		e, ok := existing.(*corev1.Service)
+		if !ok {
+			return fmt.Errorf("existing object %T does not match desired *corev1.Service", existing)
+		}
 		if applyDesiredServiceFields(e, d) {
 			logger.Info("Updating Service", "name", e.Name)
 			return r.Update(ctx, e)
 		}
 	case *networkingv1.NetworkPolicy:
-		e := existing.(*networkingv1.NetworkPolicy)
+		e, ok := existing.(*networkingv1.NetworkPolicy)
+		if !ok {
+			return fmt.Errorf("existing object %T does not match desired *networkingv1.NetworkPolicy", existing)
+		}
 		changed := false
 		if !equality.Semantic.DeepEqual(e.Spec, d.Spec) {
 			e.Spec = d.Spec
@@ -1577,7 +1583,10 @@ func (r *Neo4jEnterpriseClusterReconciler) reconcileMutableResource(ctx context.
 			return r.Update(ctx, e)
 		}
 	case *networkingv1.Ingress:
-		e := existing.(*networkingv1.Ingress)
+		e, ok := existing.(*networkingv1.Ingress)
+		if !ok {
+			return fmt.Errorf("existing object %T does not match desired *networkingv1.Ingress", existing)
+		}
 		changed := false
 		if !equality.Semantic.DeepEqual(e.Spec, d.Spec) {
 			e.Spec = d.Spec
@@ -1591,7 +1600,10 @@ func (r *Neo4jEnterpriseClusterReconciler) reconcileMutableResource(ctx context.
 			return r.Update(ctx, e)
 		}
 	case *certmanagerv1.Certificate:
-		e := existing.(*certmanagerv1.Certificate)
+		e, ok := existing.(*certmanagerv1.Certificate)
+		if !ok {
+			return fmt.Errorf("existing object %T does not match desired *certmanagerv1.Certificate", existing)
+		}
 		changed := false
 		if !equality.Semantic.DeepEqual(e.Spec, d.Spec) {
 			e.Spec = d.Spec

--- a/internal/controller/neo4jrestore_alldatabases.go
+++ b/internal/controller/neo4jrestore_alldatabases.go
@@ -262,16 +262,29 @@ func (r *Neo4jRestoreReconciler) ensureClusterSeedConfigReady(
 	if credsSecret != "" {
 		rolled, rErr := r.seedCredsRolledOut(ctx, cluster, credsSecret)
 		if rErr != nil || !rolled {
-			r.updateRestoreStatus(ctx, restore, StatusPending,
-				fmt.Sprintf("Waiting for cluster %q server pods to roll out seed credentials Secret %q", cluster.Name, credsSecret))
+			msg := fmt.Sprintf("Waiting for cluster %q server pods to roll out seed credentials Secret %q", cluster.Name, credsSecret)
+			if rErr != nil {
+				msg += fmt.Sprintf(" (rollout check pending: %v)", rErr)
+			}
+			r.updateRestoreStatus(ctx, restore, StatusPending, msg)
+			// A transient rollout-check error is treated as "not rolled out yet":
+			// this function drives all waiting via status + RequeueAfter and never
+			// propagates transient errors (cf. the projErr handling above). The
+			// error is surfaced in the status message set just above.
 			return ctrl.Result{RequeueAfter: r.RequeueAfter}, false, nil
 		}
 	}
 	if hasCustomEndpoint && clusterSpecEnvHasSeedEndpoint(cluster) {
 		rolled, rErr := r.specEnvEndpointRolledOut(ctx, cluster)
 		if rErr != nil || !rolled {
-			r.updateRestoreStatus(ctx, restore, StatusPending,
-				fmt.Sprintf("Waiting for cluster %q server pods to roll out the S3 endpoint", cluster.Name))
+			msg := fmt.Sprintf("Waiting for cluster %q server pods to roll out the S3 endpoint", cluster.Name)
+			if rErr != nil {
+				msg += fmt.Sprintf(" (rollout check pending: %v)", rErr)
+			}
+			r.updateRestoreStatus(ctx, restore, StatusPending, msg)
+			// Transient rollout-check error → keep waiting; this function retries
+			// via RequeueAfter and never propagates transient errors. The error is
+			// surfaced in the status message set just above.
 			return ctrl.Result{RequeueAfter: r.RequeueAfter}, false, nil
 		}
 	}

--- a/internal/validation/backup_validator.go
+++ b/internal/validation/backup_validator.go
@@ -373,7 +373,7 @@ func (v *BackupValidator) validateSchedule(schedule string) (err error) {
 	}
 
 	if _, perr := cron.ParseStandard(schedule); perr != nil {
-		return fmt.Errorf("invalid cron schedule %q: %v (Kubernetes CronJob expects standard 5-field cron, e.g. \"0 2 * * *\", or a macro like \"@daily\")", schedule, perr)
+		return fmt.Errorf("invalid cron schedule %q: %w (Kubernetes CronJob expects standard 5-field cron, e.g. \"0 2 * * *\", or a macro like \"@daily\")", schedule, perr)
 	}
 	return nil
 }


### PR DESCRIPTION
**Stacked on #299** (base = `chore/remove-dead-code`). Merge #299 first, then this retargets to `main`.

## What & why

#299 added a CI lint gate scoped to `--enable=unused` because the repo carried pre-existing golangci-lint debt (Go lint was never run in CI — only `helm-lint`). This PR burns down that debt and switches the gate to the **full `.golangci.yml`**.

`golangci-lint run ./...` (full config) is now **clean (exit 0)**; build + unit tests pass.

## Findings fixed (12)

| Linter | Fix |
|---|---|
| errorlint (3) | Wrap error args with `%w` not `%v`. `neo4jbackup_sharded.go` double-wraps (`%w: %w`) — `errBackupTransient` stays matchable via `errors.Is`. |
| forcetypeassert (4) | The apply helper's type switch now checks each `existing.(*T)` assertion and returns a clear error on mismatch instead of risking a panic. |
| nilerr (2) | The all-databases seed-rollout gate now folds the transient check error into its `Pending` status message — no longer silently swallowed (cf. #297). Using the error also satisfies the linter with no behaviour change (still retries via `RequeueAfter`). |
| staticcheck SA4010 (1) | `stripBackupPVCOwnerRef` built a `kept` slice it never used (the real strip runs later against a fresh object via `filtered`); the first loop now just detects whether a matching owner-ref exists. |
| govet unusedwrite (2) | `triggerAlert` built a `MemoryAlert` whose `Level`/`Timestamp` went unread after #299 removed the alert callback; log level/message/stats directly and drop the now-dead `MemoryAlert` type. |

## Also removed
- The write-only `filteredResources` field + `setupResourceFilters` (dead — real namespace/label filtering is done by controller-runtime `cache.Options`). This was the "orthogonal dead code" flagged in #299.

## CI
- `Go Lint (unused)` → **`Go Lint`**, now running the full `.golangci.yml` config as a merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)