### PR TITLE
fix: correctness defects surfaced by the auth fan-out investigation

### DIFF
--- a/.gitmir/model/index.json
+++ b/.gitmir/model/index.json
@@ -11,6 +11,6 @@
     "statusFlows": 9,
     "reactions": 2
   },
-  "at": "2026-08-27T10:51:28Z",
+  "at": "2026-08-28T10:27:08Z",
   "project": "neo4j-kubernetes-operator"
 }

--- a/.gitmir/model/serverFunctions.json
+++ b/.gitmir/model/serverFunctions.json
@@ -1283,7 +1283,7 @@
     "name": "Validate Neo4jUser spec",
     "serverUnitId": "su-validation",
     "operation": "business_action",
-    "description": "UserValidator.Validate enforces the Neo4j username shape/length, requires at least one auth provider (passwordSecretRef or externalAuth), rejects the reserved 'system' username and the 'native' externalAuth provider, and reports a not-yet-applied password Secret as a transient Pending gap rather than a Failed error (internal/validation/user_validator.go).",
+    "description": "UserValidator.Validate enforces the Neo4j username shape/length, requires at least one auth provider (passwordSecretRef or externalAuth), rejects the reserved 'system' username and the 'native' externalAuth provider, WARNS (without rejecting) when the username is the default bootstrap admin 'neo4j' because managing it rewrites the credential the operator itself authenticates with, and reports a not-yet-applied password Secret as a transient Pending gap rather than a Failed error (internal/validation/user_validator.go).",
     "readsFieldIds": [],
     "writesFieldIds": [],
     "callsFunctionIds": [],

