### PR TITLE
ci(collect-logs): surface operator errors in the job log, counted by frequency

### DIFF
--- a/.github/actions/collect-logs/action.yml
+++ b/.github/actions/collect-logs/action.yml
@@ -89,6 +89,74 @@ runs:
           echo "(every pod reported Ready — nothing to surface)"
         fi
 
+    # The step above only fires for a NOT-READY pod. A failure where every pod
+    # is healthy and the OPERATOR is the thing erroring produces "(every pod
+    # reported Ready — nothing to surface)" and nothing else, leaving the job
+    # log with no signal at all — the operator log goes only to the artifact.
+    #
+    # That cost a full extra diagnosis pass on the PR #337 failure: a Neo4jUser
+    # never reached Ready while its cluster was entirely healthy, and the cause
+    # (the same reconcile error repeating for 10 minutes) was invisible until
+    # someone downloaded the artifact. The frequency summary below is the part
+    # that matters for that shape of failure: it collapses hundreds of identical
+    # reconcile errors into one counted line.
+    - name: Surface operator errors in the job log
+      if: always()
+      shell: bash
+      run: |
+        ns=neo4j-operator-system
+        dep=deployment/neo4j-operator-controller-manager
+        if ! kubectl get -n "$ns" "$dep" >/dev/null 2>&1; then
+          echo "(no operator deployment in $ns — nothing to surface)"
+          exit 0
+        fi
+
+        log=$(mktemp)
+        kubectl logs -n "$ns" "$dep" --tail=-1 > "$log" 2>&1 || true
+        if [ ! -s "$log" ]; then
+          echo "(operator log empty)"
+          exit 0
+        fi
+
+        # A stuck reconcile repeats one error many times, so the COUNT is the
+        # tell. Strip the per-reconcile noise (ids, timestamps) so repetitions
+        # collapse onto one line.
+        echo "::group::operator errors by frequency (top 10)"
+        if grep -qE '\bERROR\b' "$log"; then
+          grep -E '\bERROR\b' "$log" \
+            | sed -E 's/.*"error": "([^"]{0,180}).*/\1/' \
+            | sed -E 's/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/<uuid>/g' \
+            | sort | uniq -c | sort -rn | head -10
+        else
+          echo "(no ERROR lines)"
+        fi
+        echo "::endgroup::"
+
+        # cut -f4 (tab-delimited by default) pulls the message out of the
+        # operator's "<ts>\t<level>\t<logger>\t<message>\t<json>" line. Do NOT
+        # swap this for `sed 's/[^\t]*\t//'`: \t inside a bracket expression is
+        # GNU-only, so it silently no-ops on BSD sed and the timestamp stays in
+        # the key, defeating the deduplication.
+        #
+        # Warnings get the same counted treatment. A plain "last N" is useless
+        # here: benign topology advisories ("2 servers provide limited fault
+        # tolerance") repeat constantly and would push the one interesting
+        # warning off the end.
+        echo "::group::operator warning events by frequency (top 10)"
+        if grep -qF '"type": "Warning"' "$log"; then
+          grep -F '"type": "Warning"' "$log" \
+            | cut -f4 \
+            | cut -c1-180 \
+            | sort | uniq -c | sort -rn | head -10
+        else
+          echo "(no Warning events)"
+        fi
+        echo "::endgroup::"
+
+        echo "::group::operator log tail (last 150 lines)"
+        tail -150 "$log"
+        echo "::endgroup::"
+
     - name: Archive cluster logs
       uses: actions/upload-artifact@v7
       if: always()


### PR DESCRIPTION
## Summary

Makes an operator-side integration failure diagnosable **from the job log alone**.

`collect-logs` already had a "Surface not-Ready pod logs" step — but it only fires for a pod that never became Ready. When every pod is **healthy** and the *operator* is the thing erroring, that step prints:

```
(every pod reported Ready — nothing to surface)
```

…and nothing else. The operator log goes only to the artifact.

That is exactly what happened on #337: a `Neo4jUser` never reached Ready while its cluster was entirely fine, and the cause — one reconcile error repeating for ten minutes — was invisible until someone downloaded the artifact and grepped it. It cost a full extra diagnosis pass, and I initially published the **wrong root cause** because of it (see the correction thread on #339).

## What it adds

Three groups in the job log, alongside the existing artifact:

1. **Operator ERRORs aggregated by frequency.** This is the load-bearing part. A stuck reconcile's signature is *one error repeating*, so the count is the tell.
2. **Warning events, also by frequency** — not "last N". Benign topology advisories fire ~196 times per run and would push the one interesting warning off the end.
3. A bounded tail for context.

## Verification

Replayed the exact pipeline against the **real `cluster-debug.log` artifact from the #337 failure**. The root cause lands as the *first line of output*:

```
=== operator errors by frequency (top 10) ===
  36 failed to alter user appuser: Neo4jError: Neo.ClientError.Statement.ArgumentError
     (Failed to alter the specified user 'appuser': Old password and new password cannot be the same.)
   5 Neo4jEnterpriseCluster.neo4j.neo4j.com ...
   4 failed to reconcile TLS Certificate: ...
```

That would have ended the diagnosis in one pass. The warning group, replayed the same way, collapses 196 advisories into two lines and shows the `alter user failed` warning clearly.

## One bug this caught in itself

The warning aggregation originally used `sed` to strip the leading log fields. Testing against the real log showed it **silently not matching**: `\t` inside a bracket expression is GNU-only, so it works on the CI runner but no-ops on BSD sed — it would have passed my local check while behaving differently in CI, leaving timestamps in the dedup key and defeating the aggregation entirely.

Switched to `cut -f4` (tab-delimited by default, portable), with a comment so it does not get "simplified" back.

## Scope

CI diagnostics only — no operator or test behaviour changes. The product bug this exposed is fixed separately in #340.

Refs #339.
