### PR TITLE
feat: multi-cluster fleet metric label + GitOps fan-out guide + hub/spoke design analysis

### DIFF
--- a/.gitmir/model/apiRoutes.json
+++ b/.gitmir/model/apiRoutes.json
@@ -4,7 +4,7 @@
     "method": "GET",
     "path": "/metrics",
     "name": "Operator metrics",
-    "description": "Prometheus metrics endpoint for the operator's own controller-runtime manager (neo4j_operator_server_health and friends), bound to --metrics-bind-address (default :8080).",
+    "description": "Prometheus metrics endpoint for the operator's own controller-runtime manager (neo4j_operator_server_health and friends), bound to --metrics-bind-address (default :8080). neo4j_operator_server_health additionally carries a k8s_cluster label naming the Kubernetes cluster this operator instance runs in, set via --kubernetes-cluster-name; it is empty unless that flag is supplied, so scrapes from several clusters can be federated without series colliding.",
     "serverUnitId": "su-platform-manager",
     "moduleId": "mod-platform",
     "auth": false

--- a/.gitmir/model/index.json
+++ b/.gitmir/model/index.json
@@ -11,6 +11,6 @@
     "statusFlows": 9,
     "reactions": 2
   },
-  "at": "2026-08-28T10:27:08Z",
+  "at": "2026-08-31T08:34:44Z",
   "project": "neo4j-kubernetes-operator"
 }

--- a/charts/neo4j-operator/templates/_helpers.tpl
+++ b/charts/neo4j-operator/templates/_helpers.tpl
@@ -203,5 +203,8 @@ Get container args based on configuration
 - --metrics-bind-address=0
 {{- end }}
 - --health-probe-bind-address=:8081
+{{- if .Values.kubernetesClusterName }}
+- --kubernetes-cluster-name={{ .Values.kubernetesClusterName }}
+{{- end }}
 
 {{- end }}

--- a/charts/neo4j-operator/values.yaml
+++ b/charts/neo4j-operator/values.yaml
@@ -28,6 +28,17 @@ watchNamespaces: []
 developmentMode: false
 logLevel: info  # debug, info, warn, error
 
