### PR TITLE
fix(neo4juser): permanent livelock when a password ALTER re-sets the same value

### DIFF
--- a/internal/controller/neo4juser_controller.go
+++ b/internal/controller/neo4juser_controller.go
@@ -197,17 +197,41 @@ func (r *Neo4jUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			return r.fail(ctx, user, "post-create read failed", err, requeue)
 		}
 		if info == nil {
-			// Should be impossible — we just created it. Treat as transient.
-			return r.fail(ctx, user, "user not visible after create (eventual consistency?)", nil, requeue)
+			// The user demonstrably exists — CREATE USER just succeeded — but
+			// the system database has not made it visible to this session yet.
+			// That is benign eventual consistency on a multi-server cluster,
+			// NOT a failure: requeue and re-read rather than recording Failed.
+			//
+			// Returning an error here used to be the entry point to a
+			// permanent livelock. The applied password hash is written to
+			// status only at the end of a successful pass, so failing here
+			// left it empty; the next reconcile then saw "password needs
+			// rotating", issued an ALTER to the SAME password, and Neo4j
+			// rejects that outright — forever. IsPasswordUnchangedError below
+			// closes that trap too, but not entering it is cheaper.
+			r.Recorder.Eventf(user, corev1.EventTypeNormal, EventReasonUserCreated,
+				"User %q created; awaiting visibility in the system database", username)
+			return ctrl.Result{RequeueAfter: requeue}, nil
 		}
 	} else {
 		// Diff and ALTER existing user.
 		opts := r.computeAlter(user, info, passwordHash, passwordValue, desiredSuspended)
 		if !opts.IsEmpty() {
 			if err := nc.AlterUser(ctx, username, &opts); err != nil {
-				return r.fail(ctx, user, "alter user failed", err, requeue)
+				// "Old password and new password cannot be the same" means the
+				// stored password ALREADY equals what the spec asks for — the
+				// desired state holds. Treat it as success so the reconcile
+				// proceeds and records the hash; failing here instead makes the
+				// condition permanent, because the hash is what would stop us
+				// re-issuing the same ALTER next time.
+				if !neo4jclient.IsPasswordUnchangedError(err) {
+					return r.fail(ctx, user, "alter user failed", err, requeue)
+				}
+				r.Recorder.Eventf(user, corev1.EventTypeNormal, EventReasonUserUpdated,
+					"User %q password already matches spec; recording as applied", username)
+			} else {
+				r.Recorder.Eventf(user, corev1.EventTypeNormal, EventReasonUserUpdated, "User %q updated", username)
 			}
-			r.Recorder.Eventf(user, corev1.EventTypeNormal, EventReasonUserUpdated, "User %q updated", username)
 		}
 	}
 

--- a/internal/neo4j/error_classify.go
+++ b/internal/neo4j/error_classify.go
@@ -96,3 +96,35 @@ func IsNotFoundError(err error) bool {
 	return strings.Contains(msg, "not found") ||
 		strings.Contains(msg, "does not exist")
 }
+
+// IsPasswordUnchangedError reports whether err is Neo4j rejecting an
+// `ALTER USER … SET PASSWORD` because the new password equals the current one.
+//
+// Neo4j treats this as a hard ArgumentError, but for a reconciler it is the
+// DESIRED state already holding: the stored password is exactly what the spec
+// asks for. Callers should treat it as success, otherwise a benign no-op ALTER
+// becomes a permanent failure.
+//
+// This is not hypothetical. The Neo4jUser reconciler records the applied
+// password hash in status only after a fully successful pass. If anything
+// interrupts between CREATE USER and that status write — an operator restart, a
+// conflict, or the post-create read racing the system database's eventual
+// consistency — the next reconcile sees an empty status hash, decides the
+// password needs rotating, and issues an ALTER to the same value. Without this
+// classification that ALTER fails forever and the user never reaches Ready
+// (observed in CI: PR #337's 2026.06 lane, a 630s spec timeout).
+//
+// Matched on the error CODE plus the message, because ArgumentError alone
+// covers many unrelated failures.
+func IsPasswordUnchangedError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	if !strings.Contains(msg, "argumenterror") {
+		return false
+	}
+	// Neo4j: "Failed to alter the specified user 'x': Old password and new
+	// password cannot be the same."
+	return strings.Contains(msg, "old password and new password cannot be the same")
+}

