### PR TITLE
ci(docs): let a manual docs re-publish keep the released version's title

### DIFF
--- a/.github/workflows/pages-docs.yml
+++ b/.github/workflows/pages-docs.yml
@@ -38,6 +38,17 @@ on:
         required: false
         default: false
         type: boolean
+      # Without this, a manual re-publish of an existing version renames it in the
+      # version selector: the tag path titles vX.Y as the full "vX.Y.Z", while a
+      # dispatch could only title it "vX.Y". Re-publishing v1.14 to correct a doc
+      # therefore relabelled it from "v1.14.0" to "v1.14", inconsistent with
+      # every other entry. Pass the full tag here when refreshing a released
+      # version; leave empty for a throwaway alias like "dev".
+      title:
+        description: 'Title shown in the version selector (default: the alias). Use the full vX.Y.Z when refreshing a released version.'
+        required: false
+        default: ''
+        type: string
 
 permissions:
   contents: write   # mike needs to push to gh-pages
@@ -99,8 +110,9 @@ jobs:
             else
               echo "extra="       >> "$GITHUB_OUTPUT"
             fi
-            echo "title=${{ inputs.version-alias }}" >> "$GITHUB_OUTPUT"
-            echo "Manual deploy: ${{ inputs.version-alias }}"
+            manual_title="${{ inputs.title }}"
+            echo "title=${manual_title:-${{ inputs.version-alias }}}" >> "$GITHUB_OUTPUT"
+            echo "Manual deploy: ${{ inputs.version-alias }} (title: ${manual_title:-${{ inputs.version-alias }}})"
           else
             echo "alias=main"  >> "$GITHUB_OUTPUT"
             echo "extra="      >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Re-publishing an existing docs version to correct a typo silently **renames it in the version selector**.

The tag path titles `vX.Y` with the full `vX.Y.Z`; the dispatch path could only title it with the alias. So re-publishing `v1.14` relabelled it from **"v1.14.0"** to **"v1.14"** — inconsistent with the `v1.13.0` entry sitting next to it.

Adds an optional `title` input, defaulting to the alias, so a dispatch can reproduce the tag-shaped title:

```
gh workflow run pages-docs.yml --ref main \
  -f version-alias=v1.14 -f update-latest=true -f title=v1.14.0
```

Found by re-publishing `v1.14` and then reading `versions.json`, rather than assuming the deploy was faithful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShMPdnbQJadgBEhFsxTY8R