### PR TITLE
fix(ci): wait for ca-cluster-issuer to be Ready, and surface cert-manager state

### DIFF
--- a/.github/actions/collect-logs/action.yml
+++ b/.github/actions/collect-logs/action.yml
@@ -50,6 +50,22 @@ runs:
           done
         done
 
+        # cert-manager state. A TLS spec fails as "no TLS secret found" or a
+        # cluster stuck Initializing, and the cause is usually one level up:
+        # ca-cluster-issuer not Ready, or a CertificateRequest stuck pending.
+        # None of that is visible from pods or operator logs, and it is exactly
+        # what was missing when integration run 32226204116 failed both TLS
+        # specs with "IssuerNotReady".
+        echo "=== cert-manager: Issuers / Certificates / Requests ===" >> cluster-debug.log
+        kubectl get clusterissuers,issuers,certificates,certificaterequests -A -o wide >> cluster-debug.log 2>&1 || true
+        echo "--- ca-cluster-issuer detail ---" >> cluster-debug.log
+        kubectl describe clusterissuer ca-cluster-issuer >> cluster-debug.log 2>&1 || true
+        echo "--- not-Ready certificates ---" >> cluster-debug.log
+        kubectl get certificates -A -o json 2>/dev/null \
+          | jq -r '.items[] | select([.status.conditions[]? | select(.type=="Ready" and .status=="True")] | length == 0)
+                   | "\(.metadata.namespace)/\(.metadata.name): \([.status.conditions[]? | "\(.type)=\(.status) \(.reason) \(.message)"] | join("; "))"' \
+          >> cluster-debug.log 2>&1 || true
+
         echo "=== CRD Status ===" >> cluster-debug.log
         kubectl get crd | grep neo4j >> cluster-debug.log 2>&1 || true
 
@@ -155,6 +171,32 @@ runs:
 
         echo "::group::operator log tail (last 150 lines)"
         tail -150 "$log"
