### PR TITLE
docs(aura): publish per-surface verification status; mark CMK as unproven

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,15 @@ runs on the Aura API **v1 (GA)**, while multi-database and console-RBAC run on
 | `AuraProviderConfig` | Shared Aura API credentials + default organization/project |
 | `AuraInstance` | Aura instance lifecycle — create, resize, pause/resume, upgrade, delete |
 | `AuraSnapshot`, `AuraRestore` | Instance-level snapshots and restore |
-| `AuraCustomerManagedKey` | Customer-managed encryption keys (CMK) |
+| `AuraCustomerManagedKey` | Customer-managed encryption keys (CMK). **Unproven — never exercised against the live API** |
 | `AuraIPFilter` | Organization-scoped network allowlists (v2beta1) |
 | `AuraDatabase`, `AuraDatabaseBackup`, `AuraDatabaseRestore` | Per-database lifecycle and backups on an Aura instance (v2beta1). Requires an `AuraInstance` created with `multiDatabase: true` — Aura fixes that at creation and cannot convert an existing instance |
 | `AuraOrganizationMember`, `AuraProjectMember`, `AuraInvite` | Aura **console** RBAC — org/project roles and email invites (v2beta1). Not in-database Neo4j users |
+
+Every Aura surface above has been exercised against a **live Aura account**
+except `AuraCustomerManagedKey`, which needs a real cloud KMS key and is
+therefore **unproven** — see
+[Verification status](https://priyolahiri.github.io/neo4j-kubernetes-operator/main/user_guide/aura_orchestration/#verification-status).
 
 > Aura console-RBAC is platform identity (who can use the Aura console/project).
 > In-database users, roles and privileges are `Neo4jUser` / `Neo4jRole` /

--- a/docs/api_reference/auracustomermanagedkey.md
+++ b/docs/api_reference/auracustomermanagedkey.md
@@ -1,5 +1,19 @@
 # AuraCustomerManagedKey API Reference
 
+> **⛔ UNPROVEN — never exercised against the live Aura API.** Every other Aura
+> CRD has been driven end-to-end against a real account; this one has not,
+> because it needs a real cloud KMS key (AWS KMS / GCP Cloud KMS / Azure Key
+> Vault) with IAM grants to Aura, which cannot be created disposably. Its shape
+> comes from the published v1 OpenAPI spec — and on this API, spec-derived
+> contracts have repeatedly proven wrong in ways unit tests could not catch.
+> **Verify in a non-production project before relying on it.** See
+> [Verification status](../user_guide/aura_orchestration.md#verification-status).
+>
+> One behaviour *is* test-pinned: the v1 CMK **list** endpoint returns only
+> `id`, `name` and `tenant_id`, so adoption narrows on `name` and then confirms
+> with a per-key `GET` — a key can never be matched on
+> `keyId`/`region`/`cloudProvider` from a list entry.
+
 The `AuraCustomerManagedKey` Custom Resource Definition (CRD) registers a customer-managed encryption key (CMK) with Neo4j Aura for use by dedicated-tier instances. The key material lives in the customer's own cloud KMS; Aura stores only a reference to it.
 
 ## Overview

--- a/docs/api_reference/auradatabase.md
+++ b/docs/api_reference/auradatabase.md
@@ -1,6 +1,7 @@
 # AuraDatabase API Reference
 
 > **⚠️ BETA / best-effort.** Uses the Aura API **v2beta1** (an unstable beta — breaking changes allowed without a version bump). The database create body is not fully schema'd upstream and is mirrored from the response shape. See the [Aura Orchestration Guide](../user_guide/aura_orchestration.md).
+> **✅ Live-verified 2026-07-31** — create → backup → restore → delete walked on a real multi-database instance. See [Verification status](../user_guide/aura_orchestration.md#verification-status).
 
 The `AuraDatabase` CRD manages a database on a managed Neo4j Aura instance. Aura manages replication/topology per tier, so there is **no topology knob** — for databases on a self-managed cluster, use [`Neo4jDatabase`](neo4jdatabase.md) instead.
 

--- a/docs/api_reference/auradatabasebackup.md
+++ b/docs/api_reference/auradatabasebackup.md
@@ -1,6 +1,7 @@
 # AuraDatabaseBackup API Reference
 
 > **⚠️ BETA / best-effort.** Uses the Aura API **v2beta1** (unstable beta). See the [Aura Orchestration Guide](../user_guide/aura_orchestration.md).
+> **✅ Live-verified 2026-07-31.** See [Verification status](../user_guide/aura_orchestration.md#verification-status).
 
 The `AuraDatabaseBackup` CRD takes an **on-demand** per-database backup on a managed Neo4j Aura instance. Like [`AuraSnapshot`](aurasnapshot.md), a backup is one-shot and is **not** deleted from Aura when the CR is removed.
 

--- a/docs/api_reference/auradatabaserestore.md
+++ b/docs/api_reference/auradatabaserestore.md
@@ -1,6 +1,7 @@
 # AuraDatabaseRestore API Reference
 
 > **⚠️ BETA / best-effort.** Uses the Aura API **v2beta1** (unstable beta). See the [Aura Orchestration Guide](../user_guide/aura_orchestration.md).
+> **✅ Live-verified 2026-07-31.** See [Verification status](../user_guide/aura_orchestration.md#verification-status).
 
 The `AuraDatabaseRestore` CRD performs a **one-shot, in-place** restore of a database on a managed Neo4j Aura instance from one of its per-database backups. Requires a multi-database instance — see [`AuraDatabase`](auradatabase.md).
 

--- a/docs/api_reference/aurainstance.md
+++ b/docs/api_reference/aurainstance.md
@@ -1,5 +1,7 @@
 # AuraInstance API Reference
 
+> **✅ Live-verified 2026-08-01** — the full lifecycle (create → snapshot → restore → resize → pause → resume → tier upgrade → delete) was walked against a real Aura project. See [Verification status](../user_guide/aura_orchestration.md#verification-status).
+
 The `AuraInstance` Custom Resource Definition (CRD) declaratively manages a Neo4j Aura cloud instance via the Aura REST API — provision, resize, pause/resume, upgrade, and (optionally) delete. It is distinct from `spec.auraFleetManagement`, which registers a self-managed cluster into the Aura console.
 
 ## Overview
@@ -26,7 +28,7 @@ Set exactly one of `providerConfigRef` or `credentialsSecretRef` for API access.
 | `type` | `string` | Enum `free-db` / `professional-db` / `business-critical` / `enterprise-db` / `professional-ds` / `enterprise-ds`. `enterprise-db` = Virtual Dedicated Cloud (VDC). **Required. Immutable** except the in-place `professional-db` → `business-critical` upgrade. |
 | `version` | `string` | Coarse Aura Neo4j major version (e.g. `"5"`). **Required. Immutable.** |
 | `memory` | `string` | Instance memory, e.g. `4GB`. Mutable — drives online resize. Required except for `free-db` (size fixed by tier). |
-| `storage` | `string` | Instance storage, e.g. `8GB`. Mutable. Not configurable for `free-db`. |
+| `storage` | `string` | Instance storage, e.g. `8GB`. **In practice Aura derives storage from `memory`** — resizing memory auto-scales storage (e.g. 1GB→2GB memory takes storage 2GB→4GB), and a memory/storage pair the tier does not offer is rejected outright (`invalid-memory-size`, naming both values). **Prefer leaving this unset**: a value that disagrees with the tier makes the operator retry a permanently failing update. Not configurable for `free-db`. |
 | `name` | `string` | Aura instance name (max 30 chars). Defaults to `metadata.name`. |
 | `paused` | `bool` | Desired paused state — drives pause / resume. |
 | `vectorOptimized` | `*bool` | Enables vector optimization. |
@@ -60,7 +62,7 @@ Clones a new instance from an existing one at create time (immutable). Exactly o
 |---|---|---|
 | `instanceId` | `string` | Aura instance ID (mirror of the external-name annotation). |
 | `phase` | `string` | Mirrors the Aura instance status (`Creating`, `Running`, `Pausing`, `Paused`, `Resuming`, `Updating`, `Restoring`, `Destroying`, …). |
-| `connectionUrl` | `string` | Bolt routing URL (`neo4j+s://…`). |
+| `connectionUrl` | `string` | Bolt routing URL (`neo4j+s://…`). Aura returns this as **null while an instance is resuming**, so the operator keeps the last known value rather than blanking it — a pause/resume cycle will not clear this field. |
 | `metricsIntegrationUrl` | `string` | Prometheus scrape endpoint, when available. |
 | `binding` | `object` | Service Binding "Provisioned Service" pointer (`{name}` — the connection Secret). |
 | `conditions` | `[]metav1.Condition` | `Ready` (instance usable) and `Synced` (operator reconciled spec). |

--- a/docs/api_reference/aurainvite.md
+++ b/docs/api_reference/aurainvite.md
@@ -1,6 +1,7 @@
 # AuraInvite API Reference
 
 > **⚠️ BETA / best-effort.** Uses the Aura API **v2beta1** (unstable beta). See the [Aura Orchestration Guide](../user_guide/aura_orchestration.md).
+> **✅ Live-verified 2026-08-01 — and the contract was WRONG.** Until then this CRD could not send an invite in either of its two modes. Fixed; see [Verification status](../user_guide/aura_orchestration.md#verification-status).
 
 The `AuraInvite` CRD invites a user (by email) to a Neo4j Aura **organization** — or a **project** within it — with a role. This is how a new person is granted Aura **console** access; it is **not** an in-database Neo4j user. An existing member's role is managed with [`AuraOrganizationMember`](auraorganizationmember.md) / [`AuraProjectMember`](auraprojectmember.md).
 

--- a/docs/api_reference/auraipfilter.md
+++ b/docs/api_reference/auraipfilter.md
@@ -1,8 +1,13 @@
 # AuraIPFilter API Reference
 
-> **⚠️ BETA / best-effort.** IP filtering is only available on the Aura API **v2beta1** surface, which is an unstable beta (breaking changes are allowed without a version bump). This CRD is best-effort and its behaviour may change to track the API. The shape below is taken from the official v2beta1 `IpFilter` schema. See the [Aura Orchestration Guide](../user_guide/aura_orchestration.md) before relying on it in production.
+> **⚠️ BETA / best-effort.** IP filtering is only available on the Aura API **v2beta1** surface, which is an unstable beta (breaking changes are allowed without a version bump). This CRD is best-effort and its behaviour may change to track the API. The shape below is taken from the **live API**, which differs from the published `IpFilter` schema in several places — see below. See the [Aura Orchestration Guide](../user_guide/aura_orchestration.md) before relying on it in production.
+> **✅ Live-verified 2026-08-01 — and the contract was WRONG.** Until then this CRD could not create, update *or* delete a filter; all three are fixed. See [Verification status](../user_guide/aura_orchestration.md#verification-status).
 
 The `AuraIPFilter` Custom Resource Definition (CRD) manages a Neo4j Aura network IP filter (an allowlist) via the Aura API v2beta1.
+
+**One filter per project.** Aura rejects a second filter targeting a project that already has one (`ip-filter-already-exists`), so two `AuraIPFilter` CRs cannot both target the same project.
+
+**Filters are organization-scoped.** They live at the organization level and are *applied* to instances/projects, so the CR needs an organization ID — from `spec.organizationId` or the provider config's `defaultOrganizationId`.
 
 ## Overview
 

--- a/docs/api_reference/auraorganizationmember.md
+++ b/docs/api_reference/auraorganizationmember.md
@@ -1,6 +1,7 @@
 # AuraOrganizationMember API Reference
 
 > **⚠️ BETA / best-effort.** Uses the Aura API **v2beta1** (unstable beta). See the [Aura Orchestration Guide](../user_guide/aura_orchestration.md).
+> **✅ Live-verified 2026-08-01** — request shapes and the role enum confirmed against the API's own validation errors. See [Verification status](../user_guide/aura_orchestration.md#verification-status).
 
 The `AuraOrganizationMember` CRD manages the **organization-level role** of an existing Aura *console* user (identified by email). This is Aura **platform** identity — **not** an in-database Neo4j user. To bring a new person in, create an [`AuraInvite`](aurainvite.md).
 

--- a/docs/api_reference/auraprojectmember.md
+++ b/docs/api_reference/auraprojectmember.md
@@ -1,6 +1,7 @@
 # AuraProjectMember API Reference
 
 > **⚠️ BETA / best-effort.** Uses the Aura API **v2beta1** (unstable beta). See the [Aura Orchestration Guide](../user_guide/aura_orchestration.md).
+> **✅ Live-verified 2026-08-01** — request shapes and the role enum confirmed against the API's own validation errors. See [Verification status](../user_guide/aura_orchestration.md#verification-status).
 
 The `AuraProjectMember` CRD manages the **project-level role** of an Aura *console* user (identified by email). This is Aura **platform** identity — **not** an in-database Neo4j user.
 

--- a/docs/api_reference/auraproviderconfig.md
+++ b/docs/api_reference/auraproviderconfig.md
@@ -1,5 +1,7 @@
 # AuraProviderConfig API Reference
 
+> **✅ Live-verified 2026-07-30** — a token from the v1 OAuth endpoint authenticates v2beta1 calls too, so one credential covers every Aura CRD. See [Verification status](../user_guide/aura_orchestration.md#verification-status).
+
 The `AuraProviderConfig` Custom Resource Definition (CRD) holds Neo4j Aura API credentials and account-level defaults. Other Aura resources reference it via `providerConfigRef` so they can share one OAuth token cache and one Aura API rate-limit budget (25/125 req/min per credential).
 
 ## Overview

--- a/docs/api_reference/aurarestore.md
+++ b/docs/api_reference/aurarestore.md
@@ -1,5 +1,11 @@
 # AuraRestore API Reference
 
+> **✅ Live-verified 2026-08-01.** See [Verification status](../user_guide/aura_orchestration.md#verification-status).
+
+While a restore runs, the **instance** reports `status: restoring` and its
+`connectionUrl` may be briefly unavailable — restore is an instance-level
+operation, not a database-level one.
+
 The `AuraRestore` Custom Resource Definition (CRD) restores an [`AuraInstance`](aurainstance.md) in place from one of its snapshots — the Aura equivalent of `Neo4jRestore`. It is a one-shot action recorded as an auditable object: on completion the CR stays as history and does not re-fire.
 
 ## Overview

--- a/docs/api_reference/aurasnapshot.md
+++ b/docs/api_reference/aurasnapshot.md
@@ -1,6 +1,16 @@
 # AuraSnapshot API Reference
 
+> **✅ Live-verified 2026-08-01.** See [Verification status](../user_guide/aura_orchestration.md#verification-status).
+
 The `AuraSnapshot` Custom Resource Definition (CRD) takes an on-demand snapshot of an [`AuraInstance`](aurainstance.md) — the Aura equivalent of `Neo4jBackup`. Restore is a separate [`AuraRestore`](aurarestore.md) CR.
+
+Three behaviours confirmed against the live API that are easy to misread:
+
+- **`status.profile` is `AdHoc` for snapshots this CRD takes**, and `Scheduled` for the automatic ones Aura makes on its own. Listing an instance's snapshots shows both.
+- **`status.exportable` means "exportable *now*"** — it is `false` while the snapshot runs and flips to `true` on completion. It is not a property of the finished snapshot decided up front.
+- **Aura starts a scheduled snapshot immediately after an instance is created**, and it allows only one snapshot at a time. An `AuraSnapshot` created in that window is legitimately refused with `snapshot-not-allowed`; the operator retries, so it resolves itself.
+
+The create call returns only the snapshot ID — no status — so a fresh CR reports `phase: Pending` until the first poll reads the real state.
 
 ## Overview
 

--- a/docs/developer_guide/release_verification.md
+++ b/docs/developer_guide/release_verification.md
@@ -122,6 +122,26 @@ recommended** whenever an `Aura*` CRD or `internal/aura/` changed, because the
 published Aura OpenAPI spec is known to disagree with the live API (see
 `docs/knowledge/operations.md` id 87).
 
+**Take that disagreement seriously.** As of 2026-08-01 every Aura surface except
+CMK has been driven against a real account, and three of them — fleet
+provisioning, IP filters and invites — were **broken in ways the unit suite could
+not see**, because the fixtures asserted the client matched the *spec* rather
+than the API. A green `make test-unit` is not evidence that an Aura write path
+works.
+
+**Cheap technique worth reusing:** to learn an enum or a required field without
+mutating anything, send a deliberately invalid value — the API answers with the
+full list of accepted values, or names the missing field, and changes nothing.
+
+| Surface | Live-verified | |
+|---|---|---|
+| Instances (v1 lifecycle), snapshots, restore | 2026-08-01 | ✅ |
+| Databases + per-database backup/restore (v2beta1) | 2026-07-31 | ✅ |
+| IP filters (v2beta1) | 2026-08-01 | ✅ contract corrected |
+| Console RBAC: members, invites (v2beta1) | 2026-08-01 | ✅ invite contract corrected |
+| Fleet provisioning (v2beta1) | 2026-07-31 | ✅ contract corrected |
+| **Customer-managed keys (v1)** | — | ❌ **never exercised; needs a real cloud KMS key** |
+
 Set up an `AuraProviderConfig` (or an inline `credentialsSecretRef`) with an API
 client ID + secret from the Aura console.
 

--- a/docs/user_guide/aura_fleet_management.md
+++ b/docs/user_guide/aura_fleet_management.md
@@ -142,6 +142,12 @@ into a Secret. If you give the operator Aura API credentials instead, it can
 register the Fleet Manager deployment **and mint the token itself** — no wizard,
 no copy-paste.
 
+!!! success "Verified against a live Aura account (2026-07-31)"
+    The whole provisioning path — deployment registration, token minting,
+    rotation and cleanup — has been driven end-to-end against a real Aura
+    organization. That verification found and fixed four silent bugs; see
+    [Aura Orchestration → Verification status](aura_orchestration.md#verification-status).
+
 Set `spec.auraFleetManagement.provision` instead of `tokenSecretRef` (the two are
 mutually exclusive):
 

--- a/docs/user_guide/aura_orchestration.md
+++ b/docs/user_guide/aura_orchestration.md
@@ -39,6 +39,47 @@ Design details and rationale: `docs/design/aura-orchestration.md`.
 | `AuraOrganizationMember` / `AuraProjectMember` | Manage an Aura console user's org / project role (console-RBAC), **v2beta1** (beta). |
 | `AuraInvite` | Invites a user to an Aura organization or project (console-RBAC), **v2beta1** (beta). |
 
+## Verification status
+
+Every one of these CRDs talks to a **live cloud API**, so what matters is not
+only whether the code compiles but whether its request shapes are what Aura
+actually accepts. The table below says exactly that, per surface.
+
+This is worth taking seriously: several of these contracts were originally built
+from the published OpenAPI spec, and when they were finally exercised against a
+real account, **three of them turned out to be wrong in ways unit tests could not
+catch** — because the tests asserted the client matched the spec, not the API.
+
+| Surface | Aura API | Live-verified | Notes |
+|---|---|---|---|
+| `AuraProviderConfig` | OAuth | ✅ 2026-07-30 | A token from the v1 endpoint authenticates v2beta1 calls too. |
+| `AuraInstance` | v1 (+ v2beta1 for `multiDatabase`) | ✅ 2026-08-01 | Full lifecycle walked: create → snapshot → restore → resize → pause → resume → tier upgrade → delete. |
+| `AuraSnapshot` | v1 | ✅ 2026-08-01 | |
+| `AuraRestore` | v1 | ✅ 2026-08-01 | |
+| `AuraCustomerManagedKey` | v1 | ❌ **UNTESTED** | See the warning below. |
+| `AuraIPFilter` | v2beta1 | ✅ 2026-08-01 | Contract was **wrong** and has been corrected — it could not create, update or delete. |
+| `AuraDatabase`, `AuraDatabaseBackup`, `AuraDatabaseRestore` | v2beta1 | ✅ 2026-07-31 | Requires a multi-database instance. |
+| `AuraOrganizationMember`, `AuraProjectMember` | v2beta1 | ✅ 2026-08-01 | Read + write shapes and all role enums confirmed. |
+| `AuraInvite` | v2beta1 | ✅ 2026-08-01 | Contract was **wrong** and has been corrected — it could not send an invite. |
+| `spec.auraFleetManagement` (on a self-managed cluster) | v2beta1 | ✅ 2026-07-31 | See [Aura Fleet Management](aura_fleet_management.md). |
+
+!!! danger "AuraCustomerManagedKey has never been exercised against the Aura API"
+    Every other Aura surface above has been driven end-to-end against a real
+    account. `AuraCustomerManagedKey` has **not**, because it needs a real cloud
+    KMS key (AWS KMS / GCP Cloud KMS / Azure Key Vault) with IAM grants to Aura,
+    which cannot be created disposably.
+
+    Its client shape comes from the **published v1 OpenAPI spec**, and on this API
+    that has repeatedly proven insufficient. Treat `AuraCustomerManagedKey` as
+    **unproven**: expect that create or update may be rejected, and verify it in a
+    non-production project before relying on it. The one part that *is* pinned by
+    a test is the adoption logic — the v1 CMK **list** endpoint returns only
+    `id`/`name`/`tenant_id`, so a filter can never be matched on
+    `key_id`/`region`/`cloud_provider` from a list entry.
+
+    If you do exercise it, please report what you find so this table can be
+    updated.
+
 ## Quick start
 
 ```yaml
@@ -203,7 +244,9 @@ Each step is detailed in the sections that follow.
 
 ## Lifecycle
 
-- **Resize:** change `spec.memory` / `spec.storage` → online resize.
+- **Resize:** change `spec.memory` → online resize. **Leave `spec.storage`
+  unset**: Aura derives storage from memory and scales it for you, and a pair
+  the tier does not offer is rejected outright.
 - **Pause/resume:** set `spec.paused: true` / `false`.
 - **Upgrade tier:** change `spec.type` from `professional-db` to
   `business-critical` → in-place upgrade (see below).
@@ -227,6 +270,13 @@ instance). Aura requires ≥ 2GB storage for Business Critical, and the GDS plug
 is removed on upgrade — size and configure the instance accordingly first.
 
 ## Customer-managed encryption keys (CMK)
+
+!!! danger "Unproven — the only Aura surface never exercised against the live API"
+    See [Verification status](#verification-status). This CRD's contract comes
+    from the published OpenAPI spec, which on this API has repeatedly turned out
+    not to match what the service accepts. **Verify it in a non-production
+    project before relying on it**, and expect that create or update may be
+    rejected outright.
 
 Dedicated-tier instances (`enterprise-db` / `enterprise-ds`) can be encrypted
 with a key you hold in your own cloud KMS. Register the key with an
@@ -364,6 +414,8 @@ spec:
   organizationId: "<org-id>"    # or defaultOrganizationId on the provider config
   email: carol@example.com
   role: organization-member     # organization-* ; for a project invite set projectId + a namespace-* role
+  # For a project-scoped invite you MUST also set organizationRole — Aura
+  # requires an organization role on every invite. See the note below.
 ---
 # Manage the org role of an EXISTING console user (by email).
 apiVersion: neo4j.neo4j.com/v1beta1
@@ -386,6 +438,32 @@ spec:
   email: bob@example.com
   role: project-metrics-integration-reader  # project-admin | project-member | project-viewer | project-metrics-integration-reader
 ```
+
+!!! warning "Every invite carries an organization role"
+    Aura has **no project-only invitation**: an invite must always grant at
+    least one `organization-*` role. So a project-scoped `AuraInvite` (a
+    `namespace-*` `role` plus `projectId`) must **also** set
+    `spec.organizationRole` — the apiserver rejects it otherwise.
+
+    The operator deliberately does not pick a default for you: silently granting
+    organization membership nobody asked for is a privilege decision that
+    belongs to you.
+
+!!! note "Three role vocabularies, and they are not interchangeable"
+    Aura spells the same ideas differently depending on where the role appears,
+    and each list below is exactly what the API accepts:
+
+    - **organization roles** — `organization-owner`, `organization-admin`,
+      `organization-member`
+    - **project roles** (on `AuraProjectMember`) — `project-admin`,
+      `project-member`, `project-viewer`,
+      `project-metrics-integration-reader`
+    - **project roles *inside an invite*** (on `AuraInvite`) —
+      `namespace-viewer`, `namespace-member`, `namespace-admin`,
+      `namespace-metrics-integration-reader`
+
+    Yes, the third list really does use `namespace-` for the same concepts the
+    second calls `project-`. That is the API's spelling, not the operator's.
 
 `AuraOrganizationMember` reconciles the org role of a user who is **already** an
 organization member; if the email isn't one yet, the CR reports a `NotAMember`
@@ -442,6 +520,19 @@ which also makes create idempotent (a crash can't produce a duplicate instance).
   except the `professional-db → business-critical` upgrade) cannot be changed
   after creation (enforced by the apiserver). Changing them requires a new
   instance.
+- **`multiDatabase` is fixed at creation.** Only an instance created with
+  `multiDatabase: true` can host `AuraDatabase` resources, only
+  `business-critical` and `enterprise-db` support it, and Aura offers no way to
+  convert an existing instance. Instances created by operator versions before
+  this field existed are single-database for good.
+- **Every invite carries an organization role.** Aura has no project-only
+  invitation, so an `AuraInvite` scoping someone to a project must also set
+  `spec.organizationRole`.
+- **Restores are not observable to completion.** Aura accepts them
+  asynchronously and exposes no status to poll, so an `AuraDatabaseRestore`
+  ends at `Submitted` — confirm the result in the Aura console.
+- **`AuraCustomerManagedKey` is unproven** — see [Verification
+  status](#verification-status).
 
 ## Network IP filtering (beta)
 


### PR DESCRIPTION
The Aura CRDs talk to a live cloud API, so the question a reader actually has is not *"does this compile"* but *"is this request shape one Aura accepts"*. The docs never answered it. They do now.

## New: Verification status

A table in the Aura Orchestration guide saying, **per surface**, whether it has been driven against a real account and on what date. Every API reference page carries a matching one-line banner linking back to it.

| Surface | Live-verified |
|---|---|
| `AuraProviderConfig` | ✅ 2026-07-30 |
| `AuraInstance` (full lifecycle) | ✅ 2026-08-01 |
| `AuraSnapshot`, `AuraRestore` | ✅ 2026-08-01 |
| `AuraIPFilter` | ✅ 2026-08-01 — contract was wrong, corrected |
| `AuraDatabase` + backup/restore | ✅ 2026-07-31 |
| `AuraOrganizationMember`, `AuraProjectMember` | ✅ 2026-08-01 |
| `AuraInvite` | ✅ 2026-08-01 — contract was wrong, corrected |
| Fleet provisioning | ✅ 2026-07-31 — contract was wrong, corrected |
| **`AuraCustomerManagedKey`** | ❌ **UNPROVEN** |

## CMK marked unproven, prominently

Called out in three places — the guide section, the API reference page, and the README table. It is the only Aura surface never exercised live, because it needs a real cloud KMS key with IAM grants to Aura that cannot be created disposably.

**Why say this out loud rather than stay quiet:** three surfaces (fleet, IP filters, invites) were found broken *precisely because* their tests asserted the client matched the published spec rather than the API. CMK is in exactly that position today. The difference between a reader trusting it and a reader checking it is whether we admit it.

The page also records the one CMK behaviour that *is* test-pinned: the v1 list endpoint returns only `id`/`name`/`tenant_id`, so adoption narrows on `name` then confirms with a per-key GET.

## Behaviours documented where users meet them

- **instances** — `storage` is *derived* from `memory`; leave `spec.storage` unset, since a mismatched pair is rejected permanently and the operator will retry it forever. `connectionUrl` is null while resuming and is deliberately not blanked.
- **snapshots** — `profile` is `AdHoc` vs `Scheduled`; `exportable` means "exportable **now**" (it flips on completion); a scheduled snapshot fires right after instance creation, so an early `AuraSnapshot` legitimately fails with `snapshot-not-allowed` and resolves itself.
- **restore** — the *instance* reports `restoring`; a database restore ends at `Submitted` because Aura exposes nothing to poll.
- **IP filters** — one filter per project, and the page no longer claims its shape comes from the published schema. That claim *was* the bug.
- **invites** — every invite carries an organization role, so a project-scoped invite must set `organizationRole`; plus all three role vocabularies spelled out, including that invites really do say `namespace-` for what project members call `project-`.

`release_verification.md` Phase 4 gets the same table, plus the probe technique that made all this cheap: **send a deliberately invalid enum value and the API replies with the full accepted list, mutating nothing.**

## Merge order

Docs-only. Describes behaviour from #324 (IP filters), #325 (invites) and #326 (snapshots) — **merge those first** so the docs and the code agree. No overlapping files except a different region of `aurainvite.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)