+# Name of the Kubernetes cluster this operator instance runs in. When set, every
+# neo4j_operator_server_health series carries it as the `k8s_cluster` label, so
+# metrics federated from several Kubernetes clusters into one Prometheus stay
+# distinguishable even when the Neo4j cluster name and namespace are identical
+# in each. Empty (the default) emits an empty label, which Prometheus treats as
+# absent — existing queries and dashboards are unaffected.
+#
+# NOT the same thing as the `cluster_name` label, which means the *Neo4j*
+# cluster. See docs/user_guide/guides/multi_cluster.md.
+kubernetesClusterName: ""
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -36,6 +36,7 @@ import (
 
 	neo4jv1beta1 "github.com/priyolahiri/neo4j-kubernetes-operator/api/v1beta1"
 	"github.com/priyolahiri/neo4j-kubernetes-operator/internal/controller"
+	operatormetrics "github.com/priyolahiri/neo4j-kubernetes-operator/internal/metrics"
 	"github.com/priyolahiri/neo4j-kubernetes-operator/internal/validation"
 
 	certv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -153,6 +154,12 @@ func main() {
 		enableLeaderElection = flag.Bool("leader-elect", false, "Enable leader election for controller manager.")
 		secureMetrics        = flag.Bool("metrics-secure", false, "If set the metrics endpoint is served securely")
 
+		// Identifies which Kubernetes cluster this operator instance runs in,
+		// so metrics scraped from several clusters into one Prometheus stay
+		// distinguishable. Deliberately not --cluster-name: `cluster_name` is
+		// already an established metric label meaning the *Neo4j* cluster.
+		kubernetesClusterName = flag.String("kubernetes-cluster-name", "", "Name of the Kubernetes cluster this operator runs in; emitted as the k8s_cluster metric label (default: unset, label empty)")
+
 		// Development mode specific flags
 		// Must stay in sync with the dev controller registry in
 		// setupDevelopmentControllers — a key that is registered but missing here
@@ -171,6 +178,10 @@ func main() {
 	opts := zap.Options{Development: true}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
+
+	// Must happen before the manager starts so that no controller records a
+	// metric before the label is available.
+	operatormetrics.SetKubernetesClusterName(*kubernetesClusterName)
 
 	// Validate and normalize mode
 	operatorMode := OperatorMode(strings.ToLower(*mode))

--- a/docs/design/multi-cluster-control-plane.md
+++ b/docs/design/multi-cluster-control-plane.md
@@ -1,0 +1,548 @@
+# Design: Multi-Kubernetes-Cluster Control Plane (hub/spoke)
+
+> **Status:** Analysis, plus the two cheapest delivery items shipped
+> (§8 items 1–2: the GitOps fan-out guide and the `k8s_cluster` metric label).
+> The hub itself is unbuilt, and §5 argues that the literal reading of the
+> request should not be built.
+> **Source:** this repository, read at commit `33a3204`; the CCDR design
+> (`cross-cluster-replication.md`), whose B1 recurs here in a worse form;
+> controller-runtime v0.24.1 (`go.mod:22`).
+> **Scope of this document:** what it would take for **one operator instance to
+> manage Neo4j across N Kubernetes clusters**. It covers the Kubernetes API
+> plane, the Bolt data plane, the CRD-surface consequences, and four delivery
+> options. It does **not** cover cross-cluster *replication* — that is CCDR, it
+> already shipped, and it is a different question (§1.1).
+> **Headline:** the Kubernetes API half is cheap and mechanically supported —
+> the operator has no `remotecommand`/exec dependency, and controller-runtime
+> ships per-cluster caches. The **Bolt half is the blocker**, and it is
+> [B1 from the CCDR design](cross-cluster-replication.md#b1--advertised-addresses-are-hardcoded-to-in-cluster-dns-network-only-the-real-blocker)
+> again: the operator is a Neo4j client as well as a Kubernetes client, its
+> connection URIs are hardcoded to in-cluster DNS, and the `neo4j://` routing
+> scheme means exposing a Service does not fix it — the server hands back
+> internal FQDNs. CCDR bought its way out with an opt-in L4 proxy scoped to one
+> port. A hub would need the same machinery on the Bolt ports, for every
+> managed cluster, mandatorily, and per-pod. **Recommended: option (c) — an
+> aggregation-only hub (§5), which needs none of it.**
+
+---
+
+## 1. What "multi-cluster" is being asked for here
+
+Four distinct questions hide under the phrase. This document is about the third.
+
+1. **One Neo4j cluster stretched across Kubernetes clusters** — one DBMS, one
+   RAFT group, servers in different Kubernetes clusters. Out of scope, and
+   argued against in §9 Q1.
+2. **Independent Neo4j clusters replicating** — shipped, as CCDR. See
+   `cross-cluster-replication.md`.
+3. **One operator managing N Kubernetes clusters** — a hub/spoke control
+   plane. **This document.**
+4. **Fleet visibility across clusters** — partially answered already by
+   `spec.auraFleetManagement` (`api/v1beta1/fleet_target.go`), which registers
+   deployments with Aura Fleet Manager. The gap is that it is Aura-tied; §5
+   covers the non-Aura form, because it turns out to be the *same* work as the
+   recommended option.
+
+### 1.1 Why (3) is not (2)
+
+CCDR moves **data** between Neo4j clusters. A hub moves **intent** between
+Kubernetes clusters. They share exactly one thing — the discovery that Neo4j
+addresses are pinned to in-cluster DNS — and that shared blocker is the reason
+this document exists at all. Nothing in the shipped CCDR proxy helps a hub:
+`spec.crossClusterReplication` fronts port 6000 (transaction shipping) and
+deliberately leaves 7687/7688 alone.
+
+---
+
+## 2. What this operator already provides
+
+The Kubernetes-API side of a hub is in better shape than expected.
+
+- **No exec, no port-forward, no SPDY.** `rest.Config` and `clientcmd` appear
+  in exactly two files — `cmd/main.go` and `internal/controller/suite_test.go`.
+  There is no `remotecommand` usage in production code at all. Every controller
+  interacts with Kubernetes purely through a `client.Client`, which is the one
+  abstraction that retargets cleanly.
+- **Uniform client injection.** All ~26 controllers are constructed with
+  `Client: mgr.GetClient()` in one contiguous block (`cmd/main.go:342-497`),
+  and every validator likewise (`validation.NewClusterValidator(mgr.GetClient())`
+  and siblings). There is a single seam to change, not a scattering.
+- **controller-runtime supports it.** `cluster.New(*rest.Config, ...) (Cluster, error)`
+  exists (`pkg/cluster/cluster.go:148`), `Cluster` is a `Runnable` that can be
+  added to a manager, and `source.Kind` takes an **explicit cache**
+  (`pkg/source/source.go:76`) — so watching a remote cluster's objects is a
+  supported composition, not a fork.
+- **Namespace scoping already parameterised.** `WATCH_NAMESPACE`
+  (`cmd/main.go:278`) already models "reconcile a subset", which is the right
+  shape to extend per remote cluster.
+- **An external Bolt hostname can already be a certificate SAN.**
+  `spec.service.dnsName` is enumerated by `BuildCertificateForEnterprise`, so
+  the SAN half of B8 is not a new build.
+
+Consequence: **if the operator only ever spoke to the Kubernetes API, a hub
+would be a straightforward refactor.** It does not.
+
+---
+
+## 3. Blockers
+
+Ranked. B1–B3 are the data-plane blockers and are the substance of this
+document. B4–B7 are structural costs that no design removes, only relocates.
+
+### B1 — The Bolt connection is hardcoded to in-cluster DNS *(the real blocker)*
+
+`internal/neo4j/client.go:2793-2808`:
+
+```go
+func buildConnectionURIForEnterprise(cluster *neo4jv1beta1.Neo4jEnterpriseCluster) string {
+	scheme := "neo4j"
+	if cluster.Spec.TLS != nil && cluster.Spec.TLS.Mode == "cert-manager" {
+		scheme = "neo4j+s"
+	}
+	host := fmt.Sprintf("%s-client.%s.svc.cluster.local", cluster.Name, cluster.Namespace)
+	port := 7687
+	...
+}
+```
+
+A hub in Kubernetes cluster A cannot resolve that name for a Neo4j deployment
+in cluster B, and there is no field to override it. This is not one call site
+in an obscure corner: **21 non-test files under `internal/controller/`
+construct a Neo4j client**, and they fall into two groups that matter
+differently.
+
+*Data-plane CRDs* — `Neo4jDatabase`, `Neo4jDatabaseAlias`, `Neo4jUser`,
+`Neo4jRole`, `Neo4jRoleBinding`, `Neo4jAuthRule`, `Neo4jShardedDatabase`,
+`Neo4jReplicaDatabase`, `Neo4jReplicaPromotion`, `Neo4jRestore`. Bolt *is*
+their implementation; without it they have no behaviour at all.
+
+*Cluster lifecycle operations* — and this is the group that is easy to miss:
+`rolling_upgrade.go`, `scale_down.go`, `splitbrain_detector.go`,
+`plugin_controller.go`, `neo4jbackup_sharded.go`, `diagnostics_databases.go`,
+`diagnostics_users_roles.go`, and both the cluster and standalone controllers
+themselves (`neo4jenterprisecluster_controller.go:639`). Draining a server
+before scale-down, sequencing a rolling upgrade, and detecting split-brain are
+all Cypher operations. **The infrastructure controllers are not Bolt-free
+either**, which is what forecloses option (b) below.
+
+A hub that can reach the Kubernetes API but not Bolt can create a StatefulSet
+in a remote cluster and cannot create a database in it. That is Argo with extra
+credentials (§4d).
+
+### B2 — The routing scheme means exposing a Service is not sufficient
+
+The URI above uses `neo4j://` (or `neo4j+s://`), the **routing** scheme. The
+driver opens one connection, calls `dbms.routing.getRoutingTable`, and then
+connects to whatever addresses the server returns. Those come from
+`server.routing.advertised_address`, pinned in
+`internal/resources/cluster.go:2363`:
+
+```
+server.routing.advertised_address=${HOSTNAME_FQDN}:7688
+```
+
+where `HOSTNAME_FQDN` is the internal pod FQDN. So a hub that reaches an
+externally-published client Service still receives internal FQDNs in the
+routing table and fails on the second hop.
+
+**This is CCDR's B1, restated on the Bolt path.** The CCDR analysis established
+the general form — "the downstream connects to a listed address, receives an
+internal FQDN in reply, and fails … there is no workaround on the listing
+side." The same reasoning applies unchanged here, with one aggravating
+difference: CCDR made its fix **opt-in** and confined it to port 6000, so
+clusters that do not replicate pay nothing. A hub needs the equivalent on the
+Bolt ports for **every** cluster it manages, or it manages none of them.
+
+`internal/validation/config_validator.go:86-89` additionally refuses any
+`*.advertised_address` override through `spec.config`
+(`operatorRuntimeManagedSettings`), so this cannot be worked around by
+configuration — it requires operator-side support, exactly as
+`spec.crossClusterReplication` did.
+
+### B3 — Split-brain detection and diagnostics need *per-pod* Bolt, not one endpoint
+
+`internal/controller/splitbrain_detector.go:232`:
+
+```go
+podURL := fmt.Sprintf("%s://%s.%s-headless.%s.svc.cluster.local:7687", ...)
+```
+
+The detector deliberately bypasses routing to compare each server's individual
+view of the cluster — that is the whole mechanism. So the exposure requirement
+is not "one reachable endpoint per cluster" but **N reachable endpoints per
+cluster**, addressable per ordinal.
+
+That is precisely the shape the CCDR proxy solves for port 6000 — one HAProxy
+listening on `16000+i` per ordinal, because "a plain Kubernetes Service cannot
+do per-ordinal port-to-specific-pod mapping." A hub would need the identical
+construction on 7687. The work is understood and already has prior art in this
+repo (`internal/resources/ccdr_proxy.go`); it is the *mandatoriness* and the
+per-cluster cost that is the problem, not the novelty.
+
+Degraded alternative: run the hub with split-brain detection and live
+diagnostics disabled for remote clusters. That is a real option, and it should
+be stated plainly rather than discovered — it means **the hub silently offers
+less safety than a local operator**, on exactly the clusters an operator is
+least able to watch by hand.
+
+### B4 — Every `clusterRef` is same-cluster by construction
+
+`ResolvedTarget` and `NewClient(c client.Client)`
+(`internal/controller/cluster_resolver.go`) resolve a `clusterRef` with a live
+`Get` against the operator's own API server, then build a Neo4j client from the
+result. Adding a cluster dimension means:
+
+- a new field on `clusterRef` for **every** dependent CRD — `Neo4jDatabase`,
+  `Neo4jDatabaseAlias`, `Neo4jUser`, `Neo4jRole`, `Neo4jRoleBinding`,
+  `Neo4jAuthRule`, `Neo4jBackup`, `Neo4jRestore`, `Neo4jReplicaDatabase`,
+  `Neo4jReplicaPromotion`, `Neo4jShardedDatabase`;
+- the same change in each corresponding validator, all of which are constructed
+  with `mgr.GetClient()` today. **A validator that silently resolves against
+  the hub's own cluster is the worst bug in this design space** — it reports
+  success against the wrong cluster, which no user will suspect;
+- for each CRD, the full hand-written surface list from `CLAUDE.md`:
+  `docs/api_reference/`, `docs/index.md`, README, mkdocs nav, ArgoCD health
+  checks, the CSV owned-resources list, the `helm-sync-artifacthub-crds.sh`
+  `describe()` row, and `config/samples/`.
+
+This is the cost that makes option (a) unattractive independent of B1–B3.
+
+### B5 — Credential aggregation changes the blast radius
+
+The hub holds N kubeconfigs **and** N Neo4j admin Secrets. Today an admin
+Secret lives in the same cluster as the database it unlocks; a hub requires a
+copy centrally. For the deployments that motivated much of this operator's
+hardening work, "one namespace that can administer every Neo4j in the estate"
+is a materially different security posture, not a deployment detail.
+
+### B6 — Failure isolation is lost
+
+Today a spoke operator failing takes out one Kubernetes cluster. With a hub,
+hub downtime means **nothing reconciles anywhere**, including the failover
+paths (`Neo4jReplicaPromotion`) most likely to be needed during an incident
+that also stresses the hub. A DR mechanism whose control plane is a single
+remote process is a weaker DR mechanism.
+
+### B7 — Watch and cache cost multiplies, and `WATCH_NAMESPACE` becomes per-cluster
+
+Each remote `cluster.Cluster` carries its own informer cache. A hub watching
+Pods, StatefulSets, Services, Secrets and ConfigMaps across N clusters holds N
+copies. `WATCH_NAMESPACE` (`cmd/main.go:278`) is currently global and would
+have to become a per-remote-cluster scope, or the hub's memory profile becomes
+a function of the largest spoke.
+
+### B8 — TLS trust is directional and currently one-sided
+
+The hub's Neo4j driver must trust each spoke's CA, and the spoke's certificate
+must carry a SAN matching whatever external name the hub dials. The SAN half is
+already expressible (`spec.service.dnsName`, §2). The trust half is the hub's
+own problem — it is a Go process with a driver, not a Neo4j server, so
+`spec.tls.additionalClusterTrustCAs` (which projects peer CAs into `/ssl/trusted/`
+for the *database*) does not apply. The hub needs its own CA bundle
+construction. New, but small, and unblocked.
+
+---
+
+## 4. Options
+
+### (a) Full hub — all controllers, remote clients
+
+The literal reading. Every controller takes a per-target client; a
+`Neo4jRemoteCluster` CR supplies the kubeconfig and the Bolt endpoints.
+
+Requires: B1 + B2 + B3 (i.e. rebuild the CCDR proxy on the Bolt ports,
+mandatory and per-cluster, with per-ordinal exposure), **plus** B4 across
+eleven CRDs and their validators, **plus** accepting B5–B7.
+
+Honest assessment: this is the KubeFed shape, and it is large for the same
+reasons KubeFed was.
+
+### (b) Split hub — Kubernetes-API controllers remote, Bolt controllers local
+
+Superficially attractive: let the hub own `Neo4jEnterpriseCluster` and
+`Neo4jEnterpriseStandalone` (which mostly build StatefulSets, Services,
+ConfigMaps and Certificates), and leave the Bolt-dependent controllers running
+locally in each spoke.
+
+**It does not survive contact with the code.** The infrastructure controllers
+are not Bolt-free — see B1's second group. Diagnostics
+(`neo4jenterprisecluster_controller.go:639`), split-brain detection, **rolling
+upgrade** (`rolling_upgrade.go`) and **scale-down draining** (`scale_down.go`)
+all open a Neo4j client, most of them per-pod. The split would have to be drawn
+*inside* a single controller's reconcile loop rather than between controllers,
+and the hub would end up able to create a cluster but not to upgrade, scale
+down, or observe it. Rejected.
+Rejected.
+
+### (c) Aggregation-only hub, then hub-authored spoke CRs — **recommended**
+
+Invert the direction. Each Kubernetes cluster keeps its own operator, with its
+local Bolt path unchanged. The hub gets a read-mostly view. Detailed in §5.
+
+### (d) Decline — document GitOps instead
+
+A large fraction of "does it support multi-cluster?" means "can I apply the
+same manifests to five clusters?" That is Argo ApplicationSets or Flux, plus
+the operator installed per cluster, and it works today. This option costs a
+documentation page.
+
+**(d) is not a joke option and should ship regardless of what else does** — it
+is the correct answer for most askers, and shipping it first tells you whether
+the remaining demand is real.
+
+---
+
+## 5. The recommended design — option (c)
+
+### 5.1 Principle
+
+> **Spokes reconcile. The hub aggregates. The hub never speaks Bolt.**
+
+Every blocker in §3 that is expensive — B1, B2, B3, and most of B5 — exists
+only because a hub was assumed to hold the Neo4j connection. Move reconciliation
+back to the spoke and they evaporate; the spoke's Bolt path is the in-cluster
+one that already works.
+
+The B1 finding that the *infrastructure* controllers also need Bolt — rolling
+upgrade, scale-down draining, split-brain, diagnostics — cuts in this option's
+favour rather than against it. Under (a) those become four more things needing
+remote Bolt; under (c) they keep working untouched, because they never leave
+the cluster they operate on.
+
+### 5.2 Phase 1 — read-only aggregation
+
+One new CRD, hub-side only:
+
+```yaml
+apiVersion: neo4j.neo4j.com/v1beta1
+kind: Neo4jRemoteCluster
+metadata:
+  name: eu-west-prod
+  namespace: neo4j-operator
+spec:
+  kubeconfigSecretRef:
+    name: eu-west-prod-kubeconfig
+    key: config
+  namespaces: [neo4j-prod, neo4j-staging]   # required; unbounded scope is rejected (B7)
+  pollInterval: 30s
+status:
+  phase: Connected              # Pending | Connected | Unreachable | Forbidden
+  observedAt: "2026-08-31T09:14:22Z"
+  deployments:
+    - kind: Neo4jEnterpriseCluster
+      namespace: neo4j-prod
+      name: prod
+      phase: Ready
+      version: "2026.06.0"
+      servers: 3
+      conditions: [{type: ServersHealthy, status: "True"}, ...]
+  collectionError: ""           # non-fatal, same contract as status.diagnostics
+```
+
+Properties that make this cheap:
+
+- **No Bolt.** The spoke operator already materialises everything interesting
+  into `status` — `status.diagnostics.servers[]`, `status.diagnostics.databases[]`,
+  the `ServersHealthy` / `DatabasesHealthy` conditions. The hub reads status; it
+  does not re-derive it.
+- **No `clusterRef` change (B4 avoided entirely).** `Neo4jRemoteCluster` is a
+  new Kind that no existing CRD references. The eleven-CRD surface change does
+  not happen.
+- **Read-only RBAC on the spoke.** The kubeconfig needs `get`/`list`/`watch` on
+  the Neo4j CRDs in named namespaces and nothing else — a far easier security
+  review than B5's "can administer every database in the estate".
+- **Hub downtime is a visibility outage, not a reconciliation outage** (B6
+  avoided).
+- **Non-fatal by construction.** An unreachable spoke sets
+  `status.phase: Unreachable` and `collectionError`, never `return err` — the
+  same contract `CollectDiagnostics` already uses.
+
+Implementation notes, following house patterns: `cluster.New` per
+`Neo4jRemoteCluster` added to the manager as a Runnable, with
+`source.Kind(remoteCache, &Neo4jEnterpriseCluster{}, ...)` so a spoke status
+change wakes the hub reconciler rather than being polled; inline validation in
+`internal/validation/remotecluster_validator.go` (**never a webhook** —
+invariant 1); finalizer that stops and drops the remote cluster's cache;
+`retry.RetryOnConflict` on status writes; structured events from
+`internal/controller/events.go`.
+
+### 5.3 Phase 1b — the fleet metric, nearly free — *implemented*
+
+Independently of the CRD: an operator flag labelling
+`neo4j_operator_server_health` with the Kubernetes cluster it runs in, so
+ordinary Prometheus federation gives a cross-cluster health view with no hub,
+no kubeconfig, and no new CRD. It covers reading (4) in §1 for people who do
+not use Aura Fleet Manager, and it landed before Phase 1 precisely because it
+may satisfy the requirement outright.
+
+**Shipped as `--kubernetes-cluster-name`, emitting the `k8s_cluster` label**
+(`internal/metrics/metrics.go`, `cmd/main.go`,
+`charts/neo4j-operator/values.yaml: kubernetesClusterName`). Two naming and
+one mechanism decision are worth recording:
+
+- **Not `--cluster-name`.** `cluster_name` is an established metric label on
+  every operator metric and it means the **Neo4j** cluster. A flag by that name
+  would have been read as setting it. The ambiguity is not cosmetic — a
+  federated dashboard that sums across the wrong one of these two labels is
+  wrong in a way nobody notices.
+- **Not a Prometheus `ConstLabel`.** A constant label would be the tidier
+  mechanism, but metrics are registered in `init()` (`metrics.go:243`), which
+  runs before `flag.Parse()`. The name is therefore held in an `atomic.Value`
+  and read at record time.
+- **Empty by default, and that is the compatibility story.** Unset emits an
+  empty `k8s_cluster` label, which Prometheus treats as equivalent to an absent
+  label for matching, so existing queries and dashboards are unaffected. The
+  Helm chart omits the flag entirely when the value is empty.
+
+### 5.4 Phase 2 — hub-authored spoke CRs (only if writes are genuinely needed)
+
+If declarative fan-out is required — "create database `foo` on these six
+clusters" — the hub **writes a `Neo4jDatabase` manifest into the spoke's
+namespace** and the spoke's local operator reconciles it over its local Bolt
+connection. The hub still never opens a driver.
+
+```yaml
+kind: Neo4jFleetDatabase          # hub-side
+spec:
+  targets:
+    clusterSelector: {matchLabels: {tier: prod}}   # selects Neo4jRemoteClusters
+  template:                                        # a Neo4jDatabase spec
+    name: analytics
+    topology: {primaries: 3, secondaries: 1}
+status:
+  targets:
+    - cluster: eu-west-prod
+      applied: true
+      observedPhase: Ready
+```
+
+This is the Open Cluster Management shape (a manifest-delivery model), and it
+is the only version of hub-side *writes* that does not require re-solving
+B1–B3. Two things to design carefully if it is ever built:
+
+- **Deletion semantics.** Removing a target from the selector must not silently
+  drop a database. Default to orphan-and-warn, mirroring §5.5 of the CCDR
+  design ("removing a CR that no longer describes anything must not be a
+  data-loss event").
+- **GitOps collision.** A hub writing objects into a spoke that Argo also
+  manages produces exactly the out-of-sync/prune fight the CCDR design cited
+  when it rejected an operator-authored handoff. The hub's written objects need
+  a documented ownership label and an Argo ignore convention, or the two
+  controllers will fight.
+
+### 5.5 What option (c) explicitly does not give you
+
+Stated plainly, because a hub that quietly does less than expected is worse
+than one that declines:
+
+- No hub-side split-brain detection or live diagnostics for remote clusters —
+  the spoke does that locally, and the hub sees only its published conclusion.
+- No hub-side Cypher. `Neo4jUser` / `Neo4jRole` / ad-hoc administration remain
+  spoke-local operations (Phase 2 can *deliver* the CRs, but the spoke executes).
+- No single point of control during a spoke API outage; if the spoke's API
+  server is down the hub can neither read nor write it, and there is no
+  fallback path.
+
+---
+
+## 6. What full hub/spoke would additionally require
+
+Recorded so that a future decision to build (a) does not re-derive it.
+
+1. **A Bolt exposure mechanism per managed cluster**, per ordinal, mandatory —
+   structurally the CCDR proxy (`internal/resources/ccdr_proxy.go`) retargeted
+   from 6000 to 7687, plus an override for `server.routing.advertised_address`
+   that the config validator currently forbids.
+2. **`buildConnectionURIForEnterprise` becomes endpoint-driven**, taking a
+   resolved endpoint rather than composing an in-cluster FQDN; same for the
+   standalone builder and `splitbrain_detector.go`.
+3. **`clusterRef.cluster` across eleven CRDs** plus their validators, plus the
+   per-CRD hand-written surface list (B4).
+4. **A hub CA bundle** for the driver's trust of each spoke (B8).
+5. **Per-remote-cluster `WATCH_NAMESPACE` scoping** (B7).
+6. **An answer to B5 and B6** that a security reviewer accepts.
+
+Items 1 and 2 are the ones with no cheap version.
+
+---
+
+## 7. Testing
+
+- **Option (c) fits the project's testing invariants; option (a) does not.**
+  The hub in (c) runs no Neo4j, so a hub-plus-one-spoke test needs **one**
+  Enterprise deployment — compatible with the standing rule that only one
+  Enterprise deployment runs at a time (concurrent JVMs wedge Bolt on a laptop).
+  A meaningful (a) test needs at least two live deployments in different
+  Kubernetes clusters, which that rule forbids on a developer machine and which
+  CI has no tooling for.
+- **Two Kind clusters are viable.** Kind clusters share a Docker network by
+  default and can route to each other — the technique the CCDR design already
+  identified. The known gap is unchanged: plain Kind has no cloud provider, so
+  `type: LoadBalancer` never gets an address, and this repo has no MetalLB /
+  `cloud-provider-kind` wiring yet. **Option (c) does not need a LoadBalancer**
+  — the hub talks to the spoke's API server, which Kind publishes — so this gap
+  blocks (a) and not (c).
+- **Unit:** kubeconfig parsing and rejection of an unbounded namespace scope;
+  status projection from a fake spoke cluster; the `Unreachable` /
+  `Forbidden` branches; validator table tests.
+- **Integration:** `Label("core")` for CRD admission and the validator, no
+  second cluster required. A genuine two-Kind-cluster aggregation spec is
+  `Label("extended")` and dispatch-gated, mirroring
+  `isPropertyShardingCompatible()`.
+
+---
+
+## 8. Delivery order
+
+1. ~~**Option (d)** — a `docs/user_guide/guides/multi_cluster.md` page covering
+   ApplicationSet/Flux fan-out with a per-cluster operator~~ → **done.**
+   Cheapest, correct for most askers, and a demand probe for everything below.
+2. ~~**§5.3** — `--cluster-name` flag + metric label + a federation example~~ →
+   **done**, as `--kubernetes-cluster-name` / `k8s_cluster` (§5.3). No new API
+   surface.
+3. **§5.2** — `Neo4jRemoteCluster`, read-only aggregation, with the full
+   hand-written-surface checklist from `CLAUDE.md` (api_reference, index, README,
+   nav, ArgoCD health check keyed off the `Ready` **condition**, CSV, helm-sync
+   `describe()` row, sample, `devControllerKeys`).
+4. **§5.4** — `Neo4jFleetDatabase` manifest delivery, only on evidence from 1–3
+   that read-only aggregation is insufficient.
+5. **Option (a)** — not scheduled. §6 is its prerequisite list.
+
+---
+
+## 9. Open questions
+
+**Q1 — Is a stretched single Neo4j cluster across Kubernetes clusters worth a
+separate analysis? Leaning no.** It requires every port externally routable —
+including `server.cluster.raft.advertised_address` (7000), which the CCDR
+design pointedly refused to touch so that "RAFT leader election never depends
+on the load balancer" — and it puts a WAN round-trip on the write path via RAFT
+commit. The one defensible variant is Kubernetes clusters on a flat L3 network
+with mutually routable pod IPs (Cilium ClusterMesh, Submariner), where the work
+reduces to letting the discovery endpoint list include servers the local
+StatefulSet does not own. Even then, two independent control planes each
+believing they own part of one DBMS is an unsolved ownership problem. Neo4j's
+own answer to geo-distribution is CCDR.
+
+**Q2 — Does the aggregated status actually satisfy the requirement?** Everything
+§5.2 surfaces is already in spoke `status`. If the real ask is cross-cluster
+*actions* rather than cross-cluster *visibility*, Phase 1 is a detour and the
+question becomes §5.4 vs. (d) directly. **This should be answered by a user
+before item 3 in §8 is started**, because it is the difference between a
+one-CRD feature and a fan-out delivery controller.
+
+**Q3 — Should `Neo4jRemoteCluster` reuse the Aura fleet plumbing?**
+`spec.auraFleetManagement` already registers deployments with a cross-cluster
+fleet service, and `fleet_target.go` already abstracts "cluster or standalone"
+for it. Whether the hub's aggregation should be a second consumer of that
+abstraction or an independent path is an implementation question that affects
+how much of §5.2 is new code.
+
+**Q4 — Hub-side kubeconfig rotation.** Kubeconfigs expire. The design needs a
+defined behaviour for credential expiry that is distinguishable in `status`
+from a genuinely unreachable spoke (`Forbidden` vs. `Unreachable` above is a
+first cut, not a rotation strategy).
+
+**Q5 — Is there a customer for (a)?** §6 is a large, mostly irreversible bill.
+It should not be paid on the strength of the phrase "multi-cluster" appearing
+in a requirements document.

--- a/docs/user_guide/guides/multi_cluster.md
+++ b/docs/user_guide/guides/multi_cluster.md
@@ -1,0 +1,215 @@
+# Running Across Multiple Kubernetes Clusters
+
+This guide covers running Neo4j under this operator in **more than one Kubernetes cluster** — how to install and configure at fleet scale, and how to get one view of health across all of them.
+
+The short version: **install the operator in every cluster, and drive it with GitOps.** There is no hub operator that reaches into other Kubernetes clusters, and the design analysis in [`docs/design/multi-cluster-control-plane.md`](https://github.com/priyolahiri/neo4j-kubernetes-operator/blob/main/docs/design/multi-cluster-control-plane.md) explains why: the operator is a Neo4j client as well as a Kubernetes client, and its Bolt connections are in-cluster by construction.
+
+## Which problem do you actually have?
+
+Four different things get called "multi-cluster". They have different answers:
+
+| What you want | Answer |
+|---|---|
+| The same Neo4j config applied to many clusters | **This guide** — GitOps fan-out |
+| One health view across clusters | **This guide** — [`k8s_cluster` metric label](#one-health-view-across-clusters) |
+| A copy of a database in another region, for DR | [Cross-Cluster Replication](cross_cluster_replication.md) |
+| One Neo4j cluster whose servers span Kubernetes clusters | Not supported, and not recommended — see below |
+
+### Why not one Neo4j cluster spanning Kubernetes clusters
+
+A single Neo4j cluster is a RAFT group. Stretching it across Kubernetes clusters puts a wide-area round trip on every write (RAFT commit is on the write path), and requires every server's RAFT and routing addresses to be externally routable. If you need Neo4j in two regions, you want two clusters and [Cross-Cluster Replication](cross_cluster_replication.md), which is the mechanism Neo4j provides for exactly this.
+
+## The model: one operator per cluster
+
+Each Kubernetes cluster runs its own operator, managing only the Neo4j deployments in that cluster. This is not a limitation to work around — it is what gives you:
+
+- **Failure isolation.** An operator outage affects one cluster. There is no shared control plane whose loss stops reconciliation everywhere.
+- **Local Bolt.** Every operator reaches its Neo4j pods over in-cluster DNS, so no database endpoint is ever exposed outside its cluster just to be administered.
+- **Local credentials.** A cluster's Neo4j admin Secret never leaves that cluster.
+
+What you fan out is **manifests**, not control.
+
+## Fan-out with Argo CD ApplicationSets
+
+An `ApplicationSet` with a cluster generator installs the operator into every registered cluster from one definition.
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: neo4j-operator
+  namespace: argocd
+spec:
+  generators:
+    - clusters:
+        selector:
+          matchLabels:
+            neo4j: "true"          # label your Argo cluster secrets
+  template:
+    metadata:
+      name: 'neo4j-operator-{{name}}'
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/priyolahiri/neo4j-kubernetes-operator
+        targetRevision: v1.14.0    # pin a release; never track main
+        path: charts/neo4j-operator
+        helm:
+          values: |
+            kubernetesClusterName: '{{name}}'
+      destination:
+        server: '{{server}}'
+        namespace: neo4j-operator
+      syncPolicy:
+        automated: {prune: true, selfHeal: true}
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true   # see "CRD size" below
+```
+
+Two things worth setting deliberately:
+
+- **`kubernetesClusterName: '{{name}}'`** wires each install's metrics label to the cluster it runs in. See [below](#one-health-view-across-clusters).
+- **`ServerSideApply=true`.** This operator's CRDs are large. Client-side apply stores the whole manifest in the `last-applied-configuration` annotation and can exceed the annotation size limit; server-side apply avoids it.
+
+### Fanning out Neo4j deployments themselves
+
+The same generator works for the workloads, with per-cluster overrides in Git:
+
+```yaml
+spec:
+  generators:
+    - git:
+        repoURL: https://github.com/your-org/neo4j-fleet
+        revision: main
+        directories:
+          - path: clusters/*
+  template:
+    metadata:
+      name: 'neo4j-{{path.basename}}'
+    spec:
+      source:
+        repoURL: https://github.com/your-org/neo4j-fleet
+        path: '{{path}}'          # clusters/eu-west/, clusters/us-east/, …
+      destination:
+        server: '{{server}}'
+        namespace: neo4j
+```
+
+Each `clusters/<name>/` directory holds that cluster's `Neo4jEnterpriseCluster`, `Neo4jDatabase`, `Neo4jUser`, `Neo4jRole` and so on. Sizing, storage class and topology differ per cluster; the CR shape does not.
+
+!!! warning "Do not fan out `Neo4jBackup` storage paths"
+    A `Neo4jBackup` written by two clusters into the same bucket path will interleave two backup chains in one directory. Give every cluster its own `spec.storage.path`. If a chain feeds cross-cluster replication, this is not merely untidy — it breaks the differential chain and forces a replica rebuild.
+
+## Fan-out with Flux
+
+The equivalent shape is a `HelmRelease` per cluster, or one `Kustomization` per cluster reconciled by a Flux instance in each:
+
+```yaml
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: neo4j-operator
+  namespace: neo4j-operator
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: charts/neo4j-operator
+      sourceRef: {kind: GitRepository, name: neo4j-operator, namespace: flux-system}
+  values:
+    kubernetesClusterName: eu-west-prod
+```
+
+Flux's usual pattern is one Flux per cluster pulling from a shared repo, which fits this operator's per-cluster model directly.
+
+## GitOps interactions worth knowing
+
+Three operator behaviours interact with drift correction. All three are by design, and all three will confuse a reviewer who meets them for the first time during an incident.
+
+- **One-shot CRs are inert to re-apply.** `Neo4jBackup`, `Neo4jRestore` and `Neo4jReplicaPromotion` reach a terminal phase and stay there. Re-applying an unchanged manifest does not re-run them, which is exactly what you want from a self-healing GitOps controller.
+- **Promotion is not a spec field.** Failover is a separate `Neo4jReplicaPromotion` CR precisely so that a GitOps controller re-applying the pre-promotion manifest cannot un-promote a database. See [Cross-Cluster Replication](cross_cluster_replication.md).
+- **Some status fields are meant to be copied into another cluster's spec.** `status.replicationPullURI` and `status.crossClusterReplication.addresses` are published for a human or a pipeline to paste into a downstream cluster's manifest. Argo will not do this for you; treat it as a deliberate step in your fleet runbook.
+
+## One health view across clusters
+
+The operator exposes `neo4j_operator_server_health` per Neo4j server, labelled with `cluster_name` (the **Neo4j** cluster) and `namespace`. Across a fleet that is not enough: `cluster_name="prod"` in namespace `neo4j` very likely exists in every one of your Kubernetes clusters, and federating them into one Prometheus collapses them into a single ambiguous series.
+
+Set `kubernetesClusterName` to disambiguate:
+
+```yaml
+# values.yaml
+kubernetesClusterName: eu-west-prod
+```
+
+or directly:
+
+```
+--kubernetes-cluster-name=eu-west-prod
+```
+
+Every `neo4j_operator_server_health` series then carries `k8s_cluster="eu-west-prod"`:
+
+```
+neo4j_operator_server_health{cluster_name="prod",namespace="neo4j",server_name="srv-0",server_address="10.0.0.1:7687",k8s_cluster="eu-west-prod"} 1
+```
+
+!!! note "`k8s_cluster` is not `cluster_name`"
+    `cluster_name` is the Neo4j cluster. `k8s_cluster` is the Kubernetes cluster it runs in. The flag is `--kubernetes-cluster-name` rather than `--cluster-name` to keep that distinction visible at the point of configuration.
+
+**Backwards compatible.** The flag is unset by default, which emits an empty `k8s_cluster` label. Prometheus treats an empty label value as equivalent to the label being absent, so existing queries, dashboards and alert rules keep matching unchanged whether or not you adopt this.
+
+### Federating
+
+With a Prometheus per cluster and one aggregating Prometheus, federate the operator metrics:
+
+```yaml
+scrape_configs:
+  - job_name: neo4j-operator-federation
+    honor_labels: true
+    metrics_path: /federate
+    params:
+      'match[]':
+        - '{__name__=~"neo4j_operator_.*"}'
+    static_configs:
+      - targets: ['prometheus.eu-west.example.com', 'prometheus.us-east.example.com']
+```
+
+Then fleet-wide queries work directly:
+
+```promql
+# Every degraded server anywhere in the fleet
+neo4j_operator_server_health == 0
+
+# Healthy server count per Kubernetes cluster
+sum by (k8s_cluster) (neo4j_operator_server_health)
+
+# Clusters where any server is degraded
+count by (k8s_cluster, cluster_name) (neo4j_operator_server_health == 0) > 0
+```
+
+An alert that names the Kubernetes cluster in its own text:
+
+```yaml
+- alert: Neo4jServerDegraded
+  expr: neo4j_operator_server_health == 0
+  for: 5m
+  annotations:
+    summary: "Neo4j server {{ $labels.server_name }} degraded in {{ $labels.cluster_name }} ({{ $labels.k8s_cluster }})"
+```
+
+If you already use Aura Fleet Management, `spec.auraFleetManagement` registers deployments with Aura's own fleet view and is an alternative to this for cross-cluster inventory.
+
+## What this does not give you
+
+Stated plainly, so nothing is discovered during an incident:
+
+- **No single `kubectl` context for the fleet.** Inspecting a Neo4j deployment means talking to its own cluster's API server.
+- **No cross-cluster Cypher.** `Neo4jUser`, `Neo4jRole` and `Neo4jDatabase` are reconciled by the operator local to each cluster. Fan out the CRs; the local operator executes them.
+- **No aggregated status object.** The `k8s_cluster` label gives you a metrics-level fleet view. There is no CR that lists every deployment across every cluster.
+
+## See also
+
+- [Cross-Cluster Replication](cross_cluster_replication.md) — a read-only copy of a database in another cluster, and one-way promotion for DR
+- [Monitoring](monitoring.md) — enabling metrics on a deployment
+- [Prometheus and Grafana Setup](prometheus-grafana-setup.md) — the single-cluster monitoring stack this builds on

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -19,6 +19,7 @@ package metrics
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -58,6 +59,13 @@ const (
 	LabelNodeType = "node_type"
 	// LabelStatus is the label key for operation status
 	LabelStatus = "status"
+
+	// LabelK8sCluster is the label key for the Kubernetes cluster this
+	// operator instance runs in. Deliberately NOT `cluster_name`, which is
+	// already taken and means the *Neo4j* cluster — the two are different
+	// things and conflating them in one label set is how a federated
+	// dashboard silently sums the wrong series.
+	LabelK8sCluster = "k8s_cluster"
 )
 
 var (
@@ -239,6 +247,33 @@ var (
 		[]string{"resource_type", LabelNamespace},
 	)
 )
+
+// kubernetesClusterName identifies the Kubernetes cluster this operator
+// instance runs in. It is empty unless --kubernetes-cluster-name is passed.
+//
+// Metrics are registered in init(), which runs before flag.Parse(), so this
+// cannot be a Prometheus ConstLabel — it is read at record time instead.
+// An empty value is emitted as an empty label, which Prometheus treats as
+// equivalent to the label being absent for matching purposes, so existing
+// queries and dashboards are unaffected when the flag is not set.
+var kubernetesClusterName atomic.Value
+
+// SetKubernetesClusterName records the Kubernetes cluster name for metric
+// labelling. Call it once from main() after flag.Parse() and before the
+// manager starts; it is atomic so a late call cannot race a recording
+// controller, but a late call will leave already-emitted series unlabelled.
+func SetKubernetesClusterName(name string) {
+	kubernetesClusterName.Store(name)
+}
+
+// KubernetesClusterName returns the configured Kubernetes cluster name, or ""
+// when --kubernetes-cluster-name was not supplied.
+func KubernetesClusterName() string {
+	if v, ok := kubernetesClusterName.Load().(string); ok {
+		return v
+	}
+	return ""
+}
 
 func init() {
 	// Register Prometheus metrics
@@ -672,9 +707,9 @@ var (
 		prometheus.GaugeOpts{
 			Subsystem: subsystem,
 			Name:      "server_health",
-			Help:      "Health of individual Neo4j servers: 1=Enabled+Available, 0=degraded",
+			Help:      "Health of individual Neo4j servers: 1=Enabled+Available, 0=degraded. The k8s_cluster label is empty unless --kubernetes-cluster-name is set.",
 		},
-		[]string{LabelClusterName, LabelNamespace, "server_name", "server_address"},
+		[]string{LabelClusterName, LabelNamespace, "server_name", "server_address", LabelK8sCluster},
 	)
 
 	// Aura orchestration (control-plane) metrics. The operator talks to the Aura
@@ -812,6 +847,6 @@ func (m *ClusterMetrics) RecordServerHealth(servers []ServerHealth) {
 		if s.Enabled && s.Available {
 			value = 1.0
 		}
-		serverHealth.WithLabelValues(m.clusterName, m.namespace, s.Name, s.Address).Set(value)
+		serverHealth.WithLabelValues(m.clusterName, m.namespace, s.Name, s.Address, KubernetesClusterName()).Set(value)
 	}
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -667,3 +667,85 @@ func TestMetricsRegistration(t *testing.T) {
 		assert.NotNil(t, metric)
 	}
 }
+
+func TestKubernetesClusterName_DefaultsToEmpty(t *testing.T) {
+	t.Cleanup(func() { SetKubernetesClusterName("") })
+
+	SetKubernetesClusterName("")
+	assert.Equal(t, "", KubernetesClusterName(),
+		"an unset --kubernetes-cluster-name must yield an empty label, not a placeholder")
+}
+
+func TestClusterMetrics_RecordServerHealth(t *testing.T) {
+	tests := []struct {
+		name       string
+		k8sCluster string
+		server     ServerHealth
+		expected   float64
+	}{
+		{
+			name:       "enabled and available, no k8s cluster name set",
+			k8sCluster: "",
+			server:     ServerHealth{Name: "srv-0", Address: "10.0.0.1:7687", Enabled: true, Available: true},
+			expected:   1.0,
+		},
+		{
+			name:       "enabled but unavailable is degraded",
+			k8sCluster: "",
+			server:     ServerHealth{Name: "srv-0", Address: "10.0.0.1:7687", Enabled: true, Available: false},
+			expected:   0.0,
+		},
+		{
+			name:       "available but disabled is degraded",
+			k8sCluster: "",
+			server:     ServerHealth{Name: "srv-0", Address: "10.0.0.1:7687", Enabled: false, Available: true},
+			expected:   0.0,
+		},
+		{
+			name:       "k8s cluster name is carried onto the series",
+			k8sCluster: "eu-west-prod",
+			server:     ServerHealth{Name: "srv-0", Address: "10.0.0.1:7687", Enabled: true, Available: true},
+			expected:   1.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(func() { SetKubernetesClusterName("") })
+			serverHealth.Reset()
+			SetKubernetesClusterName(tt.k8sCluster)
+
+			NewClusterMetrics("test-cluster", "test-namespace").
+				RecordServerHealth([]ServerHealth{tt.server})
+
+			gauge := serverHealth.WithLabelValues(
+				"test-cluster", "test-namespace", tt.server.Name, tt.server.Address, tt.k8sCluster)
+			assert.Equal(t, tt.expected, testutil.ToFloat64(gauge))
+		})
+	}
+}
+
+// The whole point of the k8s_cluster label: the same Neo4j cluster name in the
+// same namespace, running in two different Kubernetes clusters, must not
+// collapse into one series when both are scraped into one Prometheus.
+func TestClusterMetrics_RecordServerHealth_SeparatesKubernetesClusters(t *testing.T) {
+	t.Cleanup(func() { SetKubernetesClusterName("") })
+	serverHealth.Reset()
+
+	srv := ServerHealth{Name: "srv-0", Address: "10.0.0.1:7687", Enabled: true, Available: true}
+	m := NewClusterMetrics("prod", "neo4j")
+
+	SetKubernetesClusterName("eu-west")
+	m.RecordServerHealth([]ServerHealth{srv})
+
+	SetKubernetesClusterName("us-east")
+	m.RecordServerHealth([]ServerHealth{{Name: "srv-0", Address: "10.0.0.1:7687", Enabled: true, Available: false}})
+
+	require.Equal(t, 2, testutil.CollectAndCount(serverHealth),
+		"two Kubernetes clusters must produce two distinct series, not one overwritten one")
+
+	assert.Equal(t, 1.0, testutil.ToFloat64(
+		serverHealth.WithLabelValues("prod", "neo4j", "srv-0", "10.0.0.1:7687", "eu-west")))
+	assert.Equal(t, 0.0, testutil.ToFloat64(
+		serverHealth.WithLabelValues("prod", "neo4j", "srv-0", "10.0.0.1:7687", "us-east")))
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -145,6 +145,7 @@ nav:
       - Upgrades: user_guide/guides/upgrades.md
       - Storage Expansion: user_guide/guides/storage_expansion.md
       - Fault Tolerance: user_guide/guides/fault_tolerance.md
+      - Multiple Kubernetes Clusters: user_guide/guides/multi_cluster.md
       - Monitoring:
           - Overview: user_guide/guides/monitoring.md
           - Prometheus & Grafana: user_guide/guides/prometheus-grafana-setup.md


### PR DESCRIPTION
## Summary

Answers "can this operator serve multiple Kubernetes clusters?" — which turned out to be four different questions with different answers. Ships the two cheapest ones and writes down why the expensive one should not be built yet.

**1. `--kubernetes-cluster-name` / `k8s_cluster` label** (`feat(metrics)`)

Across a fleet, `neo4j_operator_server_health` is ambiguous: `cluster_name="prod"` in namespace `neo4j` very likely exists in *every* Kubernetes cluster, so federating several Prometheus instances into one collapses them into a single series. An opt-in label fixes it.

- **Not `--cluster-name`.** `cluster_name` is an established label meaning the *Neo4j* cluster. A flag by that name reads as setting it, and a dashboard summing across the wrong one of the two is wrong in a way nobody notices.
- **Not a Prometheus `ConstLabel`** (which would be tidier): metrics register in `init()` (`metrics.go:243`), before `flag.Parse()`. Held in an `atomic.Value`, read at record time.
- **Empty by default** — Prometheus treats an empty label value as absent for matching, so existing queries, dashboards and alert rules are unaffected. The chart omits the flag entirely when `kubernetesClusterName` is empty.

**2. `docs/user_guide/guides/multi_cluster.md`** (`docs`)

The answer most people asking this actually want: install the operator in every cluster, fan out manifests with Argo CD ApplicationSets or Flux. Covers the GitOps interactions that are by design but surprising (one-shot CRs inert to re-apply; promotion as a separate CR so drift correction cannot un-promote; status fields meant to be copied into another cluster's spec), plus federation queries and an alert example. States plainly what the per-cluster model does *not* give you.

**3. `docs/design/multi-cluster-control-plane.md`** (`docs`)

Analyses the literal reading — one operator managing N clusters — and recommends against building it.

The Kubernetes API half is cheap: no `exec`/`remotecommand` anywhere, and controller-runtime ships per-cluster caches. The Bolt half is [CCDR's B1](docs/design/cross-cluster-replication.md) again — connection URIs are pinned to in-cluster DNS (`client.go:2803`) and the `neo4j://` routing scheme means the server hands back internal FQDNs (`cluster.go:2363`), so exposing a Service does not fix it. **21 non-test files open a Neo4j client**, including rolling upgrade, scale-down draining and split-brain — the infrastructure controllers are not Bolt-free either, which forecloses the "K8s controllers remote, Bolt controllers local" split.

Recommends an aggregation-only hub instead: spokes reconcile, the hub reads their status, the hub never speaks Bolt. Notably it also fits the one-Enterprise-deployment-at-a-time testing rule and needs no LoadBalancer, while the full hub does not and does.

## Type of change

- [x] New feature
- [x] Documentation

## Testing

- [x] `make test-unit` passes locally (all packages)
- [x] `make lint` passes locally (0 issues)
- [x] `go vet` clean; `-race` clean on `internal/metrics`
- [x] `make check-drift` green on the committed tree
- [x] `check-crd-catalog` / `check-apiref-drift` / `check-knowledge-drift` all OK
- [x] `mkdocs build` renders the new guide
- [x] Helm rendering verified both ways — flag present with `kubernetesClusterName` set, entirely absent by default

New unit tests cover the degraded/healthy branches, the label round-trip, and the point of the feature: the same Neo4j cluster name in the same namespace across two Kubernetes clusters produces **two distinct series**, not one overwritten one.

Extended Integration Tests not run — no cluster, standalone, backup or restore controller was touched. This adds one metric label and two docs.

## Checklist

- [x] Conventional Commit titles
- [x] `make sync-all` — no regenerated artifact drifted (no API types, markers or CRDs changed)
- [x] Docs updated (new guide + nav entry; design doc)
- [x] `.gitmir` model kept current — `rt-metrics` description now records the label (no objects added/removed, counts unchanged)
- [x] Respected the project invariants in `CLAUDE.md`

## Note on `check-drift`

It fails locally on *any* uncommitted chart edit — its pathspec covers `charts/neo4j-operator` wholesale (`Makefile:420-422`), generated or not. Confirmed the generators do not rewrite `values.yaml` or `_helpers.tpl` (md5 unchanged across `make sync-all bundle`), and it is green on the committed tree.