+        echo "::endgroup::"
+
+    # TLS specs fail with a symptom ("no TLS secret found") whose cause lives in
+    # cert-manager, not in the operator or the pod. Surface a NOT-READY issuer or
+    # certificate directly in the job log; stay silent when everything is Ready
+    # so this adds no noise to unrelated failures.
+    - name: Surface not-Ready cert-manager objects in the job log
+      if: always()
+      shell: bash
+      run: |
+        problems=0
+        echo "::group::cert-manager readiness"
+        for kind in clusterissuer issuer certificate certificaterequest; do
+          out=$(kubectl get "$kind" -A -o json 2>/dev/null \
+            | jq -r '.items[]? | select([.status.conditions[]? | select(.type=="Ready" and .status=="True")] | length == 0)
+                     | "\(.kind) \(.metadata.namespace // "-")/\(.metadata.name): \([.status.conditions[]? | "\(.type)=\(.status) (\(.reason // "-")) \(.message // "")"] | join(" | "))"' 2>/dev/null || true)
+          if [ -n "$out" ]; then printf '%s\n' "$out"; problems=1; fi
+        done
+        if [ "$problems" = 0 ]; then
+          echo "(all cert-manager issuers/certificates report Ready)"
+        else
+          echo ""
+          echo "A not-Ready issuer explains TLS specs failing with 'no TLS secret found'"
+          echo "or a cluster stuck Initializing — the operator is waiting on a Secret"
+          echo "cert-manager will never produce."
+        fi
         echo "::endgroup::"
 
     - name: Archive cluster logs

--- a/Makefile
+++ b/Makefile
@@ -990,6 +990,10 @@ dev-cluster: ## Create a Kind cluster for development
 		kubectl wait --for=condition=ready pod -l app.kubernetes.io/instance=cert-manager -n cert-manager --timeout=300s; \
 		echo "Creating self-signed ClusterIssuer for development..."; \
 		kubectl apply -f config/dev/self-signed-issuer.yaml || echo "Self-signed issuer creation skipped (file may not exist)"; \
+		echo "Waiting for ca-cluster-issuer to become Ready (TLS deployments depend on it)..."; \
+		kubectl wait --for=condition=Ready certificate/selfsigned-ca -n cert-manager --timeout=180s || true; \
+		kubectl wait --for=condition=Ready clusterissuer/ca-cluster-issuer --timeout=180s || \
+			echo "WARNING: ca-cluster-issuer not Ready — spec.tls.mode=cert-manager deployments will hang waiting for a Secret"; \
 		echo "Development cluster ready!"; \
 	else \
 		echo "Development cluster already exists"; \

--- a/scripts/test-env.sh
+++ b/scripts/test-env.sh
@@ -58,16 +58,53 @@ cluster() {
     kubectl apply -f "https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml"
     kubectl wait --for=condition=ready pod -l app.kubernetes.io/instance=cert-manager -n cert-manager --timeout=300s
 
-    # Create self-signed ClusterIssuer for testing
+    # Create self-signed ClusterIssuer for testing.
+    #
+    # The TLS specs issue certificates from ca-cluster-issuer, which is THREE
+    # objects deep:
+    #
+    #   selfsigned-cluster-issuer (selfSigned)
+    #     -> Certificate selfsigned-ca
+    #       -> Secret selfsigned-ca-secret
+    #         -> ClusterIssuer ca-cluster-issuer
+    #
+    # This previously waited only on the Certificate, with `|| log warning` so a
+    # timeout was swallowed and the suite started anyway. Both parts were wrong:
+    #
+    #  1. A Ready Certificate does NOT imply a Ready ClusterIssuer — the issuer
+    #     goes Ready only after cert-manager observes the resulting Secret, a
+    #     further reconcile.
+    #  2. Continuing past a timeout turns a setup problem into confusing red TLS
+    #     specs 20 minutes later. Observed on a slow runner (main @5f5d17c,
+    #     integration run 32226204116): both TLS specs failed with
+    #     "IssuerNotReady: Referenced issuer does not have a Ready status
+    #     condition" while every non-TLS spec passed.
+    #
+    # So: wait for what the tests actually depend on, with a timeout that suits a
+    # loaded CI runner, and FAIL LOUDLY rather than handing back a cluster whose
+    # TLS is broken.
     log "Creating self-signed ClusterIssuer for testing..."
-    if kubectl apply -f "${PROJECT_ROOT}/config/dev/self-signed-issuer.yaml"; then
-        # Wait for the bootstrap CA certificate to be issued so ca-cluster-issuer becomes Ready
-        log "Waiting for CA certificate to be issued..."
-        kubectl wait --for=condition=Ready certificate/selfsigned-ca -n cert-manager --timeout=60s || \
-            log "Warning: CA certificate not yet ready (TLS tests may fail)"
-    else
-        echo "Self-signed issuer creation skipped (file may not exist)"
+    if ! kubectl apply -f "${PROJECT_ROOT}/config/dev/self-signed-issuer.yaml"; then
+        log "ERROR: could not apply ${PROJECT_ROOT}/config/dev/self-signed-issuer.yaml"
+        log "       Every TLS spec depends on it; refusing to hand back a half-configured cluster."
+        exit 1
     fi
+
+    log "Waiting for the bootstrap CA certificate (selfsigned-ca)..."
+    if ! kubectl wait --for=condition=Ready certificate/selfsigned-ca -n cert-manager --timeout=180s; then
+        log "ERROR: bootstrap CA certificate selfsigned-ca never became Ready."
+        kubectl describe certificate/selfsigned-ca -n cert-manager 2>&1 | tail -30 || true
+        exit 1
+    fi
+
+    log "Waiting for ca-cluster-issuer to become Ready..."
+    if ! kubectl wait --for=condition=Ready clusterissuer/ca-cluster-issuer --timeout=180s; then
+        log "ERROR: ca-cluster-issuer never became Ready — every TLS spec would fail against this cluster."
+        kubectl get clusterissuer,certificate -A 2>&1 || true
+        kubectl describe clusterissuer/ca-cluster-issuer 2>&1 | tail -30 || true
+        exit 1
+    fi
+    log "ca-cluster-issuer is Ready."
 
     log "Test cluster ready!"
 }


### PR DESCRIPTION
## Summary

Fixes the cause of the TLS failures in integration run [32226204116](https://github.com/priyolahiri/neo4j-kubernetes-operator/actions/runs/32226204116) (main @`5f5d17c`, 5.26 lane), and adds the cert-manager diagnostics that were missing while diagnosing it.

Both failing specs were TLS; all 19 others passed. The cluster spec's own diagnostics named the cause:

```
IssuerNotReady: Referenced issuer does not have a Ready status condition
Issuing: Issuing certificate as Secret does not exist
Requested: Created new CertificateRequest resource "tls-strict-1787123385-tls-1"
```

`ca-cluster-issuer` was not Ready, so the operator waited on a Secret cert-manager would never produce — surfacing as `no TLS secret found` (standalone, 600s) and a cluster stuck `Initializing` (1200s).

## Root cause: three lines in `scripts/test-env.sh`

```bash
kubectl wait --for=condition=Ready certificate/selfsigned-ca -n cert-manager --timeout=60s || \
    log "Warning: CA certificate not yet ready (TLS tests may fail)"
```

Two defects:

1. **It waits on the wrong object.** The chain is `selfsigned-cluster-issuer` → Certificate `selfsigned-ca` → Secret `selfsigned-ca-secret` → ClusterIssuer `ca-cluster-issuer`. A Ready *Certificate* does not imply a Ready *ClusterIssuer* — the issuer only goes Ready once cert-manager observes the resulting Secret, a further reconcile. The specs depend on the issuer.
2. **It swallows its own timeout** and hands back a cluster whose TLS is broken. The comment predicts the consequence (`TLS tests may fail`) rather than preventing it.

This is a latent trap, not a constant failure — it needs a runner slow enough to blow the 60s budget. That run was slow: the **5.26 lane took 59m29s against 2026.06's 35m01s on the same commit**, and 5.26 is normally the *faster* of the two.

## Changes

**`scripts/test-env.sh`** — wait for `clusterissuer/ca-cluster-issuer` `condition=Ready` (what the specs actually need), 180s, and **fail** with the issuer/certificate state printed. A broken issuer should be an honest setup error, not confusing red TLS specs twenty minutes later.

**`make dev-cluster`** — same wait, warning-only since it is interactive.

**`collect-logs`** — the state that was missing when diagnosing this:
- artifact: issuers/certificates/requests, a `ca-cluster-issuer` describe, and a not-Ready summary
- job log: a not-Ready summary, continuing the thread from #341

Both stay **silent when everything is Ready**, so they add no noise to unrelated failures.

## Verification

Against a live Kind cluster:

- Both `kubectl wait` commands succeed on a healthy cluster — including the ClusterIssuer wait that was missing.
- The jq filters print **nothing** when all objects are Ready.
- Against a deliberately broken Certificate (issuerRef to a nonexistent ClusterIssuer), they name the object, condition, reason and the actionable message:

```
Certificate jqprobe/broken-cert: Issuing=True (DoesNotExist) ... | Ready=False (DoesNotExist) ...
CertificateRequest jqprobe/broken-cert-1: ... Ready=False (Pending) Referenced "ClusterIssuer" not found:
  clusterissuer.cert-manager.io "does-not-exist" not found
```

That last line is exactly what run 32226204116 needed and didn't have.

## Honest limits

- I could **not** confirm from the artifacts whether the issuer eventually became Ready in that run — `cluster-debug.log` captured no ClusterIssuer state, which is itself part of what this PR fixes. So "the issuer never became Ready for the whole run" remains inference; the *script defect* is verified by reading it.
- Like #341, the diagnostics only execute on a failing run, so CI cannot validate them. The broken-object replay above is their verification.
