### PR TITLE
feat(cli): kubectl-neo4j validate — offline manifest validation

### DIFF
--- a/.github/release-notes-template.md
+++ b/.github/release-notes-template.md
@@ -74,10 +74,25 @@ See [Supported Neo4j Versions](https://priyolahiri.github.io/neo4j-kubernetes-op
 |-------|-------------|
 | `neo4j-kubernetes-operator-complete.yaml` | Complete operator install (CRDs + RBAC + Deployment) |
 | `neo4j-kubernetes-operator.yaml` | CRDs only |
+| `kubectl-neo4j___VERSION___<os>_<arch>.tar.gz` | `kubectl-neo4j` CLI plugin (darwin/linux, arm64/amd64) |
+| `kubectl-neo4j___VERSION___windows_amd64.zip` | `kubectl-neo4j` CLI plugin (Windows) |
+| `kubectl-neo4j___VERSION___checksums.txt` | SHA-256 checksums for every CLI archive |
 
-`kubectl apply --server-side` is the recommended apply form for both assets (the largest CRDs exceed client-side apply's last-applied annotation limit).
+`kubectl apply --server-side` is the recommended apply form for both manifest assets (the largest CRDs exceed client-side apply's last-applied annotation limit).
 
 **Helm users**: apply the CRD asset (`neo4j-kubernetes-operator.yaml`) before `helm upgrade` — Helm never upgrades CRDs.
+
+### `kubectl-neo4j` CLI
+
+Validates your manifests against this operator's own validators **before** you apply them — the feedback an admission webhook would give you, except this operator deliberately has none. Ships on this tag and carries this release's validation rules, so keep it on the same version as the operator you deploy.
+
+```bash
+curl -sSL https://github.com/priyolahiri/neo4j-kubernetes-operator/releases/download/__TAG__/kubectl-neo4j___VERSION___linux_amd64.tar.gz | tar -xz
+sudo mv kubectl-neo4j /usr/local/bin/
+kubectl neo4j validate -f manifests/
+```
+
+Same support terms as the operator: best-effort, no SLA. See the [CLI guide](https://priyolahiri.github.io/neo4j-kubernetes-operator/user_guide/guides/cli/).
 
 ## Documentation
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,9 @@ jobs:
     - name: api_reference in sync with CRD spec fields
       run: make check-apiref-drift
 
+    - name: kubectl-neo4j release asset names agree everywhere
+      run: make check-cli-asset-names
+
     - name: Every CRD listed on docs landing page, README and nav
       run: make check-crd-catalog
 
@@ -123,6 +126,20 @@ jobs:
 
     - name: Run golangci-lint
       run: ./bin/golangci-lint run --timeout=6m ./...
+
+    # The operator itself only ever runs on linux, but kubectl-neo4j is a
+    # plugin users install on their own laptops, so it is released for darwin
+    # and windows too. Without this, a unix-only import reaching cmd/ compiles
+    # fine here and fails at RELEASE time — the most expensive moment to learn
+    # it, since the tag is already pushed. Compile-only, no tests, ~seconds.
+    - name: Cross-compile kubectl-neo4j for released platforms
+      run: |
+        set -euo pipefail
+        for target in darwin/arm64 darwin/amd64 linux/amd64 linux/arm64 windows/amd64; do
+          echo "=> ${target}"
+          CGO_ENABLED=0 GOOS="${target%%/*}" GOARCH="${target##*/}" \
+            go build -o /dev/null ./cmd/kubectl-neo4j
+        done
 
   unit-tests:
     name: Unit Tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -316,6 +316,63 @@ jobs:
           release-artifacts/neo4j-kubernetes-operator-complete.yaml || {
           echo "ERROR: complete.yaml is not pinned to ${TAG_NAME}" >&2; exit 1; }
 
+    # kubectl-neo4j plugin binaries. Deliberately NOT a separate workflow or a
+    # goreleaser config: this job already checks out the source and sets up Go,
+    # and the "Create GitHub Release" step below attaches release-artifacts/* by
+    # glob, so cross-compiling into that directory is the whole integration.
+    #
+    # The asset NAMING is the load-bearing decision here, not the build. krew
+    # plugin manifests and any install script pin these exact filenames, so
+    # renaming them later silently breaks every existing installer. The
+    # goreleaser-style `name_version_os_arch.ext` convention is used because it
+    # is what krew tooling already expects.
+    - name: Build kubectl-neo4j binaries
+      env:
+        CLEAN_TAG: ${{ needs.determine-tag.outputs.clean_tag }}
+        TAG_NAME: ${{ needs.determine-tag.outputs.tag_name }}
+      run: |
+        set -euo pipefail
+        mkdir -p release-artifacts dist
+
+        # Same version string the binary reports via `kubectl neo4j version`,
+        # and the same one its validate output cites as the ruleset it speaks
+        # for. Offline validation that cannot name its operator release is how
+        # silent version skew starts (design doc Q4).
+        LDFLAGS="-s -w -X main.version=${TAG_NAME}"
+
+        build() {
+          local goos="$1" goarch="$2" ext="${3:-}"
+          local bin="kubectl-neo4j${ext}"
+          echo "building ${goos}/${goarch}"
+          CGO_ENABLED=0 GOOS="${goos}" GOARCH="${goarch}" \
+            go build -trimpath -ldflags "${LDFLAGS}" -o "dist/${bin}" ./cmd/kubectl-neo4j
+
+          local stem="kubectl-neo4j_${CLEAN_TAG}_${goos}_${goarch}"
+          if [ "${goos}" = "windows" ]; then
+            (cd dist && zip -q "../release-artifacts/${stem}.zip" "${bin}")
+          else
+            tar -czf "release-artifacts/${stem}.tar.gz" -C dist "${bin}"
+          fi
+          rm -f "dist/${bin}"
+        }
+
+        build darwin  arm64
+        build darwin  amd64
+        build linux   amd64
+        build linux   arm64
+        build windows amd64 .exe
+
+        # One checksum file covering every archive, so a user can verify a
+        # single download without fetching the others.
+        (cd release-artifacts && \
+          shasum -a 256 kubectl-neo4j_* > "kubectl-neo4j_${CLEAN_TAG}_checksums.txt")
+
+        # Fail the release rather than ship an unusable asset set.
+        test "$(ls release-artifacts/kubectl-neo4j_*.tar.gz | wc -l)" -eq 4
+        test -f "release-artifacts/kubectl-neo4j_${CLEAN_TAG}_windows_amd64.zip"
+        echo "kubectl-neo4j assets:"
+        ls -1 release-artifacts/kubectl-neo4j_*
+
     - name: Generate release notes
       id: release-notes
       env:

--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ GO_TEST_CMD ?= go test
 test-unit: manifests generate fmt vet envtest ## Run unit tests (no cluster required)
 	@echo "🧪 Running unit tests..."
 	@mkdir -p coverage
-	@./scripts/run-tests-clean.sh env KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" $(GO_TEST_CMD) $$(go list ./... | grep -v /e2e | grep -v /integration | grep -v "/test/webhooks" | grep -v "/test/testutil" | grep -v "/cmd") -coverprofile coverage/coverage-unit.out -race -v
+	@./scripts/run-tests-clean.sh env KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" $(GO_TEST_CMD) $$(go list ./... | grep -v /e2e | grep -v /integration | grep -v "/test/webhooks" | grep -v "/test/testutil") -coverprofile coverage/coverage-unit.out -race -v
 
 # Webhook tests removed - webhooks migrated to client-side validation
 
@@ -341,6 +341,12 @@ test-ci-local: ## Emulate CI workflow locally with debug logging (for troublesho
 .PHONY: build
 build: manifests generate fmt vet ## Build manager binary.
 	go build -o bin/manager cmd/main.go
+
+.PHONY: build-cli
+build-cli: ## Build the kubectl-neo4j plugin into bin/. Add bin/ to PATH to use `kubectl neo4j`.
+	go build -ldflags "-X main.version=$(shell git describe --tags --always --dirty 2>/dev/null || echo dev)" \
+		-o bin/kubectl-neo4j ./cmd/kubectl-neo4j
+	@echo "built bin/kubectl-neo4j — try: ./bin/kubectl-neo4j validate -f config/samples/"
 
 # Removed: run target - operator must run in-cluster for proper DNS resolution
 

--- a/Makefile
+++ b/Makefile
@@ -451,6 +451,10 @@ check-drift: sync-all bundle ## CI gate: regenerate everything and fail if anyth
 check-invariants: ## Verify the 5 hard architectural invariants hold (grep guard; runtime image check lives in image_validator.go).
 	@./scripts/check-invariants.sh
 
+.PHONY: check-cli-asset-names
+check-cli-asset-names: ## Verify the kubectl-neo4j release asset naming convention matches everywhere it is pinned.
+	@./scripts/check-cli-asset-names.sh
+
 .PHONY: check-knowledge-drift
 check-knowledge-drift: ## Verify every 'pinned-by:'/file reference in docs/knowledge/ still resolves to a real path.
 	@./scripts/check-knowledge-drift.sh

--- a/cmd/kubectl-neo4j/main.go
+++ b/cmd/kubectl-neo4j/main.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2025 Priyo Lahiri.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Command kubectl-neo4j is a kubectl plugin for the Neo4j Kubernetes Operator.
+//
+// Installed on PATH as `kubectl-neo4j`, it is invoked as `kubectl neo4j <cmd>`;
+// it also runs standalone. See docs/design/cli-tool.md for the design and the
+// rule that governs what may be added here:
+//
+//	The CLI may create and read Custom Resources and read Kubernetes state.
+//	It must NEVER execute Cypher or neo4j-admin for a mutating operation.
+//
+// The point of this binary is that it reuses the operator's OWN packages —
+// internal/validation, internal/resources, api/v1beta1 — rather than restating
+// their rules. Anything that would require copying a rule out of the operator
+// is a signal to export it there, not to duplicate it here.
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+// version is stamped at build time with -ldflags "-X main.version=vX.Y.Z".
+// It is deliberately reported in validate's output: offline validation is only
+// ever authoritative for the operator release it was built from, and output
+// that does not say which release it speaks for invites silent version skew.
+var version = "dev"
+
+const usage = `kubectl-neo4j — CLI for the Neo4j Kubernetes Operator
+
+Usage:
+  kubectl neo4j <command> [flags]
+
+Commands:
+  validate    Validate Neo4j CR manifests against the operator's own validators
+  version     Print the version
+
+Run "kubectl neo4j <command> -h" for command flags.
+`
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+// run is main's testable core: argv in, exit code out, no os.Exit.
+func run(args []string, stdout, stderr *os.File) int {
+	if len(args) == 0 {
+		fmt.Fprint(stderr, usage)
+		return exitUsage
+	}
+
+	switch args[0] {
+	case "validate":
+		return runValidate(args[1:], stdout, stderr)
+	case "version":
+		fmt.Fprintln(stdout, version)
+		return exitOK
+	case "-h", "--help", "help":
+		fmt.Fprint(stdout, usage)
+		return exitOK
+	default:
+		fmt.Fprintf(stderr, "unknown command %q\n\n%s", args[0], usage)
+		return exitUsage
+	}
+}

--- a/cmd/kubectl-neo4j/validate.go
+++ b/cmd/kubectl-neo4j/validate.go
@@ -159,6 +159,11 @@ Usage:
 Runs offline. No cluster connection is made, so checks that resolve
 cross-references (clusterRef, Secrets) are reported as skipped.
 
+Note: the operator stops validating a resource after certain critical errors
+(an invalid image, for example), so fixing the reported errors and re-running
+may surface further ones. A clean run means nothing further is reachable, not
+that nothing was ever wrong.
+
 Exit codes: 0 clean, 1 validation errors (or warnings with --strict), 2 usage.
 
 Flags:

--- a/cmd/kubectl-neo4j/validate.go
+++ b/cmd/kubectl-neo4j/validate.go
@@ -1,0 +1,405 @@
+/*
+Copyright 2025 Priyo Lahiri.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/yaml"
+
+	neo4jv1beta1 "github.com/priyolahiri/neo4j-kubernetes-operator/api/v1beta1"
+	"github.com/priyolahiri/neo4j-kubernetes-operator/internal/validation"
+)
+
+// Exit codes are part of this command's contract with CI, so they are named
+// rather than written as bare integers at the return sites.
+const (
+	exitOK      = 0 // no errors (warnings alone do not fail unless --strict)
+	exitInvalid = 1 // at least one validation error, or a warning under --strict
+	exitUsage   = 2 // bad flags, unreadable input, undecodable YAML
+)
+
+// validators maps a Kind to an offline validation function.
+//
+// Membership here is a claim that the kind's validator is SAFE WITH A NIL
+// KUBERNETES CLIENT, established per kind rather than assumed:
+//
+//   - Neo4jEnterpriseStandalone, Neo4jBackup, Neo4jPlugin — their constructors
+//     take no client at all.
+//   - Neo4jDatabaseAlias, Neo4jReplicaDatabase — their constructors accept a
+//     client and store it, but no code path dereferences it.
+//   - Neo4jEnterpriseCluster — its single client use is
+//     ValidateAdminSecretPassword, which returns early when the client is nil.
+//
+// TestOfflineValidatorsAreNilClientSafe pins every one of those claims, so a
+// future client call added to any of these validators fails a test here rather
+// than panicking in a user's terminal.
+//
+// Kinds NOT listed resolve cross-references (clusterRef, Secrets, roles)
+// through the API server. Running them with no cluster would report "not
+// found" as a validation failure — a false error, which is worse than not
+// checking — so they are reported as skipped until a --context path exists.
+var validators = map[string]func([]byte) (field.ErrorList, []string, error){
+	"Neo4jEnterpriseCluster": func(doc []byte) (field.ErrorList, []string, error) {
+		var obj neo4jv1beta1.Neo4jEnterpriseCluster
+		if err := yaml.Unmarshal(doc, &obj); err != nil {
+			return nil, nil, err
+		}
+		out := validation.NewClusterValidator(nil).ValidateCreateWithWarnings(context.Background(), &obj)
+		return out.Errors, out.Warnings, nil
+	},
+	"Neo4jEnterpriseStandalone": func(doc []byte) (field.ErrorList, []string, error) {
+		var obj neo4jv1beta1.Neo4jEnterpriseStandalone
+		if err := yaml.Unmarshal(doc, &obj); err != nil {
+			return nil, nil, err
+		}
+		return validation.NewStandaloneValidator().ValidateCreate(&obj), nil, nil
+	},
+	"Neo4jBackup": func(doc []byte) (field.ErrorList, []string, error) {
+		var obj neo4jv1beta1.Neo4jBackup
+		if err := yaml.Unmarshal(doc, &obj); err != nil {
+			return nil, nil, err
+		}
+		return validation.NewBackupValidator().Validate(&obj), nil, nil
+	},
+	"Neo4jPlugin": func(doc []byte) (field.ErrorList, []string, error) {
+		var obj neo4jv1beta1.Neo4jPlugin
+		if err := yaml.Unmarshal(doc, &obj); err != nil {
+			return nil, nil, err
+		}
+		out := validation.NewPluginValidator().Validate(&obj)
+		return out.Errors, out.Warnings, nil
+	},
+	"Neo4jDatabaseAlias": func(doc []byte) (field.ErrorList, []string, error) {
+		var obj neo4jv1beta1.Neo4jDatabaseAlias
+		if err := yaml.Unmarshal(doc, &obj); err != nil {
+			return nil, nil, err
+		}
+		out := validation.NewAliasValidator(nil).Validate(context.Background(), &obj)
+		return out.Errors, out.Warnings, nil
+	},
+	"Neo4jReplicaDatabase": func(doc []byte) (field.ErrorList, []string, error) {
+		var obj neo4jv1beta1.Neo4jReplicaDatabase
+		if err := yaml.Unmarshal(doc, &obj); err != nil {
+			return nil, nil, err
+		}
+		out := validation.NewReplicaValidator(nil).Validate(context.Background(), &obj)
+		return out.Errors, out.Warnings, nil
+	},
+}
+
+// finding is one rendered line of output, decoupled from field.Error so that
+// errors and warnings can be sorted and printed uniformly.
+type finding struct {
+	severity string // "error" | "warning"
+	path     string
+	detail   string
+}
+
+// docResult is the outcome for a single YAML document.
+type docResult struct {
+	source   string
+	kind     string
+	name     string
+	skipped  string // non-empty = reason this document was not validated
+	findings []finding
+}
+
+func (d docResult) errorCount() int {
+	n := 0
+	for _, f := range d.findings {
+		if f.severity == "error" {
+			n++
+		}
+	}
+	return n
+}
+
+func (d docResult) warningCount() int { return len(d.findings) - d.errorCount() }
+
+func runValidate(args []string, stdout, stderr *os.File) int {
+	fs := flag.NewFlagSet("validate", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var files multiFlag
+	fs.Var(&files, "f", "Manifest file, directory, or - for stdin. Repeatable.")
+	strict := fs.Bool("strict", false, "Treat warnings as errors (exit non-zero on warnings)")
+	quiet := fs.Bool("quiet", false, "Print findings only; suppress the summary and banner")
+	fs.Usage = func() {
+		fmt.Fprint(stderr, `Validate Neo4j CR manifests against the operator's own validators.
+
+Usage:
+  kubectl neo4j validate -f <file|dir|-> [-f ...] [--strict] [--quiet]
+
+Runs offline. No cluster connection is made, so checks that resolve
+cross-references (clusterRef, Secrets) are reported as skipped.
+
+Exit codes: 0 clean, 1 validation errors (or warnings with --strict), 2 usage.
+
+Flags:
+`)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	if len(files) == 0 {
+		fs.Usage()
+		return exitUsage
+	}
+
+	inputs, err := expandInputs(files)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return exitUsage
+	}
+
+	var results []docResult
+	for _, in := range inputs {
+		rs, err := validateSource(in)
+		if err != nil {
+			fmt.Fprintf(stderr, "error: %s: %v\n", in, err)
+			return exitUsage
+		}
+		results = append(results, rs...)
+	}
+
+	return report(results, stdout, *strict, *quiet)
+}
+
+// validateSource reads one input (a path, or "-" for stdin) and validates every
+// YAML document it contains.
+func validateSource(source string) ([]docResult, error) {
+	var r io.Reader
+	if source == "-" {
+		r = os.Stdin
+	} else {
+		f, err := os.Open(source)
+		if err != nil {
+			return nil, err
+		}
+		defer f.Close()
+		r = f
+	}
+
+	var results []docResult
+	// NewYAMLReader splits on "---" so a single file may hold many objects,
+	// which is how people actually write manifests.
+	reader := k8syaml.NewYAMLReader(bufio.NewReader(r))
+	for {
+		doc, err := reader.Read()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if isEmptyDoc(doc) {
+			continue
+		}
+		res, err := validateDoc(doc, source)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, res)
+	}
+	return results, nil
+}
+
+// isEmptyDoc reports whether a YAML document carries no content at all.
+//
+// A whitespace check is not sufficient: `---\n# a comment\n---` yields a
+// document that is non-empty as bytes but decodes to nothing. Treating that as
+// an object produces a spurious "no kind field" line for every commented
+// separator in a hand-written manifest, which is exactly the kind of noise that
+// makes people stop reading a linter's output.
+func isEmptyDoc(doc []byte) bool {
+	if len(strings.TrimSpace(string(doc))) == 0 {
+		return true
+	}
+	var probe map[string]interface{}
+	if err := yaml.Unmarshal(doc, &probe); err != nil {
+		// Leave malformed YAML to validateDoc, which reports it properly.
+		return false
+	}
+	return len(probe) == 0
+}
+
+// validateDoc decodes one document far enough to learn its Kind, then hands it
+// to the operator's validator for that Kind.
+func validateDoc(doc []byte, source string) (docResult, error) {
+	var meta struct {
+		metav1.TypeMeta   `json:",inline"`
+		metav1.ObjectMeta `json:"metadata,omitempty"`
+	}
+	if err := yaml.Unmarshal(doc, &meta); err != nil {
+		return docResult{}, fmt.Errorf("cannot parse YAML: %w", err)
+	}
+
+	res := docResult{source: source, kind: meta.Kind, name: meta.Name}
+
+	switch {
+	case meta.Kind == "":
+		res.skipped = "no kind field — not a Kubernetes object"
+		return res, nil
+	case !strings.HasPrefix(meta.APIVersion, "neo4j.neo4j.com/"):
+		res.skipped = fmt.Sprintf("not a Neo4j operator resource (apiVersion %q)", meta.APIVersion)
+		return res, nil
+	}
+
+	fn, ok := validators[meta.Kind]
+	if !ok {
+		res.skipped = fmt.Sprintf("%s validation resolves cross-references and needs a cluster connection; not yet supported offline", meta.Kind)
+		return res, nil
+	}
+
+	errs, warns, err := fn(doc)
+	if err != nil {
+		return docResult{}, fmt.Errorf("cannot decode %s: %w", meta.Kind, err)
+	}
+	for _, e := range errs {
+		res.findings = append(res.findings, finding{"error", e.Field, e.ErrorBody()})
+	}
+	for _, w := range warns {
+		res.findings = append(res.findings, finding{"warning", "", w})
+	}
+
+	sort.SliceStable(res.findings, func(i, j int) bool {
+		if res.findings[i].severity != res.findings[j].severity {
+			return res.findings[i].severity == "error"
+		}
+		return res.findings[i].path < res.findings[j].path
+	})
+	return res, nil
+}
+
+func report(results []docResult, stdout *os.File, strict, quiet bool) int {
+	totalErr, totalWarn, validated, skipped := 0, 0, 0, 0
+
+	for _, r := range results {
+		if r.skipped != "" {
+			skipped++
+			if !quiet {
+				fmt.Fprintf(stdout, "- %s: skipped — %s\n", describe(r), r.skipped)
+			}
+			continue
+		}
+		validated++
+		totalErr += r.errorCount()
+		totalWarn += r.warningCount()
+
+		if len(r.findings) == 0 {
+			if !quiet {
+				fmt.Fprintf(stdout, "✓ %s: ok\n", describe(r))
+			}
+			continue
+		}
+		fmt.Fprintf(stdout, "%s:\n", describe(r))
+		for _, f := range r.findings {
+			mark := "✗"
+			if f.severity == "warning" {
+				mark = "⚠"
+			}
+			if f.path != "" {
+				fmt.Fprintf(stdout, "  %s %s: %s\n", mark, f.path, f.detail)
+			} else {
+				fmt.Fprintf(stdout, "  %s %s\n", mark, f.detail)
+			}
+		}
+	}
+
+	if !quiet {
+		fmt.Fprintf(stdout, "\n%d validated, %d skipped — %d error(s), %d warning(s)\n",
+			validated, skipped, totalErr, totalWarn)
+		// Offline output is only authoritative for the release it was built
+		// from. Saying so is the cheap half of the version-skew answer.
+		fmt.Fprintf(stdout, "validated against operator rules %s\n", version)
+	}
+
+	if totalErr > 0 || (strict && totalWarn > 0) {
+		return exitInvalid
+	}
+	return exitOK
+}
+
+func describe(r docResult) string {
+	kind := r.kind
+	if kind == "" {
+		kind = "document"
+	}
+	if r.name == "" {
+		return fmt.Sprintf("%s (%s)", kind, r.source)
+	}
+	return fmt.Sprintf("%s/%s (%s)", kind, r.name, r.source)
+}
+
+// expandInputs turns the -f values into a concrete file list, walking any
+// directory one level for the YAML extensions people actually use.
+func expandInputs(files []string) ([]string, error) {
+	var out []string
+	for _, f := range files {
+		if f == "-" {
+			out = append(out, f)
+			continue
+		}
+		info, err := os.Stat(f)
+		if err != nil {
+			return nil, err
+		}
+		if !info.IsDir() {
+			out = append(out, f)
+			continue
+		}
+		entries, err := os.ReadDir(f)
+		if err != nil {
+			return nil, err
+		}
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			switch strings.ToLower(filepath.Ext(e.Name())) {
+			case ".yaml", ".yml", ".json":
+				out = append(out, filepath.Join(f, e.Name()))
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("no manifest files found")
+	}
+	return out, nil
+}
+
+// multiFlag collects a repeatable string flag.
+type multiFlag []string
+
+func (m *multiFlag) String() string { return strings.Join(*m, ",") }
+func (m *multiFlag) Set(v string) error {
+	*m = append(*m, v)
+	return nil
+}

--- a/cmd/kubectl-neo4j/validate_test.go
+++ b/cmd/kubectl-neo4j/validate_test.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeManifest writes content to a temp file and returns its path.
+func writeManifest(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "manifest.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+const validCluster = `
+apiVersion: neo4j.neo4j.com/v1beta1
+kind: Neo4jEnterpriseCluster
+metadata:
+  name: ok-cluster
+spec:
+  acceptLicenseAgreement: "yes"
+  image: {repo: neo4j, tag: "5.26-enterprise"}
+  topology: {servers: 3}
+  storage: {size: 10Gi}
+`
+
+// TestOfflineValidatorsAreNilClientSafe is the load-bearing test for this
+// command. Every kind in the `validators` map is a claim that its validator
+// tolerates a nil Kubernetes client — three of them because their constructor
+// takes no client, two because they accept one and never dereference it, and
+// one because its single client call returns early on nil.
+//
+// Those are properties of code in internal/validation that this package does
+// not own. If someone adds a client call to any of them, the CLI would panic in
+// a user's terminal with no warning. This test converts that into a build-time
+// failure here.
+func TestOfflineValidatorsAreNilClientSafe(t *testing.T) {
+	// A minimal document per kind — enough to decode and reach the validator.
+	// Correctness of the RESULT is not asserted here; absence of a panic is.
+	docs := map[string]string{
+		"Neo4jEnterpriseCluster":    "apiVersion: neo4j.neo4j.com/v1beta1\nkind: Neo4jEnterpriseCluster\nmetadata: {name: c}\nspec: {}\n",
+		"Neo4jEnterpriseStandalone": "apiVersion: neo4j.neo4j.com/v1beta1\nkind: Neo4jEnterpriseStandalone\nmetadata: {name: s}\nspec: {}\n",
+		"Neo4jBackup":               "apiVersion: neo4j.neo4j.com/v1beta1\nkind: Neo4jBackup\nmetadata: {name: b}\nspec: {}\n",
+		"Neo4jPlugin":               "apiVersion: neo4j.neo4j.com/v1beta1\nkind: Neo4jPlugin\nmetadata: {name: p}\nspec: {}\n",
+		"Neo4jDatabaseAlias":        "apiVersion: neo4j.neo4j.com/v1beta1\nkind: Neo4jDatabaseAlias\nmetadata: {name: a}\nspec: {}\n",
+		"Neo4jReplicaDatabase":      "apiVersion: neo4j.neo4j.com/v1beta1\nkind: Neo4jReplicaDatabase\nmetadata: {name: r}\nspec: {}\n",
+	}
+
+	require.Len(t, docs, len(validators),
+		"every kind in the validators map needs a nil-client probe here — a new kind was added without one")
+
+	for kind, fn := range validators {
+		doc, ok := docs[kind]
+		require.True(t, ok, "no nil-client probe for kind %q", kind)
+		t.Run(kind, func(t *testing.T) {
+			require.NotPanics(t, func() {
+				_, _, err := fn([]byte(doc))
+				assert.NoError(t, err)
+			}, "%s validator dereferenced a nil Kubernetes client", kind)
+		})
+	}
+}
+
+func TestValidate_CleanManifestExitsZero(t *testing.T) {
+	path := writeManifest(t, validCluster)
+	results, err := validateSource(path)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Empty(t, results[0].findings, "expected no findings, got %+v", results[0].findings)
+	assert.Equal(t, 0, results[0].errorCount())
+}
+
+func TestValidate_ReportsErrorsWithFieldPaths(t *testing.T) {
+	path := writeManifest(t, `
+apiVersion: neo4j.neo4j.com/v1beta1
+kind: Neo4jEnterpriseCluster
+metadata:
+  name: bad-cluster
+spec:
+  acceptLicenseAgreement: "yes"
+  image: {repo: neo4j, tag: "5.26-enterprise"}
+  storage: {size: 10Gi}
+  topology:
+    servers: 3
+    serverRoles:
+      - {serverIndex: 7, modeConstraint: "PRIMARY"}
+`)
+	results, err := validateSource(path)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	require.NotEmpty(t, results[0].findings)
+	var paths []string
+	for _, f := range results[0].findings {
+		paths = append(paths, f.path)
+	}
+	assert.Contains(t, strings.Join(paths, " "), "spec.topology.serverRoles[0].serverIndex",
+		"field paths must survive into the rendered finding — they are the point of the command")
+}
+
+// The operator's own spec.config rules are the clearest example of a rule that
+// `kubectl apply --dry-run=server` cannot catch, so it is pinned explicitly.
+func TestValidate_CatchesRulesDryRunCannot(t *testing.T) {
+	path := writeManifest(t, `
+apiVersion: neo4j.neo4j.com/v1beta1
+kind: Neo4jEnterpriseCluster
+metadata:
+  name: cfg
+spec:
+  acceptLicenseAgreement: "yes"
+  image: {repo: neo4j, tag: "5.26-enterprise"}
+  storage: {size: 10Gi}
+  topology: {servers: 3}
+  config:
+    dbms.default_database: "mydb"
+    server.cluster.advertised_address: "foo:6000"
+`)
+	results, err := validateSource(path)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	joined := ""
+	for _, f := range results[0].findings {
+		joined += f.path + " " + f.detail + "\n"
+	}
+	assert.Contains(t, joined, "dbms.default_database")
+	assert.Contains(t, joined, "server.cluster.advertised_address")
+}
+
+func TestValidate_MultiDocumentAndSkips(t *testing.T) {
+	path := writeManifest(t, validCluster+`---
+apiVersion: neo4j.neo4j.com/v1beta1
+kind: Neo4jUser
+metadata: {name: u}
+spec: {clusterRef: {name: c}, username: u}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata: {name: unrelated}
+`)
+	results, err := validateSource(path)
+	require.NoError(t, err)
+	require.Len(t, results, 3)
+
+	assert.Empty(t, results[0].skipped, "the cluster should be validated")
+	assert.Contains(t, results[1].skipped, "cluster connection",
+		"a cross-referencing kind must be skipped, not reported as failing")
+	assert.Contains(t, results[2].skipped, "not a Neo4j operator resource",
+		"non-Neo4j objects must pass through untouched")
+}
+
+func TestValidate_EmptyAndCommentOnlyDocumentsAreIgnored(t *testing.T) {
+	path := writeManifest(t, "---\n# just a comment\n---\n"+validCluster)
+	results, err := validateSource(path)
+	require.NoError(t, err)
+	require.Len(t, results, 1, "blank and comment-only documents must not produce results")
+}
+
+func TestExpandInputs_DirectoryWalk(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.yaml"), []byte(validCluster), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.yml"), []byte(validCluster), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("ignored"), 0o600))
+
+	got, err := expandInputs([]string{dir})
+	require.NoError(t, err)
+	assert.Len(t, got, 2, "only YAML/JSON extensions should be picked up")
+}
+
+func TestExpandInputs_MissingPathIsAUsageError(t *testing.T) {
+	_, err := expandInputs([]string{filepath.Join(t.TempDir(), "nope.yaml")})
+	assert.Error(t, err)
+}

--- a/docs/design/cli-tool.md
+++ b/docs/design/cli-tool.md
@@ -339,6 +339,50 @@ It also functions as a test of the B3 mitigation: if `validate` cannot be built
 without copying something out of `internal/`, that is early evidence the
 shared-package discipline will not hold, and it is far cheaper to learn now.
 
+### 6.1 What the prototype found
+
+Built as `cmd/kubectl-neo4j`. **The B3 discipline held** — not one rule was
+copied out of `internal/`; the command is a decoder, a dispatch table and a
+renderer. Two findings changed the picture, one better than expected and one
+worse.
+
+**Offline coverage is six kinds, not two.** The first cut supported only
+`Neo4jEnterpriseCluster` and `Neo4jEnterpriseStandalone`, on the assumption
+that any validator whose constructor takes a `client.Client` needs a cluster.
+That is not what the code does. Establishing it per kind rather than by
+signature:
+
+| Kind | Why it is safe with a nil client |
+|---|---|
+| `Neo4jEnterpriseStandalone`, `Neo4jBackup`, `Neo4jPlugin` | constructor takes no client |
+| `Neo4jDatabaseAlias`, `Neo4jReplicaDatabase` | constructor accepts a client, stores it, **never dereferences it** |
+| `Neo4jEnterpriseCluster` | single client call is `ValidateAdminSecretPassword`, which returns early on nil |
+
+Those are properties of code this command does not own, so they are pinned by
+`TestOfflineValidatorsAreNilClientSafe`, which probes every kind in the
+dispatch table and fails if the map and the probe list ever diverge. A client
+call added to any of those validators becomes a failing test here rather than a
+panic in a user's terminal.
+
+The remaining kinds resolve `clusterRef`, Secrets or roles through the API
+server. They are reported as *skipped*, never as failing — reporting "not
+found" for a cluster that simply is not reachable would be a false error, which
+is worse than not checking.
+
+**Validation short-circuits, so `validate` may need more than one pass.**
+`validateCluster` returns early when image validation fails
+(`cluster_validator.go:170-174`, *"if image is invalid, other validations are
+less meaningful"*), so a manifest with a bad image reports nothing about
+storage, TLS, auth or `spec.config` until the image is fixed. Observed
+directly: a manifest with both a malformed image and two rejected config keys
+reported only the image and topology errors; correcting the image surfaced the
+config errors on the next run.
+
+This is the operator's own behaviour, faithfully reproduced, and the CLI should
+**not** diverge from it — diverging is exactly the B3 failure this design is
+built to avoid. But it is worse UX for a linter than for a reconciler, and the
+honest options are recorded in §9 Q5 rather than papered over.
+
 ---
 
 ## 7. Testing
@@ -410,6 +454,17 @@ originally assumed:
 make the operator legible; one to humans, one to agents. If `explain` and the
 MCP server end up encoding the same troubleshooting knowledge in two places,
 that is B3 in a new costume. Worth checking before §8 item 6, not before item 1.
+
+**Q5 — Should the operator batch validation errors instead of short-circuiting?**
+Raised by the prototype (§6.1). The early return in `validateCluster` predates
+any CLI and is reasonable for a reconciler, where the user re-reads status after
+each fix anyway. For a linter it means a fix-one-rerun loop.
+
+The fix belongs in the **operator**, not the CLI: remove the early return so
+every validator contributes, and let callers decide what to show. That is an
+operator behaviour change with test impact and its own review, so it is filed
+here rather than smuggled into a CLI change. Until then the CLI's help text
+should say that a clean run after fixes may reveal further errors.
 
 **Q4 — Version skew: mostly resolved by Q2, with one thing left to build.**
 Lockstep release means `kubectl-neo4j vX.Y.Z` encodes operator `vX.Y.Z`'s rules

--- a/docs/design/cli-tool.md
+++ b/docs/design/cli-tool.md
@@ -408,10 +408,24 @@ honest options are recorded in §9 Q5 rather than papered over.
 1. **`validate`, offline only** (§6). One command, no cluster, no release
    pipeline yet — buildable and reviewable as a normal PR, with `go run` and
    `make` targets for local use.
-2. **Cross-compile matrix in `release.yml`** (revised B1). Much smaller than
-   first assessed — a `GOOS`/`GOARCH` matrix writing into `release-artifacts/`,
-   which the existing release step already globs. Settle the asset naming
-   convention here, before anything pins to it.
+2. ~~**Cross-compile matrix in `release.yml`** (revised B1)~~ → **done.** A
+   `GOOS`/`GOARCH` matrix writing into `release-artifacts/`, which the existing
+   release step already globs — no new workflow, as the revised B1 predicted.
+   Five targets, tar.gz for unix and zip for Windows, one checksums file, with
+   an assertion that fails the release rather than shipping a partial asset set.
+
+   The asset naming convention is settled as
+   `kubectl-neo4j_<version>_<os>_<arch>.<ext>` and is now pinned in three
+   places — the release workflow, the release-notes template and the CLI guide.
+   Because that string is a public contract that krew manifests and install
+   scripts depend on, `scripts/check-cli-asset-names.sh` fails CI if the three
+   ever disagree. This repo's own lesson about the CRD catalogue applies
+   directly: two of three surfaces being right is the shape of a drift review
+   miss.
+
+   A CI cross-compile step (`ci.yml`) builds all five targets on every PR, so a
+   unix-only import reaching `cmd/` fails a pull request rather than a tagged
+   release.
 3. **`validate --context`** — the 8 cross-reference validators.
 4. **`status`** (§4.2), then **`connect` / `cypher`** (§4.3).
 5. **krew index submission** (B6), once the command set is stable enough that

--- a/docs/user_guide/guides/cli.md
+++ b/docs/user_guide/guides/cli.md
@@ -1,0 +1,179 @@
+# `kubectl-neo4j` CLI
+
+A small companion CLI for this operator, distributed as a `kubectl` plugin. Today it does one thing: validate your Neo4j manifests **before** you apply them.
+
+!!! warning "Support"
+    The CLI ships with the operator, on the same tag, under the **same support terms as the operator itself**: best-effort via [GitHub issues](https://github.com/priyolahiri/neo4j-kubernetes-operator/issues), no official or commercial support, no SLA, and behaviour may change between releases without notice. A downloadable binary is not a more supported artifact than the operator it comes from.
+
+## Why it exists
+
+This operator has **no admission webhooks** — that is a deliberate architectural invariant, not an omission. The upside is a much simpler install with no certificate plumbing and no webhook outage mode. The downside is that spec mistakes are only reported *after* you apply, through `status` and events:
+
+```
+edit YAML → apply → wait for reconcile → read status → find the mistake → repeat
+```
+
+Across 26 resource kinds and 234 top-level spec fields, that loop is slow.
+
+`kubectl neo4j validate` closes it. It runs **the operator's own validators** against your files, locally, with no cluster connection — so you get the same errors you would have got from the reconciler, before you apply.
+
+## Install
+
+=== "Download a release"
+
+    Binaries are attached to every [release](https://github.com/priyolahiri/neo4j-kubernetes-operator/releases). Pick your platform:
+
+    ```bash
+    VERSION=1.15.0     # the release you want
+    OS=darwin          # darwin | linux | windows
+    ARCH=arm64         # arm64 | amd64
+
+    curl -sSLO "https://github.com/priyolahiri/neo4j-kubernetes-operator/releases/download/v${VERSION}/kubectl-neo4j_${VERSION}_${OS}_${ARCH}.tar.gz"
+    curl -sSLO "https://github.com/priyolahiri/neo4j-kubernetes-operator/releases/download/v${VERSION}/kubectl-neo4j_${VERSION}_checksums.txt"
+    shasum -a 256 -c --ignore-missing "kubectl-neo4j_${VERSION}_checksums.txt"
+
+    tar -xzf "kubectl-neo4j_${VERSION}_${OS}_${ARCH}.tar.gz"
+    chmod +x kubectl-neo4j
+    sudo mv kubectl-neo4j /usr/local/bin/
+    ```
+
+    Windows builds are published as `.zip` rather than `.tar.gz`.
+
+=== "Build from source"
+
+    ```bash
+    git clone https://github.com/priyolahiri/neo4j-kubernetes-operator
+    cd neo4j-kubernetes-operator
+    make build-cli          # writes bin/kubectl-neo4j
+    export PATH="$PWD/bin:$PATH"
+    ```
+
+Anything named `kubectl-*` on your `PATH` becomes a `kubectl` subcommand, so once installed:
+
+```bash
+kubectl neo4j version
+kubectl plugin list        # should list kubectl-neo4j
+```
+
+It also runs standalone as `kubectl-neo4j` if you prefer.
+
+## `validate`
+
+```bash
+kubectl neo4j validate -f cluster.yaml
+kubectl neo4j validate -f manifests/            # a directory
+kubectl neo4j validate -f a.yaml -f b.yaml      # repeatable
+helm template . | kubectl neo4j validate -f -   # stdin
+```
+
+Example output:
+
+```
+Neo4jEnterpriseCluster/prod (cluster.yaml):
+  ✗ spec.config.dbms.default_database: Invalid value: "mydb": deprecated setting: use dbms.setDefaultDatabase() procedure instead
+  ✗ spec.topology.serverRoles[0].serverIndex: Invalid value: 7: must be in range [0, 1]
+  ⚠ Even number of servers (2) may reduce fault tolerance when databases specify odd-numbered server allocations. Consider using an odd number of servers for optimal fault tolerance.
+  ⚠ 2 servers provide limited fault tolerance. If one server fails, databases may lose quorum. Consider using 3 or more servers for production deployments.
+
+1 validated, 0 skipped — 2 error(s), 2 warning(s)
+validated against operator rules v1.15.0
+```
+
+Errors are listed before warnings, each sorted by field path.
+
+### Flags
+
+| Flag | Meaning |
+|---|---|
+| `-f` | File, directory, or `-` for stdin. Repeatable. |
+| `--strict` | Treat warnings as errors (exit non-zero on warnings). |
+| `--quiet` | Print findings only — no per-file "ok" lines, no summary. |
+
+### Exit codes
+
+These are a stable contract, so you can rely on them in CI:
+
+| Code | Meaning |
+|---|---|
+| `0` | No errors. Warnings alone do not fail unless `--strict`. |
+| `1` | At least one validation error (or a warning under `--strict`). |
+| `2` | Usage problem: bad flags, unreadable file, undecodable YAML. |
+
+## What it checks — and what it doesn't
+
+### It is not a replacement for `--dry-run=server`
+
+`kubectl apply --dry-run=server` already enforces the **CRD schema**: field types, enums, numeric ranges, required fields, and the CEL immutability rules. `validate` does **not** duplicate that.
+
+What it adds is everything that lives in the operator's validators *beyond* the schema — the rules the API server has no way to know about:
+
+- cross-field topology rules, `serverRoles` index bounds and duplicate detection
+- `spec.config` keys the operator rejects: deprecated 4.x settings, and keys the operator manages itself at runtime (advertised addresses, discovery, topology)
+- TLS strictness and issuer-capability rules
+- storage, image, and licence-acceptance requirements
+- advisory topology warnings — even server counts, two-server clusters with
+  limited fault tolerance, all-PRIMARY or all-SECONDARY mode constraints
+
+The two are complementary. In CI, run both.
+
+### Kinds validated offline
+
+Six kinds validate with no cluster connection:
+
+`Neo4jEnterpriseCluster` · `Neo4jEnterpriseStandalone` · `Neo4jBackup` · `Neo4jPlugin` · `Neo4jDatabaseAlias` · `Neo4jReplicaDatabase`
+
+Every other kind — `Neo4jDatabase`, `Neo4jUser`, `Neo4jRole`, `Neo4jRoleBinding`, `Neo4jAuthRule`, `Neo4jShardedDatabase` and the Aura resources — resolves cross-references (a `clusterRef`, a Secret, a role) through the Kubernetes API. Those are reported as **skipped**:
+
+```
+- Neo4jUser/analytics (users.yaml): skipped — Neo4jUser validation resolves cross-references and needs a cluster connection; not yet supported offline
+```
+
+**Skipped is not a failure.** Reporting "cluster not found" for a cluster that simply is not reachable would be a false error, which is worse than not checking at all — so the command declines to guess.
+
+### A clean run may not be the last word
+
+The operator stops validating a resource after certain critical errors — an invalid image, for example — because later checks are not meaningful once the image is wrong. `validate` reproduces that faithfully rather than inventing its own behaviour, so:
+
+> Fixing everything reported and re-running may surface **further** errors.
+
+A clean run means nothing further is reachable, not that nothing was ever wrong. Re-run until two consecutive runs agree.
+
+### Version skew
+
+The output always names the ruleset it used:
+
+```
+validated against operator rules v1.15.0
+```
+
+The CLI carries the validation rules of the release it was built from. If your cluster runs a different operator version, a rule added later will not be checked and a rule since removed may still be enforced. **Keep the CLI on the same version as the operator you deploy.**
+
+## In CI
+
+Because it needs no cluster, it fits any pipeline that can run a binary:
+
+```yaml
+- name: Validate Neo4j manifests
+  run: |
+    curl -sSL "https://github.com/priyolahiri/neo4j-kubernetes-operator/releases/download/v${VERSION}/kubectl-neo4j_${VERSION}_linux_amd64.tar.gz" | tar -xz
+    ./kubectl-neo4j validate -f manifests/ --strict
+```
+
+Or as a pre-commit hook:
+
+```yaml
+- repo: local
+  hooks:
+    - id: neo4j-validate
+      name: Validate Neo4j manifests
+      entry: kubectl-neo4j validate -f
+      language: system
+      files: '^manifests/.*\.ya?ml$'
+```
+
+`--strict` is the usual choice for CI: it makes advisory warnings — such as a two-server cluster that will lose quorum if one server fails — block the pipeline rather than scroll past.
+
+## See also
+
+- [Troubleshooting](troubleshooting.md) — diagnosing a deployment that is already running
+- [Resource Sizing](resource_sizing.md) — the floors behind several of the warnings

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -115,6 +115,7 @@ nav:
       - Deployment: user_guide/deployment.md
       - Operator Modes: user_guide/operator-modes.md
       - Try the Demo: user_guide/guides/demo.md
+      - CLI (kubectl-neo4j): user_guide/guides/cli.md
       - Supported Neo4j Versions: user_guide/version_support.md
       - Upgrade Guide: user_guide/migration_guide.md
 

--- a/scripts/check-cli-asset-names.sh
+++ b/scripts/check-cli-asset-names.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Verify the kubectl-neo4j release asset naming convention is identical in
+# every place that pins it.
+#
+# Why this exists: the asset filename is a PUBLIC contract. krew plugin
+# manifests, install scripts, and anyone's CI pin the exact string, so renaming
+# assets silently breaks every existing installer. Three files spell the
+# convention out independently:
+#
+#   .github/workflows/release.yml        — builds and names the archives
+#   .github/release-notes-template.md    — tells users what to download
+#   docs/user_guide/guides/cli.md        — the install instructions
+#
+# This repo already learned that "two of three surfaces being right is the
+# shape of drift review misses" (CLAUDE.md, on the CRD catalogue). Same shape,
+# same guard.
+set -euo pipefail
+
+fail() { echo "ERROR: $*" >&2; exit 1; }
+
+RELEASE_WF=".github/workflows/release.yml"
+NOTES_TMPL=".github/release-notes-template.md"
+CLI_DOC="docs/user_guide/guides/cli.md"
+
+for f in "$RELEASE_WF" "$NOTES_TMPL" "$CLI_DOC"; do
+  [ -f "$f" ] || fail "$f not found"
+done
+
+# The workflow is the source of truth: it builds `kubectl-neo4j_<ver>_<os>_<arch>`
+# with a .tar.gz for unix and a .zip for windows, plus one checksums file.
+grep -q 'stem="kubectl-neo4j_\${CLEAN_TAG}_\${goos}_\${goarch}"' "$RELEASE_WF" \
+  || fail "$RELEASE_WF no longer builds kubectl-neo4j_<version>_<os>_<arch>; update this check and every consumer below"
+grep -q 'kubectl-neo4j_\${CLEAN_TAG}_checksums.txt' "$RELEASE_WF" \
+  || fail "$RELEASE_WF no longer produces kubectl-neo4j_<version>_checksums.txt"
+
+# Consumers must use the same stem, with __VERSION__ / shell-var substitution.
+grep -q 'kubectl-neo4j___VERSION___linux_amd64\.tar\.gz' "$NOTES_TMPL" \
+  || fail "$NOTES_TMPL does not reference kubectl-neo4j___VERSION___linux_amd64.tar.gz"
+grep -q 'kubectl-neo4j___VERSION___windows_amd64\.zip' "$NOTES_TMPL" \
+  || fail "$NOTES_TMPL does not reference the windows .zip asset"
+grep -q 'kubectl-neo4j___VERSION___checksums\.txt' "$NOTES_TMPL" \
+  || fail "$NOTES_TMPL does not reference the checksums asset"
+
+grep -q 'kubectl-neo4j_\${VERSION}_\${OS}_\${ARCH}\.tar\.gz' "$CLI_DOC" \
+  || fail "$CLI_DOC install instructions do not match the released asset name"
+grep -q 'kubectl-neo4j_\${VERSION}_checksums\.txt' "$CLI_DOC" \
+  || fail "$CLI_DOC does not tell users how to fetch the checksums file"
+
+echo "check-cli-asset-names: OK — release workflow, release notes template and CLI guide agree on the asset naming convention."


### PR DESCRIPTION
## Summary

First slice of the CLI designed in #352 — `validate`, offline, one command. Plus a CI fix found while building it.

The case is structural, not ergonomic. Invariant 1 forbids admission webhooks, so the **29 validators** in `internal/validation/` only ever speak to a user *after* they apply — via status and events, across **26 kinds and 234 top-level spec fields**. This closes that loop client-side **without reimplementing a single rule**: the command is a decoder, a dispatch table, and a renderer.

```
$ kubectl neo4j validate -f cluster.yaml
Neo4jEnterpriseCluster/cfg-test (cluster.yaml):
  ✗ spec.config.dbms.default_database: Invalid value: "mydb": deprecated setting: use dbms.setDefaultDatabase() procedure instead
  ✗ spec.config.server.cluster.advertised_address: Forbidden: operator-managed configuration: advertised addresses are set per-pod (FQDN) by the operator at runtime
  ✗ spec.storage.size: Required value: storage size must be specified

1 validated, 0 skipped — 3 error(s), 0 warning(s)
validated against operator rules v1.14.0-23-g28ba7fe
```

Neither of the first two errors is reachable by `kubectl apply --dry-run=server` — they live in `internal/validation`, not the CRD schema. That gap is the whole point.

## Offline coverage is six kinds, not the two the design predicted

I'd assumed any validator whose constructor takes a `client.Client` needs a cluster. That is not what the code does. Established per kind:

| Kind | Why it is nil-client safe |
|---|---|
| `Neo4jEnterpriseStandalone`, `Neo4jBackup`, `Neo4jPlugin` | constructor takes no client |
| `Neo4jDatabaseAlias`, `Neo4jReplicaDatabase` | accept a client, store it, **never dereference it** |
| `Neo4jEnterpriseCluster` | single client call is `ValidateAdminSecretPassword`, which returns early on nil |

Those are properties of code this package does not own, so **`TestOfflineValidatorsAreNilClientSafe` pins every one of them** and fails if the dispatch table and the probe list ever diverge. A client call added to any of those validators becomes a failing test here rather than a panic in a user's terminal.

Kinds that resolve cross-references are reported as **skipped, never as failing** — reporting "not found" for a cluster that is simply unreachable would be a false error, which is worse than not checking.

## The CI fix, found while building this

`test-unit` filtered out `./cmd` via `grep -v "/cmd"`, and `ci.yml` runs only `make test-unit`. **Every test under `cmd/` has never executed in CI** — including `TestDevControllerDefaultCoversRegistry`, which `CLAUDE.md`'s "Adding a CRD" table names as the guard for `devControllerKeys`.

That guard's own comment states the failure it prevents: a key registered in the dev controller registry but missing from the flag default means dev mode *"ACCEPTS the CR and then silently ignores it forever: no status, no events, no logs, indistinguishable from a hung reconcile"* — what the 12 `aura*` keys did before they were added. It has been dormant since it was written.

Removing the exclusion activates it and covers the new package in the same lane. Committed separately (`c5776c1`) so it can stand or be reverted on its own.

## Type of change

- [x] New feature
- [x] Bug fix (CI coverage)

## Testing

- [x] `make test-unit` — zero failures with `/cmd` now included; both `TestDevControllerDefaultCoversRegistry` and `TestOfflineValidatorsAreNilClientSafe` confirmed running
- [x] `make lint` 0 issues, `go vet` clean, `go test -race ./cmd/...` passes
- [x] `make sync-all bundle` — no generated artifact drift
- [x] `check-crd-catalog` / `check-apiref-drift` / `check-knowledge-drift` OK
- [x] Run against the project's own `config/samples/`: 7 documents validated clean, 21 skipped, exit 0

New tests cover clean manifests, field-path preservation, the rules `--dry-run=server` cannot catch, multi-document files, skip classification, comment-only documents, and directory walking.

## One finding filed rather than fixed

**Validation short-circuits.** `validateCluster` returns early when image validation fails (`cluster_validator.go:170-174`, *"if image is invalid, other validations are less meaningful"*), so a manifest with a bad image reports nothing about storage, TLS, auth or `spec.config` until the image is fixed. Reproduced directly.

The CLI deliberately **does not** diverge from this — diverging is exactly the second-source-of-truth failure the design exists to prevent. The fix belongs in the operator (remove the early return, let callers decide what to show), which is a behaviour change with its own test impact, so it is filed as **Q5** in the design doc rather than smuggled in here.

## Not in this PR

No release pipeline yet (design item 2), no `--context` path for the 8 cross-referencing validators (item 3), no krew submission. `make build-cli` builds it locally with the version stamped from `git describe`.