--- a/internal/neo4j/password_unchanged_test.go
+++ b/internal/neo4j/password_unchanged_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2025 Priyo Lahiri.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package neo4j
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// The verbatim error Neo4j 2026.06 returned in the CI failure this fix came
+// from (PR #337, 2026.06 lane). Kept exact: the classifier matches on the
+// message, so a paraphrase would not prove anything.
+const realNeo4jPasswordUnchanged = "Neo4jError: Neo.ClientError.Statement.ArgumentError " +
+	"(Failed to alter the specified user 'appuser': Old password and new password cannot be the same.)"
+
+func TestIsPasswordUnchangedError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"the real CI error", errors.New(realNeo4jPasswordUnchanged), true},
+		{
+			"wrapped, as the controller sees it",
+			fmt.Errorf("failed to alter user appuser: %w", errors.New(realNeo4jPasswordUnchanged)),
+			true,
+		},
+		{
+			"a DIFFERENT ArgumentError must not be swallowed",
+			errors.New("Neo4jError: Neo.ClientError.Statement.ArgumentError (Invalid input 'x')"),
+			false,
+		},
+		{
+			"the right message under the wrong code is not this condition",
+			errors.New("Neo.ClientError.Security.Forbidden (Old password and new password cannot be the same.)"),
+			false,
+		},
+		{"unrelated error", errors.New("connection refused"), false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsPasswordUnchangedError(tc.err); got != tc.want {
+				t.Errorf("IsPasswordUnchangedError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/test/integration/neo4juser_test.go
+++ b/test/integration/neo4juser_test.go
@@ -93,6 +93,73 @@ var _ = Describe("Neo4jUser end-to-end", Label("core"), func() {
 		}
 	})
 
+	// Regression: a Neo4jUser must recover when its recorded password hash is
+	// lost while the Neo4j user already exists with the desired password.
+	//
+	// This used to livelock permanently. The hash is written to status only at
+	// the end of a fully successful pass, so any interruption before that —
+	// operator restart, update conflict, or the post-create SHOW USERS racing
+	// the system database's eventual consistency — left it empty. The next
+	// reconcile then saw "password needs rotating", issued ALTER USER ... SET
+	// PASSWORD with the value already stored, and Neo4j rejects same-password
+	// ALTER as a hard ArgumentError. The hash was therefore never recorded and
+	// the loop repeated forever (CI: PR #337, 630s spec timeout).
+	//
+	// Clearing the hash directly reproduces the trapped state deterministically,
+	// without needing to win the original race. Before the fix this spec hangs
+	// until timeout; after it, the user returns to Ready.
+	It("recovers when the applied password hash is lost", SpecTimeout(testTimeout), func(ctx SpecContext) {
+		By("Creating a Neo4jUser and waiting for it to become Ready")
+		user = &neo4jv1beta1.Neo4jUser{
+			ObjectMeta: metav1.ObjectMeta{Name: "hashloss", Namespace: namespace.Name},
+			Spec: neo4jv1beta1.Neo4jUserSpec{
+				ClusterRef:        clusterName,
+				Username:          "hashloss",
+				PasswordSecretRef: &neo4jv1beta1.SecretKeyRef{Name: "appuser-creds"},
+			},
+		}
+		Expect(k8sClient.Create(ctx, user)).To(Succeed())
+
+		key := types.NamespacedName{Name: "hashloss", Namespace: namespace.Name}
+		Eventually(func() string {
+			u := &neo4jv1beta1.Neo4jUser{}
+			if err := k8sClient.Get(ctx, key, u); err != nil {
+				return ""
+			}
+			return u.Status.Phase
+		}, clusterTimeout, interval).Should(Equal("Ready"))
+
+		By("Clearing status.passwordSecretHash to simulate an interrupted reconcile")
+		Eventually(func() error {
+			u := &neo4jv1beta1.Neo4jUser{}
+			if err := k8sClient.Get(ctx, key, u); err != nil {
+				return err
+			}
+			u.Status.PasswordSecretHash = ""
+			u.Status.Phase = "Pending"
+			return k8sClient.Status().Update(ctx, u)
+		}, time.Minute, interval).Should(Succeed())
+
+		By("Expecting the user to reconcile back to Ready rather than livelock")
+		// The controller now re-issues ALTER USER with the password already in
+		// place. Neo4j rejects it; the fix classifies that rejection as the
+		// desired state already holding, so the pass completes and re-records
+		// the hash instead of failing forever.
+		Eventually(func() string {
+			u := &neo4jv1beta1.Neo4jUser{}
+			if err := k8sClient.Get(ctx, key, u); err != nil {
+				return ""
+			}
+			return u.Status.Phase
+		}, clusterTimeout, interval).Should(Equal("Ready"),
+			"Neo4jUser livelocked: it re-ALTERs to the same password and never recovers")
+
+		By("Confirming the hash was re-recorded, so the loop cannot repeat")
+		u := &neo4jv1beta1.Neo4jUser{}
+		Expect(k8sClient.Get(ctx, key, u)).To(Succeed())
+		Expect(u.Status.PasswordSecretHash).ToNot(BeEmpty())
+	})
+
 	It("creates, rotates and drops a user", SpecTimeout(testTimeout), func(ctx SpecContext) {
 		By("Creating a Neo4jUser bound to the reader role")
 		user = &neo4jv1beta1.Neo4jUser{


### PR DESCRIPTION
## Summary

Fixes a **permanent livelock** in the `Neo4jUser` reconciler: a user could get stuck Pending forever, never reaching Ready, after a benign race during creation.

Surfaced as the CI failure on #337 (2026.06 lane, 630s spec timeout). Root cause is in `internal/controller/neo4juser_controller.go`, not in that PR's dependency bump. Diagnosis and correction history in #339.

## The loop

From the operator log in that run's `integration-test-logs-2026.06-enterprise` artifact:

```
21:22:54  User "appuser" created
21:22:54  user not visible after create (eventual consistency?)
21:22:55  alter user failed: ... ArgumentError (Failed to alter the specified
          user 'appuser': Old password and new password cannot be the same.)
          ... repeating until the spec timed out
```

1. `CREATE USER` succeeds, setting password P.
2. The immediate post-create `SHOW USERS` does not see the user yet — eventual consistency in the system database on a multi-server cluster.
3. The controller returns an error. The applied password hash is written to status only at the **end** of a fully successful pass, so `status.passwordSecretHash` stays empty.
4. Next reconcile: user is visible, takes the ALTER branch. `computeAlter` compares the Secret hash against the empty status hash → "password needs rotating" → `ALTER USER … SET PASSWORD P`.
5. Neo4j rejects same-password ALTER as a hard `ArgumentError`.
6. Fail → hash still never recorded → **step 4 forever**.

## Why this is worth fixing properly

The *trigger* is racy — which is why it is rare and hit the slower CalVer lane. The *outcome* is not: once entered there is no recovery path.

And the entry point is wider than this one race. **Any** interruption between `CREATE USER` and the terminal status write — an operator restart, an update conflict, a transient connection blip — leaves the same empty hash and the same livelock. That is the part that made me treat it as more than a test annoyance.

## The fix

**1. `IsPasswordUnchangedError` (`internal/neo4j/error_classify.go`) — the load-bearing change.**
Classifies "Old password and new password cannot be the same" as *the desired state already holding*. The ALTER path treats it as success and proceeds to record the hash. This makes password reconciliation idempotent and closes the trap **however it is entered**, not just via this race.

Matched on the error code **and** message: `ArgumentError` alone covers many unrelated failures, so code-only would swallow real errors.

**2. Post-create invisibility requeues instead of recording Failed.**
The user demonstrably exists — `CREATE USER` just succeeded — so this is expected eventual consistency, not an error. Narrows how often the trap is entered at all. Secondary to (1), which holds even without it.

## Testing

- `make test-unit`, `make lint`, `make vet` green.
- New test pins the **verbatim** Neo4j error string from the CI failure, including the wrapped form the controller actually sees (`fmt.Errorf("failed to alter user %s: %w", …)`), and asserts a *different* `ArgumentError` is **not** swallowed.
- The failing scenario itself is the existing `Neo4jUser end-to-end` core spec — it exercises this path on every integration run, which is how it was caught.

## Not included

I have **not** reproduced the race deliberately (it needs the system database to lag a `SHOW USERS` right after `CREATE USER`). The fix is derived from the operator log of a real occurrence plus the code path, and the classifier is tested against that exact error string — but a green CI run here is not proof the race is gone, only that nothing regressed.

Closes #339 — see the correction thread there; the original "CI teardown flake" framing in that issue was mine and was wrong.