--- a/api/v1beta1/neo4jbackup_types.go
+++ b/api/v1beta1/neo4jbackup_types.go
@@ -31,8 +31,10 @@ type Neo4jBackupSpec struct {
 	// Topology-agnostic: the operator resolves cluster vs standalone itself.
 	// Pair it with exactly one scope field — Database (single) or AllDatabases.
 	//
-	// InstanceRef + scope is the preferred API as of v1.13. When InstanceRef is
-	// set it is authoritative and the legacy Target block (below) is ignored.
+	// InstanceRef + scope became the scope API in v1.13, replacing the legacy
+	// `target` block, which has since been removed entirely — there is no
+	// namespace field anywhere on this API, which is what keeps a backup
+	// scoped to its own namespace (docs/knowledge/backup-restore.md rule 80).
 	// +optional
 	InstanceRef string `json:"instanceRef,omitempty"`
 
@@ -546,7 +548,11 @@ type ShardValidationStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Target",type=string,JSONPath=`.spec.target.kind`
+// Instance replaced a dead "Target" column that pointed at `.spec.target.kind`.
+// The legacy `spec.target` block was removed when `instanceRef` became the
+// scope API in v1.13, so that column rendered permanently empty in
+// `kubectl get neo4jbackup`. `.spec.instanceRef` is its direct successor.
+// +kubebuilder:printcolumn:name="Instance",type=string,JSONPath=`.spec.instanceRef`
 // +kubebuilder:printcolumn:name="Schedule",type=string,JSONPath=`.spec.schedule`
 // +kubebuilder:printcolumn:name="LastRun",type=string,JSONPath=`.status.lastRunTime`
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`

--- a/bundle/manifests/neo4j.neo4j.com_neo4jbackups.yaml
+++ b/bundle/manifests/neo4j.neo4j.com_neo4jbackups.yaml
@@ -15,8 +15,8 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .spec.target.kind
-      name: Target
+    - jsonPath: .spec.instanceRef
+      name: Instance
       type: string
     - jsonPath: .spec.schedule
       name: Schedule
@@ -112,8 +112,10 @@ spec:
                   Topology-agnostic: the operator resolves cluster vs standalone itself.
                   Pair it with exactly one scope field — Database (single) or AllDatabases.
 
-                  InstanceRef + scope is the preferred API as of v1.13. When InstanceRef is
-                  set it is authoritative and the legacy Target block (below) is ignored.
+                  InstanceRef + scope became the scope API in v1.13, replacing the legacy
+                  `target` block, which has since been removed entirely — there is no
+                  namespace field anywhere on this API, which is what keeps a backup
+                  scoped to its own namespace (docs/knowledge/backup-restore.md rule 80).
                 type: string
               mode:
                 default: standard

--- a/charts/neo4j-operator/crds/neo4j.neo4j.com_neo4jbackups.yaml
+++ b/charts/neo4j-operator/crds/neo4j.neo4j.com_neo4jbackups.yaml
@@ -15,8 +15,8 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .spec.target.kind
-      name: Target
+    - jsonPath: .spec.instanceRef
+      name: Instance
       type: string
     - jsonPath: .spec.schedule
       name: Schedule
@@ -112,8 +112,10 @@ spec:
                   Topology-agnostic: the operator resolves cluster vs standalone itself.
                   Pair it with exactly one scope field — Database (single) or AllDatabases.
 
-                  InstanceRef + scope is the preferred API as of v1.13. When InstanceRef is
-                  set it is authoritative and the legacy Target block (below) is ignored.
+                  InstanceRef + scope became the scope API in v1.13, replacing the legacy
+                  `target` block, which has since been removed entirely — there is no
+                  namespace field anywhere on this API, which is what keeps a backup
+                  scoped to its own namespace (docs/knowledge/backup-restore.md rule 80).
                 type: string
               mode:
                 default: standard

--- a/config/crd/bases/neo4j.neo4j.com_neo4jbackups.yaml
+++ b/config/crd/bases/neo4j.neo4j.com_neo4jbackups.yaml
@@ -15,8 +15,8 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .spec.target.kind
-      name: Target
+    - jsonPath: .spec.instanceRef
+      name: Instance
       type: string
     - jsonPath: .spec.schedule
       name: Schedule
@@ -112,8 +112,10 @@ spec:
                   Topology-agnostic: the operator resolves cluster vs standalone itself.
                   Pair it with exactly one scope field — Database (single) or AllDatabases.
 
-                  InstanceRef + scope is the preferred API as of v1.13. When InstanceRef is
-                  set it is authoritative and the legacy Target block (below) is ignored.
+                  InstanceRef + scope became the scope API in v1.13, replacing the legacy
+                  `target` block, which has since been removed entirely — there is no
+                  namespace field anywhere on this API, which is what keeps a backup
+                  scoped to its own namespace (docs/knowledge/backup-restore.md rule 80).
                 type: string
               mode:
                 default: standard

--- a/docs/api_reference/neo4jenterprisecluster.md
+++ b/docs/api_reference/neo4jenterprisecluster.md
@@ -358,11 +358,24 @@ issuerRef:
 
 ### ExternalSecretsConfig
 
+Requires [External Secrets Operator](https://external-secrets.io/) to be installed separately —
+the operator only *emits* an `ExternalSecret`; ESO resolves it. A `ClusterSecretStore` works in
+both RBAC modes, because ESO (not this operator) performs the cluster-scoped read — see
+[Operator modes](../user_guide/operator-modes.md).
+
+!!! note "Minimum External Secrets Operator version: v0.17.0"
+
+    The operator emits `apiVersion: external-secrets.io/v1`. ESO **v0.17.0** stopped serving
+    the older `v1beta1`, and this operator previously emitted that older version — so on
+    ESO ≥ 0.17 every emitted `ExternalSecret` was rejected. If you are on ESO < 0.17.0,
+    upgrade ESO (its own [migration guide](https://external-secrets.io/latest/guides/v1beta1/)
+    covers the path) rather than pinning an older operator.
+
 | Field | Type | Description |
 |---|---|---|
 | `enabled` | `bool` | Enable External Secrets integration |
 | `secretStoreRef` | [`*SecretStoreRef`](#secretstoreref) | SecretStore or ClusterSecretStore reference |
-| `refreshInterval` | `string` | Refresh interval (e.g., `"1h"`) |
+| `refreshInterval` | `string` | Refresh interval (e.g., `"1h"`). Defaults to `1h` when unset |
 | `data` | [`[]ExternalSecretData`](#externalsecretdata) | External secret data mappings |
 
 ### SecretStoreRef

--- a/docs/knowledge/backup-restore.md
+++ b/docs/knowledge/backup-restore.md
@@ -334,12 +334,14 @@ survive (verified in `api/v1beta1/neo4jenterprisecluster_types.go`) because
 
 ## Backup scope (v1.13): instanceRef, shardedDatabase, same-namespace
 
-### Rule 80 — Backup target is same-namespace for ALL kinds
-- **Scope:** `internal/validation/backup_validator.go` (`validateBackupTarget`)
-- **Rule:** A cross-namespace `target.namespace` (≠ the `Neo4jBackup` CR's namespace) is rejected for **every** kind (Cluster, Database, ShardedDatabase) — the check lives OUTSIDE the `IsDatabaseScopedBackupKind` branch. The `instanceRef` scope API has no namespace field; it always resolves within the backup CR's own namespace. To back up a cluster in another namespace, create the `Neo4jBackup` in that namespace.
-- **Why:** The check was previously scoped to database-scoped kinds only, silently allowing a `kind: Cluster` backup to target a cluster in another namespace — contradicting the operator's same-namespace blast-radius boundary (`docs/knowledge/operations.md`, the same rule enforced for user/role `clusterRef`). Never re-narrow the check back to database-scoped kinds.
-- **Pinned-by:** `internal/validation/backup_validator_test.go` ("Cluster with cross-namespace target.namespace is rejected" + "ShardedDatabase with cross-namespace target.namespace")
-- **Status:** Enforced
+### Rule 80 — Backup scope is same-namespace (enforced by API shape, NOT by a validator)
+- **Scope:** `api/v1beta1/neo4jbackup_types.go` (`InstanceRef`); `internal/validation/backup_validator.go` (`validateScopeSelection`)
+- **Rule:** a `Neo4jBackup` always backs up a deployment in its **own** namespace. `InstanceRef` names "a Neo4jEnterpriseCluster OR a Neo4jEnterpriseStandalone **in this namespace**" and carries no namespace field. To back up a cluster in another namespace, create the `Neo4jBackup` in that namespace.
+- **Why:** same blast-radius boundary as rule 18 in `docs/knowledge/operations.md` — a backup reads the target's data using the target's admin credentials, so a cross-namespace scope would be a confused-deputy escalation.
+- **How it is actually enforced:** **structurally.** There is no namespace field on the scope API, so there is nothing for a validator to reject. Adding one would silently remove the only enforcement — such a change MUST ship a consent mechanism in the same PR (see rule 18).
+- **Status:** Enforced by API shape. Deliberately not a validator.
+
+> **Correction (2026-08-28).** This rule previously described a function named **validateBackupTarget** (deliberately not backticked — backticks assert a real symbol) rejecting a cross-namespace `spec.target.namespace` "for every kind", pinned to two named tests, with Status "Enforced". **None of it exists.** That function is not defined anywhere; `spec.target` was removed when `instanceRef` replaced it in v1.13 (confirmed absent from the generated CRD schema); and neither pinned test exists in `backup_validator_test.go`. The rule was describing the pre-`instanceRef` API — and even contradicted itself mid-sentence, noting "The `instanceRef` scope API has no namespace field" while claiming a check against `target.namespace`. `scripts/check-knowledge-drift.sh` passed it green because its pin was a real file path plus quoted test-case *names*, neither of which the guard validated (now fixed — see rule 82).
 
 ### Rule 81 — `shardedDatabase` scope; all-databases CATALOGUES sharded families (restorable, not just surfaced)
 - **Scope:** `api/v1beta1/neo4jbackup_types.go` (`ShardedDatabase`, `ResolvedTarget`, `ShardedFamilyArtifacts`, `BackupRun.ShardedFamilies`), `internal/validation/backup_validator.go` (`validateScopeSelection`), `internal/controller/neo4jbackup_log_parser.go` (`parseShardedFamiliesExcludedFromLog`, `groupShardedFamiliesFromLog`), `internal/controller/neo4jbackup_controller.go` (`recordShardedExclusion`), `internal/controller/neo4jshardeddatabase_seed.go` (`resolveShardedSeed`, `findFamilyArtifacts`, `buildPerShardCloudURIs`), `internal/controller/neo4jrestore_alldatabases.go`

--- a/docs/knowledge/operations.md
+++ b/docs/knowledge/operations.md
@@ -141,12 +141,15 @@
 - **pinned-by:** user controller integration specs (pending-dependency + watch re-reconcile).
 - **enforcement:** integration test + code review. Condition constants in `internal/controller/events.go` (`ConditionTypePendingDependencies` L170, `ConditionReasonRolesPending` L178).
 
-### id 18 — Same-namespace `clusterRef` only
-- **scope:** `internal/controller/cluster_resolver.go`; user/role validators in `internal/validation/`
-- **rule:** `clusterRef` for users/roles must be in the same namespace — cross-namespace refs are not supported in v1. Multi-tenant access goes through an opt-in `Neo4jClusterAccessGrant` CR.
-- **why:** Cross-namespace privilege grants are a security boundary; v1 keeps the blast radius inside one namespace.
-- **pinned-by:** validator unit tests (cross-namespace rejection).
-- **enforcement:** validator (inline) + unit test.
+### id 18 — Same-namespace `clusterRef` only (enforced by API shape, NOT by a validator)
+- **scope:** `internal/controller/cluster_resolver.go` (`ResolveClusterRef`); the auth CRD types in `api/v1beta1/`
+- **rule:** `clusterRef` on `Neo4jUser` / `Neo4jRole` / `Neo4jRoleBinding` / `Neo4jAuthRule` always resolves in the CR's **own** namespace. Cross-namespace targeting is not supported.
+- **why:** the operator connects using the *target's* admin Secret, so a cross-namespace ref would let a principal who can write CRs in namespace A mint database credentials on a cluster in namespace B — a confused-deputy escalation across a boundary Kubernetes RBAC is supposed to hold.
+- **how it is actually enforced — read this before changing anything:** **structurally, by API shape.** `clusterRef` is a bare `string` (`api/v1beta1/neo4juser_types.go`, `neo4jrole_types.go`, `neo4jrolebinding_types.go`, `neo4jauthrule_types.go`) and `ResolveClusterRef` is always called with the CR's own `.Namespace`. There is **no validator check and no unit test** for cross-namespace rejection, because there is no namespace field to reject. **Adding a namespace field anywhere in this API silently removes the only enforcement that exists** — such a change MUST ship a consent mechanism (see below) in the same PR.
+- **if this is ever revisited:** the researched answer is a target-namespace grant object shaped like Gateway API's `ReferenceGrant` — deny-by-default, and checked **before** resolving the target, or the CR becomes a cross-namespace existence oracle (Gateway API makes that a MUST). Note the repo has declined this scope in writing: `docs/user_guide/user_role_management.md` ("not by sharing a single CR", plus an explicit non-goal) and `docs/design/aura-orchestration.md` ("Cross-namespace fan-out is out of scope").
+- **enforcement:** API shape only. Deliberately not a validator — there is nothing for one to check.
+
+> **Correction (2026-08-28).** This rule previously claimed enforcement by "validator (inline) + unit test" and routed multi-tenant access through an opt-in CR named **Neo4jClusterAccessGrant** (deliberately not backticked — backticks assert a real symbol, and this one never existed). **Neither exists.** That name appeared exactly once in the repo — in this rule's own text — and no cross-namespace validator or test was ever written. The boundary was real but the stated mechanism was fictional, which is the more dangerous failure: an implementer consulting this rule before adding a namespace field would have been told a guard existed that did not. `scripts/check-knowledge-drift.sh` passed it green because the pin was unbackticked prose (now fixed — see rule 82).
 
 ### id 19 — Identifier quoting in Cypher
 - **scope:** `internal/neo4j/auth_rules.go` (`escapeBackticks` ~L144), `internal/neo4j/users.go`, `internal/neo4j/privileges.go`

--- a/docs/user_guide/guides/cross_cluster_replication.md
+++ b/docs/user_guide/guides/cross_cluster_replication.md
@@ -407,10 +407,70 @@ completes.
 
 ## 4. Downstream: replicate users and roles
 
-Privileges and roles are **not** replicated by CCDR. Apply the same
-`Neo4jUser` / `Neo4jRole` / `Neo4jRoleBinding` CRs to the downstream cluster
-that you apply upstream — with `clusterRef` pointed at the DR cluster. The
-operator makes this a copy-paste rather than a manual re-creation.
+Users, roles, and privileges are **not** replicated by CCDR — you apply the
+same CRs to the downstream cluster yourself, with `clusterRef` pointed at the
+DR cluster.
+
+!!! danger "`Neo4jRole` privileges do NOT copy verbatim — they name the database"
+
+    The replica database is called `foo-replica`, not `foo` (see [step 2](#2-downstream-create-the-replica):
+    Cypher has no `RENAME DATABASE`, so it keeps that name permanently). And
+    **privileges attach to the database, not the alias** — see
+    [Aliases and privileges](database_aliases.md#aliases-and-privileges).
+
+    So a privilege copied verbatim grants access to a database that does not
+    exist on the DR cluster. **Neo4j accepts this without complaint**: the
+    `Neo4jRole` reconciles to `Ready`, `enforcePrivileges: true` holds it
+    there, and your dashboards stay green while DR authorization is silently
+    broken — the exact failure DR exists to prevent.
+
+    Rewrite every database name in `spec.privileges` to the replica's name.
+
+What copies, and what does not:
+
+| CR | Copies verbatim? | Why |
+|---|---|---|
+| `Neo4jRoleBinding` | ✅ Yes | names only users and roles — no database names |
+| `Neo4jUser` | ✅ Yes | `spec.roles` are role names. `spec.homeDatabase` accepts a database **or an alias**, so the failover alias from [step 3](#3-downstream-pre-stage-the-failover-alias) resolves it correctly — provided you created it |
+| `Neo4jRole` | ❌ **No** | `spec.privileges` are complete Cypher statements with the database name embedded. The alias does **not** help here |
+
+Rewriting a role for the DR cluster:
+
+```yaml
+# UPSTREAM (namespace: prod) — privileges name the database `foo`
+spec:
+  clusterRef: prod-cluster
+  name: analytics_reader
+  privileges:
+    - "GRANT ACCESS ON DATABASE foo TO analytics_reader"
+    - "GRANT MATCH {*} ON GRAPH foo NODES * TO analytics_reader"
+---
+# DOWNSTREAM (namespace: dr) — clusterRef AND every database name change
+spec:
+  clusterRef: dr-cluster
+  name: analytics_reader
+  privileges:
+    - "GRANT ACCESS ON DATABASE `foo-replica` TO analytics_reader"
+    - "GRANT MATCH {*} ON GRAPH `foo-replica` NODES * TO analytics_reader"
+```
+
+Because the replica keeps the name `foo-replica` **after promotion too**, these
+privileges stay correct through failover — there is nothing to edit during the
+outage.
+
+!!! tip "Verify, don't assume"
+
+    A wrong database name here fails silently. After applying, confirm the
+    privileges actually landed on the replica:
+
+    ```bash
+    kubectl exec -n dr <dr-cluster-server-0> -c neo4j -- \
+      cypher-shell -u neo4j -p <password> --access-mode=read \
+      "SHOW ROLE analytics_reader PRIVILEGES AS COMMANDS"
+    ```
+
+    Every returned statement should name `foo-replica`. A statement naming
+    `foo` is the silent-failure case above.
 
 ---
 

--- a/internal/resources/cluster.go
+++ b/internal/resources/cluster.go
@@ -890,7 +890,18 @@ func buildExternalSecret(cluster *neo4jv1beta1.Neo4jEnterpriseCluster, esConfig 
 	}
 
 	return map[string]any{
-		"apiVersion": "external-secrets.io/v1beta1",
+		// external-secrets.io/v1, NOT v1beta1: External Secrets Operator
+		// v0.17.0 stopped SERVING v1beta1, so an ExternalSecret emitted with
+		// the old apiVersion is rejected outright by any ESO >= 0.17 — the
+		// integration simply did not work there.
+		//
+		// The spec fields below (secretStoreRef, target, refreshInterval,
+		// data[].remoteRef) are unchanged between v1beta1 and v1 — verified
+		// against the published v1 API reference, not assumed. Because this
+		// object is built as unstructured map[string]any there is no
+		// compile-time check on any of it; the apiVersion is pinned by
+		// TestBuildExternalSecret_UsesServedAPIVersion.
+		"apiVersion": "external-secrets.io/v1",
 		"kind":       "ExternalSecret",
 		"metadata": map[string]any{
 			"name":      fmt.Sprintf("%s-%s-external-secret", cluster.Name, secretType),

--- a/internal/resources/cluster_test.go
+++ b/internal/resources/cluster_test.go
@@ -1551,3 +1551,60 @@ func TestServiceDNSName(t *testing.T) {
 			"user-supplied annotation must take precedence over the typed dnsName field")
 	})
 }
+
+// TestBuildExternalSecret_UsesServedAPIVersion pins the apiVersion the
+// operator emits for ExternalSecret objects.
+//
+// This exists because the operator shipped `external-secrets.io/v1beta1` long
+// after External Secrets Operator v0.17.0 stopped SERVING that version, so
+// every ExternalSecret it emitted was rejected by any current ESO — the
+// integration was silently broken. Nothing caught it: the object is built as
+// an unstructured map[string]any, so there is no compile-time check, and no
+// test asserted the string.
+//
+// Both builders share one helper, so both are pinned here.
+func TestBuildExternalSecret_UsesServedAPIVersion(t *testing.T) {
+	esConfig := &neo4jv1beta1.ExternalSecretsConfig{
+		Enabled: true,
+		SecretStoreRef: &neo4jv1beta1.SecretStoreRef{
+			Name: "vault-store",
+			Kind: "ClusterSecretStore",
+		},
+		Data: []neo4jv1beta1.ExternalSecretData{
+			{
+				SecretKey: "password",
+				RemoteRef: &neo4jv1beta1.ExternalSecretRemoteRef{Key: "neo4j/admin", Property: "password"},
+			},
+		},
+	}
+
+	cluster := &neo4jv1beta1.Neo4jEnterpriseCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "prod", Namespace: "ns"},
+		Spec: neo4jv1beta1.Neo4jEnterpriseClusterSpec{
+			AcceptLicenseAgreement: "eval",
+			Topology:               neo4jv1beta1.TopologyConfiguration{Servers: 2},
+			TLS:                    &neo4jv1beta1.TLSSpec{Mode: "cert-manager", ExternalSecrets: esConfig},
+			Auth:                   &neo4jv1beta1.AuthSpec{ExternalSecrets: esConfig},
+		},
+	}
+
+	for name, got := range map[string]map[string]any{
+		"tls":  resources.BuildExternalSecretForTLS(cluster),
+		"auth": resources.BuildExternalSecretForAuth(cluster),
+	} {
+		require.NotNil(t, got, "%s ExternalSecret should be built when enabled", name)
+		assert.Equal(t, "external-secrets.io/v1", got["apiVersion"],
+			"%s: must emit the SERVED apiVersion — ESO >= 0.17.0 rejects v1beta1 outright", name)
+		assert.Equal(t, "ExternalSecret", got["kind"])
+
+		// The fields below are the ones verified as unchanged between v1beta1
+		// and v1; assert they are still populated so a future apiVersion bump
+		// cannot silently drop one.
+		spec, ok := got["spec"].(map[string]any)
+		require.True(t, ok, "%s: spec should be a map", name)
+		assert.Contains(t, spec, "secretStoreRef")
+		assert.Contains(t, spec, "target")
+		assert.Contains(t, spec, "refreshInterval")
+		assert.Contains(t, spec, "data")
+	}
+}

--- a/internal/validation/user_validator.go
+++ b/internal/validation/user_validator.go
@@ -62,10 +62,38 @@ var neo4jUsernamePattern = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_.@\-]*$`)
 
 const maxNeo4jUsernameLength = 65
 
