### PR TITLE
test(integration): bound kubectl-exec with per-attempt timeout + retry

### DIFF
--- a/docs/knowledge/operations.md
+++ b/docs/knowledge/operations.md
@@ -1,4 +1,4 @@
-# Operations Knowledge Base — Runtime Invariants (rules 1–39)
+# Operations Knowledge Base — Runtime Invariants (rules 1–39, + post-checklist additions ≥ 80)
 
 > One home, no duplication. This file re-homes the non-backup half of the legacy
 > CLAUDE.md regression checklist (rules 1–39). Backup/restore/sharding rules
@@ -300,6 +300,17 @@
 - **why:** "Enabled" should imply safe obfuscation by default, but must never override an operator who explicitly set `false`; emitting the key twice would make behavior config-order-dependent.
 - **pinned-by:** `TestBuildAuditConfig_ExplicitObfuscateFalseDespiteEnabled` (`internal/resources/audit_config_test.go`).
 - **enforcement:** unit test.
+
+## Testing / CI harness
+
+> ids ≥ 80 are post-checklist additions (the original CLAUDE.md checklist was 1–79; ids 40–79 are the backup/restore/sharding rules in `docs/knowledge/backup-restore.md`).
+
+### id 80 — Integration in-pod exec must be bounded (never raw shared-context `kubectl exec`)
+- **scope:** `test/integration/integration_suite_test.go` (`boundedExec`, `execOut`, `podExecTimeout`); every in-pod exec call site across the `test/integration/*_test.go` specs.
+- **rule:** Every in-pod `kubectl exec` in an integration spec MUST go through `boundedExec` / `execOut` — which run `kubectl exec <pod> -n <ns> -- <cmd…>` under a per-attempt `podExecTimeout` context (60s) with `cmd.WaitDelay`. Never call `exec.CommandContext(ctx, "kubectl", "exec", …)` directly with the shared spec `ctx` / `SpecContext`: it carries no per-attempt deadline.
+- **why:** The shared spec context is only cancelled at the SpecTimeout, so a stuck kubelet exec stream (seen under CI node load) blocks `cmd.CombinedOutput()` indefinitely — and Gomega's `Eventually` cannot retry a function that never returns. One hung exec therefore burns the entire ~10-minute spec budget instead of retrying. This produced the 5.26 `Neo4jUser end-to-end "creates, rotates and drops a user"` flake: the operator had already created the user (Ready + visible in `SHOW USERS`), but the test's "authenticate as appuser" exec never returned. A bounded attempt is killed at `podExecTimeout` and the surrounding `Eventually` retries a fresh exec.
+- **pinned-by:** the `boundedExec` / `execOut` helpers in `test/integration/integration_suite_test.go`. No dedicated unit test guards test-harness usage — **known gap**. Manual check: `grep -rn 'exec.CommandContext(ctx, "kubectl"' test/integration/` must return only the helper (0 raw call sites today).
+- **enforcement:** convention + code review — **PROSE-ONLY — at risk**. Not covered by the `unit-tests` job (test-harness code, not operator code) and deliberately out of scope for `scripts/check-invariants.sh` (that guard is the 5 hard invariants only, and its non-test grep helper skips `_test.go`). Landed with the fix in PR #302.
 
 ## Cross-cutting helpers referenced above
 