-// reservedUsernames are usernames the operator refuses to manage to prevent
-// accidentally locking the operator out of the cluster.
+// reservedUsernames are usernames the operator refuses to manage outright.
+//
+// NOTE: this set does NOT protect the bootstrap admin account — see
+// riskyUsernames below for why that is a warning rather than a rejection.
 var reservedUsernames = map[string]struct{}{
 	"system": {}, // not a real user but a reserved keyword
+}
+
+// riskyUsernames are managed only with a loud warning: taking one over is
+// legal, occasionally deliberate, and a good way to lock the operator out of
+// the cluster it is managing.
+//
+// `neo4j` is the default bootstrap admin — the username the operator itself
+// authenticates as when the admin Secret carries no explicit `username`
+// (internal/neo4j/client.go, getCredentials). An `ALTER USER neo4j SET
+// PASSWORD` invalidates the credential every later reconcile depends on, and
+// there is no recovery path inside the operator: the admin Secret must be
+// repaired by hand.
+//
+// Warning rather than error, deliberately. docs/user_guide/user_role_management.md
+// documents the bootstrap admin as "technically manageable, but ... risky ...
+// Prefer leaving it alone", so rejecting it would contradict shipped guidance
+// and break anyone doing it on purpose. This matches the house precedent for
+// the same shape — a Neo4jDatabase named `neo4j` is allowed with a warning.
+//
+// Limitation, stated plainly: this matches the DEFAULT admin username only. A
+// cluster whose admin Secret sets a custom `username` carries the identical
+// risk under that name and will not be warned about here — checking it would
+// mean reading the target's admin Secret from the validator, which is more
+// machinery than a warning justifies.
+var riskyUsernames = map[string]struct{}{
+	"neo4j": {},
 }
 
 // Validate runs all checks on a Neo4jUser spec.
@@ -86,6 +114,13 @@ func (v *UserValidator) Validate(ctx context.Context, user *neo4jv1beta1.Neo4jUs
 		result.Errors = append(result.Errors, field.Forbidden(
 			field.NewPath("spec", "username"),
 			fmt.Sprintf("%q is reserved", username)))
+	}
+
+	if _, risky := riskyUsernames[strings.ToLower(username)]; risky {
+		result.Warnings = append(result.Warnings, fmt.Sprintf(
+			"%q is the default bootstrap admin account this operator authenticates as; managing it "+
+				"here will rewrite its password and invalidate the cluster's admin Secret, locking the "+
+				"operator out with no automatic recovery. Prefer a dedicated username.", username))
 	}
 
 	// At least one auth provider (password Secret OR ExternalAuth) must be set.

--- a/internal/validation/user_validator_test.go
+++ b/internal/validation/user_validator_test.go
@@ -191,6 +191,60 @@ func TestUserValidator_PublicWarning(t *testing.T) {
 	}
 }
 
+// TestUserValidator_BootstrapAdminWarnsNotRejected pins the lockout guard for
+// the default bootstrap admin account. Managing `neo4j` rewrites the password
+// the operator itself authenticates with, and there is no in-operator
+// recovery — but docs/user_guide/user_role_management.md documents it as
+// "technically manageable ... Prefer leaving it alone", so this must WARN and
+// still reconcile, never reject. Rejecting would contradict shipped guidance
+// and break anyone doing it deliberately.
+func TestUserValidator_BootstrapAdminWarnsNotRejected(t *testing.T) {
+	cl := newUserValidatorClient(t, sampleCluster(), samplePasswordSecret("creds"))
+	v := NewUserValidator(cl)
+	user := &neo4jv1beta1.Neo4jUser{
+		ObjectMeta: metav1.ObjectMeta{Name: "bootstrap", Namespace: "ns"},
+		Spec: neo4jv1beta1.Neo4jUserSpec{
+			ClusterRef:        "c",
+			Username:          "neo4j",
+			PasswordSecretRef: &neo4jv1beta1.SecretKeyRef{Name: "creds"},
+		},
+	}
+	res := v.Validate(context.Background(), user)
+
+	if len(res.Errors) != 0 {
+		t.Fatalf("managing the bootstrap admin must not be rejected, got errors: %v", res.Errors)
+	}
+	var found bool
+	for _, w := range res.Warnings {
+		if strings.Contains(w, "locking the operator out") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a lockout warning naming the consequence, got %v", res.Warnings)
+	}
+}
+
+// TestUserValidator_ReservedUsernameStillRejected guards the boundary between
+// riskyUsernames (warn) and reservedUsernames (reject) — widening the warning
+// set must not accidentally downgrade a hard rejection.
+func TestUserValidator_ReservedUsernameStillRejected(t *testing.T) {
+	cl := newUserValidatorClient(t, sampleCluster(), samplePasswordSecret("creds"))
+	v := NewUserValidator(cl)
+	user := &neo4jv1beta1.Neo4jUser{
+		ObjectMeta: metav1.ObjectMeta{Name: "sys", Namespace: "ns"},
+		Spec: neo4jv1beta1.Neo4jUserSpec{
+			ClusterRef:        "c",
+			Username:          "system",
+			PasswordSecretRef: &neo4jv1beta1.SecretKeyRef{Name: "creds"},
+		},
+	}
+	res := v.Validate(context.Background(), user)
+	if len(res.Errors) == 0 {
+		t.Fatal("expected `system` to remain a hard rejection")
+	}
+}
+
 // TestUserValidator_MissingSecretIsPendingNotFailed pins #259: a not-yet-applied
 // password Secret is a TRANSIENT dependency — it must land in result.Pending
 // (routing the user to phase Pending, like missing roles) instead of