--- a/test/integration/all_databases_restore_pvc_test.go
+++ b/test/integration/all_databases_restore_pvc_test.go
@@ -18,7 +18,6 @@ package integration_test
 
 import (
 	"fmt"
-	"os/exec"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -90,8 +89,8 @@ var _ = Describe("PVC Cluster Restore — All-Databases and Single-Database (v1.
 
 	cypher := func(pod, db, stmt string) {
 		Eventually(func() error {
-			out, err := exec.CommandContext(ctx, "kubectl", "exec", pod, "-n", testNamespace, "--",
-				"cypher-shell", "--format", "plain", "--database", db, "-u", "neo4j", "-p", adminPass, stmt).CombinedOutput()
+			out, err := execOut(ctx, pod, testNamespace,
+				"cypher-shell", "--format", "plain", "--database", db, "-u", "neo4j", "-p", adminPass, stmt)
 			if err != nil {
 				GinkgoWriter.Printf("cypher (%s) err=%v out=%s\n", db, err, string(out))
 			}
@@ -99,8 +98,8 @@ var _ = Describe("PVC Cluster Restore — All-Databases and Single-Database (v1.
 		}, 2*time.Minute, pollInterval).Should(Succeed())
 	}
 	readCypher := func(pod, db, stmt string) string {
-		out, _ := exec.CommandContext(ctx, "kubectl", "exec", pod, "-n", testNamespace, "--",
-			"cypher-shell", "--format", "plain", "--database", db, "-u", "neo4j", "-p", adminPass, stmt).CombinedOutput()
+		out, _ := execOut(ctx, pod, testNamespace,
+			"cypher-shell", "--format", "plain", "--database", db, "-u", "neo4j", "-p", adminPass, stmt)
 		return string(out)
 	}
 	waitRestore := func(name string) *neo4jv1beta1.Neo4jRestore {

--- a/test/integration/all_databases_restore_standalone_test.go
+++ b/test/integration/all_databases_restore_standalone_test.go
@@ -18,7 +18,6 @@ package integration_test
 
 import (
 	"fmt"
-	"os/exec"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -92,8 +91,8 @@ var _ = Describe("Standalone All-Databases Restore (v1.13 API)", Label("extended
 
 	cypher := func(pod, db, stmt string) {
 		Eventually(func() error {
-			out, err := exec.CommandContext(ctx, "kubectl", "exec", pod, "-n", testNamespace, "--",
-				"cypher-shell", "--format", "plain", "--database", db, "-u", "neo4j", "-p", adminPass, stmt).CombinedOutput()
+			out, err := execOut(ctx, pod, testNamespace,
+				"cypher-shell", "--format", "plain", "--database", db, "-u", "neo4j", "-p", adminPass, stmt)
 			if err != nil {
 				GinkgoWriter.Printf("cypher (%s) err=%v out=%s\n", db, err, string(out))
 			}
@@ -101,8 +100,8 @@ var _ = Describe("Standalone All-Databases Restore (v1.13 API)", Label("extended
 		}, 2*time.Minute, pollInterval).Should(Succeed())
 	}
 	readCypher := func(pod, db, stmt string) string {
-		out, _ := exec.CommandContext(ctx, "kubectl", "exec", pod, "-n", testNamespace, "--",
-			"cypher-shell", "--format", "plain", "--database", db, "-u", "neo4j", "-p", adminPass, stmt).CombinedOutput()
+		out, _ := execOut(ctx, pod, testNamespace,
+			"cypher-shell", "--format", "plain", "--database", db, "-u", "neo4j", "-p", adminPass, stmt)
 		return string(out)
 	}
 

--- a/test/integration/all_databases_restore_test.go
+++ b/test/integration/all_databases_restore_test.go
@@ -18,7 +18,6 @@ package integration_test
 
 import (
 	"fmt"
-	"os/exec"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -118,8 +117,9 @@ var _ = Describe("All-Databases Backup and Cluster Restore (MinIO) Integration T
 
 	writeCypher := func(podName, dbName, stmt string) {
 		Eventually(func() error {
-			cmd := exec.CommandContext(ctx, "kubectl", "exec", podName, "-n", testNamespace, "--",
+			cmd, cancel := boundedExec(ctx, podName, testNamespace,
 				"cypher-shell", "--format", "plain", "--database", dbName, "-u", "neo4j", "-p", adminPass, stmt)
+			defer cancel()
 			out, err := cmd.CombinedOutput()
 			if err != nil {
 				GinkgoWriter.Printf("cypher-shell (%s) err=%v out=%s\n", dbName, err, string(out))
@@ -243,16 +243,18 @@ var _ = Describe("All-Databases Backup and Cluster Restore (MinIO) Integration T
 
 		By("Verifying both databases' data round-tripped (pre-backup values restored)")
 		Eventually(func() string {
-			cmd := exec.CommandContext(ctx, "kubectl", "exec", podName, "-n", testNamespace, "--",
+			cmd, cancel := boundedExec(ctx, podName, testNamespace,
 				"cypher-shell", "--format", "plain", "--database", "inventory", "-u", "neo4j", "-p", adminPass,
 				"MATCH (i:Item {sku:'A-100'}) RETURN i.count AS count;")
+			defer cancel()
 			out, _ := cmd.CombinedOutput()
 			return string(out)
 		}, 3*time.Minute, pollInterval).Should(ContainSubstring("42"))
 		Eventually(func() string {
-			cmd := exec.CommandContext(ctx, "kubectl", "exec", podName, "-n", testNamespace, "--",
+			cmd, cancel := boundedExec(ctx, podName, testNamespace,
 				"cypher-shell", "--format", "plain", "--database", "customers", "-u", "neo4j", "-p", adminPass,
 				"MATCH (c:Customer {id:'C-1'}) RETURN c.tier AS tier;")
+			defer cancel()
 			out, _ := cmd.CombinedOutput()
 			return string(out)
 		}, 3*time.Minute, pollInterval).Should(ContainSubstring("gold"))

--- a/test/integration/backup_chain_test.go
+++ b/test/integration/backup_chain_test.go
@@ -18,7 +18,6 @@ package integration_test
 
 import (
 	"fmt"
-	"os/exec"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -180,11 +179,11 @@ var _ = Describe("Backup Chain Integration Tests", Label("extended"), Serial, fu
 		podName := fmt.Sprintf("%s-server-0", cluster.Name)
 		runCypher := func(stmt string) {
 			Eventually(func() error {
-				cmd := exec.CommandContext(ctx, "kubectl", "exec",
-					podName, "-n", testNamespace, "--",
+				cmd, cancel := boundedExec(ctx, podName, testNamespace,
 					"cypher-shell", "--format", "plain", "--database", dbName,
 					"-u", "neo4j", "-p", adminPass, stmt,
 				)
+				defer cancel()
 				out, err := cmd.CombinedOutput()
 				if err != nil {
 					GinkgoWriter.Printf("cypher err=%v out=%s\n", err, string(out))
@@ -292,12 +291,12 @@ var _ = Describe("Backup Chain Integration Tests", Label("extended"), Serial, fu
 		// List skus so a chain miss is visible: "pre-full" only → DIFF
 		// didn't apply; "post-full" only → FULL wasn't replayed; both → ok.
 		Eventually(func() string {
-			cmd := exec.CommandContext(ctx, "kubectl", "exec",
-				podName, "-n", testNamespace, "--",
+			cmd, cancel := boundedExec(ctx, podName, testNamespace,
 				"cypher-shell", "--format", "plain", "--database", dbName,
 				"-u", "neo4j", "-p", adminPass,
 				"MATCH (i:Item) RETURN i.sku AS sku ORDER BY sku;",
 			)
+			defer cancel()
 			out, err := cmd.CombinedOutput()
 			outStr := string(out)
 			GinkgoWriter.Printf("verify chain err=%v out=%s\n", err, outStr)

--- a/test/integration/database_neo4j_verification_test.go
+++ b/test/integration/database_neo4j_verification_test.go
@@ -19,7 +19,6 @@ package integration_test
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -100,11 +99,11 @@ var _ = Describe("Neo4jDatabase Neo4j-Level Verification", Label("core"), func()
 			By("Verifying 'verifydb' is visible via cypher-shell SHOW DATABASES")
 			podName := fmt.Sprintf("%s-server-0", clusterName)
 			Eventually(func() bool {
-				cmd := exec.CommandContext(ctx, "kubectl", "exec",
-					podName, "-n", namespace.Name, "--",
+				cmd, cancel := boundedExec(ctx, podName, namespace.Name,
 					"cypher-shell", "--format", "plain", "-u", "neo4j", "-p", adminPass,
 					"SHOW DATABASES YIELD name WHERE name = 'verifydb' RETURN count(*) AS n",
 				)
+				defer cancel()
 				out, err := cmd.CombinedOutput()
 				outStr := string(out)
 				GinkgoWriter.Printf("cypher-shell output: %s (err: %v)\n", outStr, err)

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -66,6 +66,37 @@ var interval = 5 * time.Second
 // Cluster formation timeout for complex multi-node tests
 var clusterTimeout = 5 * time.Minute
 
+// podExecTimeout bounds a SINGLE `kubectl exec` attempt. A stuck kubelet exec
+// stream (seen under CI node load) otherwise blocks cmd.CombinedOutput() on the
+// shared spec context indefinitely — the surrounding Eventually cannot retry a
+// call that never returns, so one hung exec burns the entire SpecTimeout (the
+// 10-minute opaque flake behind e.g. the Neo4jUser "authenticate as appuser"
+// check). Bounding each attempt lets Eventually kill it and retry a fresh exec.
+var podExecTimeout = 60 * time.Second
+
+// boundedExec builds a `kubectl exec <pod> -n <namespace> -- <command...>` Cmd
+// whose execution is bounded by podExecTimeout (derived from ctx). Callers MUST
+// `defer cancel()`. cmd.WaitDelay guarantees Wait returns even if the killed
+// process leaves a pipe open. Use it (not raw exec.CommandContext(ctx, ...))
+// for in-pod execs inside Eventually/Consistently so a hung exec is retried
+// rather than hanging until the spec times out.
+func boundedExec(ctx context.Context, pod, namespace string, command ...string) (*exec.Cmd, context.CancelFunc) {
+	execCtx, cancel := context.WithTimeout(ctx, podExecTimeout)
+	args := append([]string{"exec", pod, "-n", namespace, "--"}, command...)
+	cmd := exec.CommandContext(execCtx, "kubectl", args...)
+	cmd.WaitDelay = 10 * time.Second
+	return cmd, cancel
+}
+
+// execOut runs boundedExec and returns combined stdout+stderr — the one-shot
+// form for callers that don't need the *exec.Cmd. Same per-attempt timeout, so
+// it is safe inside Eventually/Consistently.
+func execOut(ctx context.Context, pod, namespace string, command ...string) ([]byte, error) {
+	cmd, cancel := boundedExec(ctx, pod, namespace, command...)
+	defer cancel()
+	return cmd.CombinedOutput()
+}
+
 // Initialize timeout based on environment
 func init() {
 	// Increase timeout in CI environments where resources are more constrained

--- a/test/integration/neo4jauthrule_test.go
+++ b/test/integration/neo4jauthrule_test.go
@@ -19,7 +19,6 @@ package integration_test
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -272,13 +271,13 @@ var _ = Describe("Neo4jAuthRule end-to-end", Label("extended"), func() {
 
 		By("Verifying SHOW AUTH RULES reports the rule")
 		Eventually(func() string {
-			cmd := exec.CommandContext(ctx, "kubectl", "exec",
-				podName, "-n", namespace.Name, "--",
+			cmd, cancel := boundedExec(ctx, podName, namespace.Name,
 				"cypher-shell", "--format", "plain", "-u", "neo4j", "-p", adminPass,
 				"CYPHER 25 SHOW AUTH RULES YIELD name, condition, enabled, roles "+
 					"WHERE name = 'analytics_team' "+
 					"RETURN name, condition, enabled, roles",
 			)
+			defer cancel()
 			out, _ := cmd.CombinedOutput()
 			return string(out)
 		}, clusterTimeout, interval).Should(SatisfyAll(
@@ -299,21 +298,21 @@ var _ = Describe("Neo4jAuthRule end-to-end", Label("extended"), func() {
 		time.Sleep(5 * time.Second)
 
 		By("Manually dropping the rule via cypher-shell to simulate drift")
-		cmd := exec.CommandContext(ctx, "kubectl", "exec",
-			podName, "-n", namespace.Name, "--",
+		cmd, cancel := boundedExec(ctx, podName, namespace.Name,
 			"cypher-shell", "--format", "plain", "-u", "neo4j", "-p", adminPass,
 			"CYPHER 25 DROP AUTH RULE analytics_team",
 		)
+		defer cancel()
 		out, err := cmd.CombinedOutput()
 		Expect(err).ToNot(HaveOccurred(), "cypher-shell DROP AUTH RULE failed; output: %s", string(out))
 
 		By("Waiting for the operator to recreate the rule (drift reconciliation)")
 		Eventually(func() bool {
-			cmd := exec.CommandContext(ctx, "kubectl", "exec",
-				podName, "-n", namespace.Name, "--",
+			cmd, cancel := boundedExec(ctx, podName, namespace.Name,
 				"cypher-shell", "--format", "plain", "-u", "neo4j", "-p", adminPass,
 				"CYPHER 25 SHOW AUTH RULES YIELD name WHERE name = 'analytics_team' RETURN count(*) AS n",
 			)
+			defer cancel()
 			out, err := cmd.CombinedOutput()
 			if err != nil {
 				GinkgoWriter.Printf("cypher-shell SHOW AUTH RULES failed: %v; output: %s\n", err, string(out))
@@ -329,22 +328,22 @@ var _ = Describe("Neo4jAuthRule end-to-end", Label("extended"), func() {
 
 		By("Manually revoking the role grant to simulate role drift")
 		Eventually(func(g Gomega) {
-			cmd := exec.CommandContext(ctx, "kubectl", "exec",
-				podName, "-n", namespace.Name, "--",
+			cmd, cancel := boundedExec(ctx, podName, namespace.Name,
 				"cypher-shell", "--format", "plain", "-u", "neo4j", "-p", adminPass,
 				"CYPHER 25 REVOKE ROLE analytics_reader FROM AUTH RULE analytics_team",
 			)
+			defer cancel()
 			out, err := cmd.CombinedOutput()
 			g.Expect(err).ToNot(HaveOccurred(), "REVOKE failed; output: %s", string(out))
 		}, clusterTimeout, interval).Should(Succeed())
 
 		By("Waiting for the operator to re-grant analytics_reader to the rule")
 		Eventually(func() string {
-			cmd := exec.CommandContext(ctx, "kubectl", "exec",
-				podName, "-n", namespace.Name, "--",
+			cmd, cancel := boundedExec(ctx, podName, namespace.Name,
 				"cypher-shell", "--format", "plain", "-u", "neo4j", "-p", adminPass,
 				"CYPHER 25 SHOW AUTH RULES YIELD name, roles WHERE name = 'analytics_team' RETURN roles",
 			)
+			defer cancel()
 			out, _ := cmd.CombinedOutput()
 			return string(out)
 		}, clusterTimeout, interval).Should(ContainSubstring("analytics_reader"))
@@ -355,11 +354,11 @@ var _ = Describe("Neo4jAuthRule end-to-end", Label("extended"), func() {
 
 		By("Waiting for the rule to disappear from SHOW AUTH RULES")
 		Eventually(func() bool {
-			cmd := exec.CommandContext(ctx, "kubectl", "exec",
-				podName, "-n", namespace.Name, "--",
+			cmd, cancel := boundedExec(ctx, podName, namespace.Name,
 				"cypher-shell", "--format", "plain", "-u", "neo4j", "-p", adminPass,
 				"CYPHER 25 SHOW AUTH RULES YIELD name WHERE name = 'analytics_team' RETURN count(*) AS n",
 			)
+			defer cancel()
 			out, err := cmd.CombinedOutput()
 			if err != nil {
 				GinkgoWriter.Printf("cypher-shell SHOW AUTH RULES failed: %v; output: %s\n", err, string(out))

--- a/test/integration/neo4jrole_test.go
+++ b/test/integration/neo4jrole_test.go
@@ -19,7 +19,6 @@ package integration_test
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -110,11 +109,11 @@ var _ = Describe("Neo4jRole end-to-end", Label("core"), func() {
 
 		By("Verifying privileges are visible via SHOW ROLE PRIVILEGES")
 		Eventually(func() string {
-			cmd := exec.CommandContext(ctx, "kubectl", "exec",
-				podName, "-n", namespace.Name, "--",
+			cmd, cancel := boundedExec(ctx, podName, namespace.Name,
 				"cypher-shell", "--format", "plain", "-u", "neo4j", "-p", adminPass,
 				"SHOW ROLE analytics_reader PRIVILEGES YIELD action, access RETURN action, access",
 			)
+			defer cancel()
 			out, _ := cmd.CombinedOutput()
 			return string(out)
 		}, clusterTimeout, interval).Should(SatisfyAll(
@@ -140,11 +139,11 @@ var _ = Describe("Neo4jRole end-to-end", Label("core"), func() {
 		// Retry transient system-DB conflicts (GQLSTATUS 25N11) — a manual
 		// admin write can briefly collide with concurrent system-DB activity.
 		Eventually(func() error {
-			cmd := exec.CommandContext(ctx, "kubectl", "exec",
-				podName, "-n", namespace.Name, "--",
+			cmd, cancel := boundedExec(ctx, podName, namespace.Name,
 				"cypher-shell", "--format", "plain", "-u", "neo4j", "-p", adminPass,
 				"REVOKE ACCESS ON DATABASE neo4j FROM analytics_reader",
 			)
+			defer cancel()
 			if out, err := cmd.CombinedOutput(); err != nil {
 				return fmt.Errorf("cypher-shell REVOKE failed; output: %s", string(out))
 			}
@@ -153,11 +152,11 @@ var _ = Describe("Neo4jRole end-to-end", Label("core"), func() {
 
 		By("Waiting for the operator to re-apply the GRANT (drift reconciliation)")
 		Eventually(func() bool {
-			cmd := exec.CommandContext(ctx, "kubectl", "exec",
-				podName, "-n", namespace.Name, "--",
+			cmd, cancel := boundedExec(ctx, podName, namespace.Name,
 				"cypher-shell", "--format", "plain", "-u", "neo4j", "-p", adminPass,
 				"SHOW ROLE analytics_reader PRIVILEGES YIELD action WHERE action = 'access' RETURN count(*) AS n",
 			)
+			defer cancel()
 			out, err := cmd.CombinedOutput()
 			if err != nil {
 				GinkgoWriter.Printf("cypher-shell SHOW ROLE PRIVILEGES failed: %v; output: %s\n", err, string(out))
@@ -174,11 +173,11 @@ var _ = Describe("Neo4jRole end-to-end", Label("core"), func() {
 
 		By("Waiting for the role to disappear from SHOW ROLES")
 		Eventually(func() bool {
-			cmd := exec.CommandContext(ctx, "kubectl", "exec",
-				podName, "-n", namespace.Name, "--",
+			cmd, cancel := boundedExec(ctx, podName, namespace.Name,
 				"cypher-shell", "--format", "plain", "-u", "neo4j", "-p", adminPass,
 				"SHOW ROLES YIELD role WHERE role = 'analytics_reader' RETURN count(*) AS n",
 			)
+			defer cancel()
 			out, err := cmd.CombinedOutput()
 			if err != nil {
 				GinkgoWriter.Printf("cypher-shell SHOW ROLES failed: %v; output: %s\n", err, string(out))

--- a/test/integration/neo4jrolebinding_test.go
+++ b/test/integration/neo4jrolebinding_test.go
@@ -19,7 +19,6 @@ package integration_test
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -83,11 +82,11 @@ var _ = Describe("Neo4jRoleBinding end-to-end", Label("core"), func() {
 
 		By("Pre-creating an external user via cypher-shell (simulating SSO first-login)")
 		Eventually(func() error {
-			cmd := exec.CommandContext(ctx, "kubectl", "exec",
-				podName, "-n", namespace.Name, "--",
+			cmd, cancel := boundedExec(ctx, podName, namespace.Name,
 				"cypher-shell", "--format", "plain", "-u", "neo4j", "-p", adminPass,
 				fmt.Sprintf("CREATE USER externuser SET PASSWORD '%s' CHANGE NOT REQUIRED", extUserPass),
 			)
+			defer cancel()
 			out, err := cmd.CombinedOutput()
 			if err != nil {
 				return fmt.Errorf("cypher-shell CREATE USER failed: %w; output: %s", err, string(out))
@@ -117,11 +116,11 @@ var _ = Describe("Neo4jRoleBinding end-to-end", Label("core"), func() {
 
 		By("Verifying externuser holds the reader role")
 		Eventually(func() string {
-			cmd := exec.CommandContext(ctx, "kubectl", "exec",
-				podName, "-n", namespace.Name, "--",
+			cmd, cancel := boundedExec(ctx, podName, namespace.Name,
 				"cypher-shell", "--format", "plain", "-u", "neo4j", "-p", adminPass,
 				"SHOW USERS YIELD user, roles WHERE user = 'externuser' RETURN user, roles",
 			)
+			defer cancel()
 			out, _ := cmd.CombinedOutput()
 			return string(out)
 		}, clusterTimeout, interval).Should(SatisfyAll(
@@ -140,11 +139,11 @@ var _ = Describe("Neo4jRoleBinding end-to-end", Label("core"), func() {
 
 		By("Waiting for the reader role to be revoked from externuser")
 		Eventually(func() bool {
-			cmd := exec.CommandContext(ctx, "kubectl", "exec",
-				podName, "-n", namespace.Name, "--",
+			cmd, cancel := boundedExec(ctx, podName, namespace.Name,
 				"cypher-shell", "--format", "plain", "-u", "neo4j", "-p", adminPass,
 				"SHOW USERS YIELD user, roles WHERE user = 'externuser' RETURN roles",
 			)
+			defer cancel()
 			out, err := cmd.CombinedOutput()
 			if err != nil {
 				GinkgoWriter.Printf("cypher-shell SHOW USERS failed: %v; output: %s\n", err, string(out))
@@ -162,11 +161,10 @@ var _ = Describe("Neo4jRoleBinding end-to-end", Label("core"), func() {
 		}, clusterTimeout, interval).Should(BeTrue(), "binding deletion must revoke the reader role")
 
 		By("Cleaning up the externally-created user")
-		_, _ = exec.CommandContext(ctx, "kubectl", "exec",
-			podName, "-n", namespace.Name, "--",
+		_, _ = execOut(ctx, podName, namespace.Name,
 			"cypher-shell", "--format", "plain", "-u", "neo4j", "-p", adminPass,
 			"DROP USER externuser IF EXISTS",
-		).CombinedOutput()
+		)
 	})
 
 	It("waits in UserNotFound when the user does not exist", SpecTimeout(testTimeout), func(ctx SpecContext) {

--- a/test/integration/neo4juser_test.go
+++ b/test/integration/neo4juser_test.go
@@ -19,7 +19,6 @@ package integration_test
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -119,11 +118,11 @@ var _ = Describe("Neo4jUser end-to-end", Label("core"), func() {
 		By("Verifying SHOW USERS via cypher-shell")
 		podName := fmt.Sprintf("%s-server-0", clusterName)
 		Eventually(func() string {
-			cmd := exec.CommandContext(ctx, "kubectl", "exec",
-				podName, "-n", namespace.Name, "--",
+			cmd, cancel := boundedExec(ctx, podName, namespace.Name,
 				"cypher-shell", "--format", "plain", "-u", "neo4j", "-p", adminPass,
 				"SHOW USERS YIELD user, roles WHERE user = 'appuser' RETURN user, roles",
 			)
+			defer cancel()
 			out, err := cmd.CombinedOutput()
 			if err != nil {
 				// Surface the failure mode so the Eventually's last-observed value
@@ -138,11 +137,11 @@ var _ = Describe("Neo4jUser end-to-end", Label("core"), func() {
 
 		By("Verifying the appuser can authenticate with the original password")
 		Eventually(func() error {
-			cmd := exec.CommandContext(ctx, "kubectl", "exec",
-				podName, "-n", namespace.Name, "--",
+			cmd, cancel := boundedExec(ctx, podName, namespace.Name,
 				"cypher-shell", "--format", "plain", "-u", "appuser", "-p", userPass,
 				"RETURN 1",
 			)
+			defer cancel()
 			out, err := cmd.CombinedOutput()
 			if err != nil {
 				return fmt.Errorf("cypher-shell auth as appuser failed: %w; output: %s", err, string(out))
@@ -173,11 +172,11 @@ var _ = Describe("Neo4jUser end-to-end", Label("core"), func() {
 
 		By("Verifying the appuser can authenticate with the new password")
 		Eventually(func() error {
-			cmd := exec.CommandContext(ctx, "kubectl", "exec",
-				podName, "-n", namespace.Name, "--",
+			cmd, cancel := boundedExec(ctx, podName, namespace.Name,
 				"cypher-shell", "--format", "plain", "-u", "appuser", "-p", newUserPass,
 				"RETURN 1",
 			)
+			defer cancel()
 			out, err := cmd.CombinedOutput()
 			if err != nil {
 				return fmt.Errorf("cypher-shell auth as appuser (rotated password) failed: %w; output: %s", err, string(out))
@@ -191,11 +190,11 @@ var _ = Describe("Neo4jUser end-to-end", Label("core"), func() {
 
 		By("Waiting for the user to disappear from SHOW USERS")
 		Eventually(func() bool {
-			cmd := exec.CommandContext(ctx, "kubectl", "exec",
-				podName, "-n", namespace.Name, "--",
+			cmd, cancel := boundedExec(ctx, podName, namespace.Name,
 				"cypher-shell", "--format", "plain", "-u", "neo4j", "-p", adminPass,
 				"SHOW USERS YIELD user WHERE user = 'appuser' RETURN count(*) AS n",
 			)
+			defer cancel()
 			out, err := cmd.CombinedOutput()
 			if err != nil {
 				GinkgoWriter.Printf("cypher-shell SHOW USERS failed: %v; output: %s\n", err, string(out))

--- a/test/integration/plugin_test.go
+++ b/test/integration/plugin_test.go
@@ -19,7 +19,6 @@ package integration_test
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"strconv"
 	"strings"
 	"time"
@@ -308,11 +307,11 @@ var _ = Describe("Neo4jPlugin Integration Tests", Label("core"), func() {
 			// it because server.directories.plugins=/plugins is set in the base config.
 			podName := fmt.Sprintf("%s-server-0", clusterName)
 			Eventually(func() int {
-				apocCheckCmd := exec.CommandContext(ctx, "kubectl", "exec",
-					podName, "-n", namespace.Name, "--",
+				apocCheckCmd, cancel := boundedExec(ctx, podName, namespace.Name,
 					"cypher-shell", "--format", "plain", "-u", "neo4j", "-p", "admin123",
 					"SHOW PROCEDURES YIELD name WHERE name STARTS WITH 'apoc' RETURN count(*) AS n",
 				)
+				defer cancel()
 				apocOut, apocErr := apocCheckCmd.CombinedOutput()
 				if apocErr != nil {
 					GinkgoWriter.Printf("cypher-shell not yet ready: %v\n", apocErr)

--- a/test/integration/property_sharding_minio_restore_test.go
+++ b/test/integration/property_sharding_minio_restore_test.go
@@ -18,7 +18,6 @@ package integration_test
 
 import (
 	"fmt"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -239,12 +238,12 @@ var _ = Describe("Property Sharding Restore (MinIO) Integration Tests", Label("e
 		hostPod := fmt.Sprintf("%s-server-0", cluster.Name)
 		writeCypher := "CREATE (:Item {sku: 'A-100', count: 42}), (:Item {sku: 'A-200', count: 13}) RETURN count(*) AS n;"
 		Eventually(func() error {
-			cmd := exec.CommandContext(ctx, "kubectl", "exec",
-				hostPod, "-n", testNamespace, "--",
+			cmd, cancel := boundedExec(ctx, hostPod, testNamespace,
 				"cypher-shell", "--format", "plain", "--database", "products",
 				"-u", "neo4j", "-p", "password123",
 				writeCypher,
 			)
+			defer cancel()
 			out, err := cmd.CombinedOutput()
 			if err != nil {
 				GinkgoWriter.Printf("sharded data-write cypher-shell err=%v out=%s\n", err, string(out))
@@ -312,12 +311,12 @@ var _ = Describe("Property Sharding Restore (MinIO) Integration Tests", Label("e
 		// cloud directory seedURI carried the data across the graph +
 		// property shards, not merely that CREATE … WAIT returned.
 		Eventually(func() string {
-			cmd := exec.CommandContext(ctx, "kubectl", "exec",
-				hostPod, "-n", testNamespace, "--",
+			cmd, cancel := boundedExec(ctx, hostPod, testNamespace,
 				"cypher-shell", "--format", "plain", "--database", "products-restored",
 				"-u", "neo4j", "-p", "password123",
 				"MATCH (i:Item {sku: 'A-100'}) RETURN i.count AS count;",
 			)
+			defer cancel()
 			out, err := cmd.CombinedOutput()
 			outStr := string(out)
 			GinkgoWriter.Printf("sharded restore verify err=%v out=%s\n", err, outStr)
@@ -393,9 +392,10 @@ var _ = Describe("Property Sharding Restore (MinIO) Integration Tests", Label("e
 		hostPod := fmt.Sprintf("%s-server-0", cluster.Name)
 		writeCypher := "CREATE (:Item {sku: 'A-100', count: 42}) RETURN count(*) AS n;"
 		Eventually(func() error {
-			cmd := exec.CommandContext(ctx, "kubectl", "exec", hostPod, "-n", testNamespace, "--",
+			cmd, cancel := boundedExec(ctx, hostPod, testNamespace,
 				"cypher-shell", "--format", "plain", "--database", "products",
 				"-u", "neo4j", "-p", "password123", writeCypher)
+			defer cancel()
 			out, err := cmd.CombinedOutput()
 			if err != nil {
 				GinkgoWriter.Printf("data-write err=%v out=%s\n", err, string(out))
@@ -472,10 +472,11 @@ var _ = Describe("Property Sharding Restore (MinIO) Integration Tests", Label("e
 
 		By("Verifying the restored DB contains the backed-up data (per-shard cloud seed carried it)")
 		Eventually(func() string {
-			cmd := exec.CommandContext(ctx, "kubectl", "exec", hostPod, "-n", testNamespace, "--",
+			cmd, cancel := boundedExec(ctx, hostPod, testNamespace,
 				"cypher-shell", "--format", "plain", "--database", "products-restored",
 				"-u", "neo4j", "-p", "password123",
 				"MATCH (i:Item {sku: 'A-100'}) RETURN i.count AS count;")
+			defer cancel()
 			out, _ := cmd.CombinedOutput()
 			return string(out)
 		}, 2*time.Minute, pollInterval).Should(ContainSubstring("42"),

--- a/test/integration/standard_database_minio_restore_test.go
+++ b/test/integration/standard_database_minio_restore_test.go
@@ -18,7 +18,6 @@ package integration_test
 
 import (
 	"fmt"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -191,12 +190,12 @@ var _ = Describe("Standard Database Restore (MinIO) Integration Tests", Label("e
 		podName := fmt.Sprintf("%s-server-0", cluster.Name)
 		writeCypher := "CREATE (:Item {sku: 'A-100', count: 42}), (:Item {sku: 'A-200', count: 13}) RETURN count(*) AS n;"
 		Eventually(func() error {
-			cmd := exec.CommandContext(ctx, "kubectl", "exec",
-				podName, "-n", testNamespace, "--",
+			cmd, cancel := boundedExec(ctx, podName, testNamespace,
 				"cypher-shell", "--format", "plain", "--database", dbName,
 				"-u", "neo4j", "-p", adminPass,
 				writeCypher,
 			)
+			defer cancel()
 			out, err := cmd.CombinedOutput()
 			if err != nil {
 				GinkgoWriter.Printf("data-write cypher-shell err=%v out=%s\n", err, string(out))
@@ -234,12 +233,12 @@ var _ = Describe("Standard Database Restore (MinIO) Integration Tests", Label("e
 		By("Modifying data so the restore-then-verify check is meaningful")
 		modifyCypher := "MATCH (i:Item) SET i.count = 999 RETURN count(i) AS n;"
 		Eventually(func() error {
-			cmd := exec.CommandContext(ctx, "kubectl", "exec",
-				podName, "-n", testNamespace, "--",
+			cmd, cancel := boundedExec(ctx, podName, testNamespace,
 				"cypher-shell", "--format", "plain", "--database", dbName,
 				"-u", "neo4j", "-p", adminPass,
 				modifyCypher,
 			)
+			defer cancel()
 			out, err := cmd.CombinedOutput()
 			if err != nil {
 				GinkgoWriter.Printf("post-backup modify err=%v out=%s\n", err, string(out))
@@ -294,12 +293,12 @@ var _ = Describe("Standard Database Restore (MinIO) Integration Tests", Label("e
 
 		By("Verifying the restored data matches the backup (count=42, not 999)")
 		Eventually(func() string {
-			cmd := exec.CommandContext(ctx, "kubectl", "exec",
-				podName, "-n", testNamespace, "--",
+			cmd, cancel := boundedExec(ctx, podName, testNamespace,
 				"cypher-shell", "--format", "plain", "--database", dbName,
 				"-u", "neo4j", "-p", adminPass,
 				"MATCH (i:Item {sku: 'A-100'}) RETURN i.count AS count;",
 			)
+			defer cancel()
 			out, err := cmd.CombinedOutput()
 			outStr := string(out)
 			GinkgoWriter.Printf("verify cypher-shell err=%v out=%s\n", err, outStr)
@@ -326,12 +325,12 @@ var _ = Describe("Standard Database Restore (MinIO) Integration Tests", Label("e
 
 		By("Re-modifying data so the type=storage restore is meaningful (count=777)")
 		Eventually(func() error {
-			cmd := exec.CommandContext(ctx, "kubectl", "exec",
-				podName, "-n", testNamespace, "--",
+			cmd, cancel := boundedExec(ctx, podName, testNamespace,
 				"cypher-shell", "--format", "plain", "--database", dbName,
 				"-u", "neo4j", "-p", adminPass,
 				"MATCH (i:Item) SET i.count = 777 RETURN count(i) AS n;",
 			)
+			defer cancel()
 			out, err := cmd.CombinedOutput()
 			if err != nil {
 				GinkgoWriter.Printf("pre-storage-restore modify err=%v out=%s\n", err, string(out))
@@ -377,12 +376,12 @@ var _ = Describe("Standard Database Restore (MinIO) Integration Tests", Label("e
 
 		By("Verifying the type=storage restore brought the data back to count=42 (not 777)")
 		Eventually(func() string {
-			cmd := exec.CommandContext(ctx, "kubectl", "exec",
-				podName, "-n", testNamespace, "--",
+			cmd, cancel := boundedExec(ctx, podName, testNamespace,
 				"cypher-shell", "--format", "plain", "--database", dbName,
 				"-u", "neo4j", "-p", adminPass,
 				"MATCH (i:Item {sku: 'A-100'}) RETURN i.count AS count;",
 			)
+			defer cancel()
 			out, err := cmd.CombinedOutput()
 			outStr := string(out)
 			GinkgoWriter.Printf("type=storage verify cypher-shell err=%v out=%s\n", err, outStr)

--- a/test/integration/standard_database_pvc_restore_test.go
+++ b/test/integration/standard_database_pvc_restore_test.go
@@ -18,7 +18,6 @@ package integration_test
 
 import (
 	"fmt"
-	"os/exec"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -155,11 +154,11 @@ var _ = Describe("Standard Database PVC Restore Integration Tests", Label("exten
 		podName := fmt.Sprintf("%s-server-0", cluster.Name)
 		writeCypher := "CREATE (:Item {sku: 'A-100', count: 42}) RETURN count(*) AS n;"
 		Eventually(func() error {
-			cmd := exec.CommandContext(ctx, "kubectl", "exec",
-				podName, "-n", testNamespace, "--",
+			cmd, cancel := boundedExec(ctx, podName, testNamespace,
 				"cypher-shell", "--format", "plain", "--database", dbName,
 				"-u", "neo4j", "-p", adminPass, writeCypher,
 			)
+			defer cancel()
 			out, err := cmd.CombinedOutput()
 			if err != nil {
 				GinkgoWriter.Printf("write err=%v out=%s\n", err, string(out))
@@ -200,11 +199,11 @@ var _ = Describe("Standard Database PVC Restore Integration Tests", Label("exten
 		By("Modifying data so the restore-then-verify check is meaningful")
 		modifyCypher := "MATCH (i:Item) SET i.count = 999 RETURN count(i) AS n;"
 		Eventually(func() error {
-			cmd := exec.CommandContext(ctx, "kubectl", "exec",
-				podName, "-n", testNamespace, "--",
+			cmd, cancel := boundedExec(ctx, podName, testNamespace,
 				"cypher-shell", "--format", "plain", "--database", dbName,
 				"-u", "neo4j", "-p", adminPass, modifyCypher,
 			)
+			defer cancel()
 			out, err := cmd.CombinedOutput()
 			if err != nil {
 				GinkgoWriter.Printf("modify err=%v out=%s\n", err, string(out))
@@ -264,12 +263,12 @@ var _ = Describe("Standard Database PVC Restore Integration Tests", Label("exten
 
 		By("Verifying the restored data matches the backup (count=42, not 999)")
 		Eventually(func() string {
-			cmd := exec.CommandContext(ctx, "kubectl", "exec",
-				podName, "-n", testNamespace, "--",
+			cmd, cancel := boundedExec(ctx, podName, testNamespace,
 				"cypher-shell", "--format", "plain", "--database", dbName,
 				"-u", "neo4j", "-p", adminPass,
 				"MATCH (i:Item {sku: 'A-100'}) RETURN i.count AS count;",
 			)
+			defer cancel()
 			out, err := cmd.CombinedOutput()
 			outStr := string(out)
 			GinkgoWriter.Printf("verify err=%v out=%s\n", err, outStr)


### PR DESCRIPTION
## Problem

Integration specs could hang for the **entire ~10-min SpecTimeout** on a single stuck `kubectl exec cypher-shell`. Every in-pod exec used the shared spec context, so a stalled kubelet exec stream blocked `cmd.CombinedOutput()` forever — and `Eventually` **cannot retry a function that never returns**. Observed as a 5.26 flake (`Neo4jUser > creates, rotates and drops a user`) where the operator had already created the user (Ready + visible in `SHOW USERS`) but the test's *"authenticate as appuser"* exec never came back.

## Fix

Add two suite helpers that bound **each attempt**:
- `boundedExec(ctx, pod, ns, cmd...) (*exec.Cmd, cancel)` — builds `kubectl exec <pod> -n <ns> -- <cmd...>` under a **60s** per-attempt timeout (process killed on hang) with `cmd.WaitDelay` so `Wait` returns even if a pipe lingers. Callers `defer cancel()`.
- `execOut(...)` — one-shot wrapper returning combined output.

A hung exec is now killed at 60s and the surrounding `Eventually` retries a fresh attempt within its own timeout, instead of burning the whole spec budget. 60s is ample for a healthy/cold cypher-shell while leaving room for ≥2 retries inside a 2-min `Eventually` and ~5 inside the 5-min `clusterTimeout`.

## Scope

Converted **all 41** in-pod exec call sites across 13 spec files (all were `cypher-shell`, no container flag). Happy-path behaviour unchanged; a missed `defer cancel()` would be a compile error, so there are no silent half-conversions. `golangci-lint` + `go vet` clean.

Independent, test-only change — complements #300 (the envtest-suite flake fix) with the integration-suite equivalent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)