--- a/scripts/check-knowledge-drift.sh
+++ b/scripts/check-knowledge-drift.sh
@@ -115,6 +115,73 @@ ${PATH_REFS}
 EOF
 fi
 
+# --- Pass 3: CRD-kind / Go identifier refs -----------------------------------
+# Extract backticked `Neo4jXxx` identifiers and assert each appears somewhere in
+# the Go source. Added after two knowledge rules were found citing things that
+# did not exist: rule 18 routed multi-tenant access through an opt-in CR name
+# that appeared exactly once in the whole repo — in that rule's own text.
+#
+# Deliberately a substring existence check against the WHOLE Go tree, not an
+# exact-symbol check against api/v1beta1/ only: `Neo4jUserReconciler` (controller)
+# and `Neo4jBackupStatus` (types) are both legitimate, and the goal is catching
+# names that exist NOWHERE, with zero false positives on real ones.
+#
+# Convention this enforces: backticks assert a real symbol. A correction note
+# discussing something that never existed must NOT backtick it.
+GO_SRC_FILES="$(git ls-files '*.go' | grep -Ev '(^|/)\.claude/worktrees/' || true)"
+
+KIND_REFS="$(grep -hoE '`Neo4j[A-Za-z0-9_]+`' ${KNOWLEDGE_FILES} 2>/dev/null \
+  | tr -d '`' \
+  | sort -u || true)"
+
+if [ -n "${KIND_REFS}" ] && [ -n "${GO_SRC_FILES}" ]; then
+  while IFS= read -r sym; do
+    [ -z "${sym}" ] && continue
+    checked=$((checked + 1))
+    # shellcheck disable=SC2086
+    if ! printf '%s\n' ${GO_SRC_FILES} | tr '\n' '\0' \
+        | xargs -0 grep -l "${sym}" >/dev/null 2>&1; then
+      echo "WARN [knowledge-drift]: identifier \`${sym}\` not found in any .go file" >&2
+      unresolved=$((unresolved + 1))
+    fi
+  done <<EOF
+${KIND_REFS}
+EOF
+fi
+
+# --- Pass 4: quoted test-case names on "Pinned-by" lines ---------------------
+# Ginkgo/table test cases are pinned by their DESCRIPTION, not a Go symbol, e.g.
+#   **Pinned-by:** `foo_test.go` ("Cluster with cross-namespace target is rejected")
+# Pass 1 only sees backticked `TestXxx` symbols, so these slipped through — which
+# is how rule 80 kept a green check while pinning two tests that did not exist.
+#
+# Scoped tightly to keep false positives at zero: only double-quoted spans on a
+# line that actually declares a pin, at least 20 characters, and containing a
+# space (a test-case description reads like prose). That filter admits real
+# descriptions while excluding the "4G" / "kubectl" / "p" noise that quoting
+# produces elsewhere on those lines. Matched with grep -F: descriptions contain
+# regex metacharacters (+, ., *) and must be compared literally.
+CASE_PINS="$(grep -hiE '^[[:space:]]*[-*]?[[:space:]]*\*\*?[Pp]inned.?by' ${KNOWLEDGE_FILES} 2>/dev/null \
+  | grep -oE '"[^"]{20,}"' \
+  | tr -d '"' \
+  | grep ' ' \
+  | sort -u || true)"
+
+if [ -n "${CASE_PINS}" ] && [ -n "${TEST_GO_FILES}" ]; then
+  while IFS= read -r desc; do
+    [ -z "${desc}" ] && continue
+    checked=$((checked + 1))
+    # shellcheck disable=SC2086
+    if ! printf '%s\n' ${TEST_GO_FILES} | tr '\n' '\0' \
+        | xargs -0 grep -lF "${desc}" >/dev/null 2>&1; then
+      echo "WARN [knowledge-drift]: test-case pin \"${desc}\" not found in any *_test.go" >&2
+      unresolved=$((unresolved + 1))
+    fi
+  done <<EOF
+${CASE_PINS}
+EOF
+fi
+
 # --- Verdict -----------------------------------------------------------------
 if [ "${unresolved}" -ne 0 ]; then
   echo "" >&2


### PR DESCRIPTION
## Why this exists

Investigating a request to automate CCDR's manual "replicate users and roles to the DR
cluster" step concluded the feature **should not be built yet** — and surfaced six real
defects in the tree along the way. This PR is those fixes; the feature is deferred with its
reasons recorded.

**The finding that changed the answer.** Copying a `Neo4jRole` to a DR cluster is *incorrect*,
independent of how it's automated. `spec.privileges` are complete Cypher statements with the
database name embedded (`GRANT ACCESS ON DATABASE foo TO analytics_reader`); the replica
database is `foo-replica` (Cypher has no `RENAME DATABASE`); and privileges attach to the
**database, not the alias**. Neo4j accepts the grant against a non-existent database without
complaint, so the CR reports `Ready`, `enforcePrivileges: true` holds it there, and dashboards
stay green while DR authorization is broken — the exact failure DR exists to prevent.

This defeats every candidate design equally: they all rewrite `clusterRef`, which turns out to
be the *easy* field. The load-bearing rewrite is a substring inside a Cypher string.

## What's fixed

| # | Fix | Severity |
|---|---|---|
| 1 | **CCDR guide step 4** told users to copy auth CRs verbatim — silently breaking DR auth. Replaced with a per-CR breakdown, worked example, and a verify command. **Regression introduced in #348.** | user-facing correctness |
| 2 | **Bootstrap-admin lockout.** `reservedUsernames` carries a comment about "preventing accidentally locking the operator out" and omitted `neo4j` — the actual default admin. Now warns. | safety |
| 3 | **Knowledge rule 18** routed multi-tenant access through a CRD that appears exactly once in the repo: in its own text. Claimed validator + test enforcement; neither exists. | false documentation |
| 4 | **Knowledge rule 80** (Status "Enforced") described a validator, a `spec.target.namespace` field, and two tests that all no longer exist — and contradicted itself mid-sentence. | false documentation |
| 5 | **`check-knowledge-drift.sh`** passed both of the above green. Two new passes added. | guard gap |
| 6 | **ESO integration broken.** Emitted `external-secrets.io/v1beta1`; ESO stopped serving it at v0.17.0, so every `ExternalSecret` was rejected on any current ESO. | functional bug |
| 7 | **Dead printcolumn.** `kubectl get neo4jbackup` had a permanently empty `Target` column pointing at `.spec.target.kind`, removed in v1.13. | user-facing |

### Notes on judgement calls

- **Fix 2 warns rather than rejects.** `user_role_management.md` documents the bootstrap admin
  as *"technically manageable, but … risky … Prefer leaving it alone"*, so rejecting would
  contradict shipped guidance and break deliberate use. Matches the house precedent — a
  `Neo4jDatabase` named `neo4j` is allowed with a warning. The code states its limitation
  plainly: it matches the *default* admin username only.
- **Fix 5's new passes were measured before being wired in** — both produce zero false
  positives across the current knowledge base, and the guard was proven by reintroducing both
  old rules into a tracked file and watching it fail with exactly the two expected warnings.
  It also caught my own correction note for backticking a phantom, which is now the stated
  convention: backticks assert a real symbol.
- **Fix 6's field compatibility was verified against the published v1 API reference**, not
  assumed. Both builders share one helper, so one change covers both.

## Deferred, not abandoned

The fan-out feature is blocked on the database-name rewrite above, plus two blockers found in
every candidate design and now recorded in rule 18:

- **Destructive adoption** — fanning out to a target where the user/role already exists
  converges it destructively on first reconcile (`diffRoles` revokes every role not in spec
  with only a `PUBLIC` guard; `enforcePrivileges` defaults `true`).
- **Cross-namespace consent** — cross-namespace targeting makes the operator a confused deputy
  (it reads the *target's* admin Secret). Researched answer: a ReferenceGrant-shaped
  deny-by-default grant in the target namespace, checked *before* resolving the target.

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `make test-unit` green, including 3 new tests (bootstrap-admin warns / `system` still
      rejected / ESO apiVersion pinned)
- [x] `make lint` — 0 issues
- [x] `make check-drift`, `check-apiref-drift`, `check-crd-catalog` clean
- [x] `scripts/check-knowledge-drift.sh` — 220 references resolve; **proven to fail** on the
      reintroduced old rules
- [x] Strict `mkdocs build` clean, new cross-links resolve
- [ ] No live-cluster run — every change is docs, validation, or a builder string, all covered
      by unit tests and the drift gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)