### PR TITLE
fix(validation): report every cluster error, not just the first critical one

### DIFF
--- a/internal/validation/cluster_validator.go
+++ b/internal/validation/cluster_validator.go
@@ -167,14 +167,23 @@ func (v *ClusterValidator) validateCluster(ctx context.Context, cluster *neo4jv1
 	// Validate topology (second most critical)
 	allErrs = append(allErrs, v.topologyValidator.Validate(cluster)...)
 
-	// Validate image (fail fast if image validation fails)
-	if imageErrs := v.imageValidator.Validate(cluster); len(imageErrs) > 0 {
-		allErrs = append(allErrs, imageErrs...)
-		// If image is invalid, other validations are less meaningful
-		return allErrs
-	}
+	// Validate image.
+	//
+	// This used to `return` early when the image was invalid, on the reasoning
+	// that "other validations are less meaningful" once it is. That is true of
+	// the *deployment*, but not of the *feedback*: this operator has no
+	// admission webhook, so a user's only channel is the errors this function
+	// produces. Returning early meant a bad image hid every storage, TLS, auth
+	// and spec.config problem until it was fixed, turning one apply into a
+	// fix-one-rerun loop — and the same loop in `kubectl neo4j validate`, which
+	// calls this code directly.
+	//
+	// Every validator below is independent of the image: none reads it except
+	// validatePropertySharding, which is opt-in and returns an error rather
+	// than assuming a parseable tag. TestValidateCluster_ReportsAllErrors pins
+	// that this function keeps reporting the full set.
+	allErrs = append(allErrs, v.imageValidator.Validate(cluster)...)
 
-	// Continue with remaining validations only if critical ones pass
 	allErrs = append(allErrs, v.storageValidator.Validate(cluster)...)
 	allErrs = append(allErrs, v.tlsValidator.Validate(cluster)...)
 	allErrs = append(allErrs, v.authValidator.Validate(cluster)...)

--- a/internal/validation/cluster_validator_test.go
+++ b/internal/validation/cluster_validator_test.go
@@ -263,3 +263,66 @@ func TestClusterValidator_NameLength(t *testing.T) {
 		})
 	}
 }
+
+// TestValidateCluster_ReportsAllErrors pins the removal of the early return
+// that used to abort validation as soon as the image was invalid.
+//
+// The operator has no admission webhook, so the ErrorList this function returns
+// is a user's ONLY feedback channel — both through status/events and through
+// `kubectl neo4j validate`, which calls it directly. Aborting on the first
+// critical error turned a single apply into a fix-one-rerun loop, where each
+// pass revealed problems the previous one had hidden.
+func TestValidateCluster_ReportsAllErrors(t *testing.T) {
+	// Deliberately broken in several independent dimensions at once. Before
+	// this change only the image (and the checks ahead of it) were reported.
+	cluster := &neo4jv1beta1.Neo4jEnterpriseCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "broken", Namespace: "default"},
+		Spec: neo4jv1beta1.Neo4jEnterpriseClusterSpec{
+			AcceptLicenseAgreement: "yes",
+			Image:                  neo4jv1beta1.ImageSpec{}, // invalid: no repo, no tag
+			Topology:               neo4jv1beta1.TopologyConfiguration{Servers: 3},
+			Config: map[string]string{
+				// Rejected by configValidator, which runs AFTER the image check.
+				"dbms.default_database": "mydb",
+			},
+		},
+	}
+
+	errs := NewClusterValidator(nil).validateCluster(context.Background(), cluster)
+	joined := errs.ToAggregate().Error()
+
+	for _, want := range []struct{ substr, why string }{
+		{"spec.image", "the image error must still be reported"},
+		{"dbms.default_database", "a spec.config error must be reported ALONGSIDE the image error, not hidden behind it"},
+		{"spec.storage", "a storage error must be reported alongside the image error too"},
+	} {
+		if !strings.Contains(joined, want.substr) {
+			t.Errorf("missing %q in validation errors: %s\ngot: %s", want.substr, want.why, joined)
+		}
+	}
+}
+
+// Property sharding is the only validator after the image check that reads the
+// image, so it is the one that could plausibly panic on a spec that never used
+// to reach it. It must produce an error, not a crash.
+func TestValidateCluster_ShardingWithInvalidImageDoesNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("validateCluster panicked on sharding with an unparseable image tag: %v", r)
+		}
+	}()
+
+	cluster := &neo4jv1beta1.Neo4jEnterpriseCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "sharded", Namespace: "default"},
+		Spec: neo4jv1beta1.Neo4jEnterpriseClusterSpec{
+			AcceptLicenseAgreement: "yes",
+			Image:                  neo4jv1beta1.ImageSpec{}, // no tag to parse a version from
+			Topology:               neo4jv1beta1.TopologyConfiguration{Servers: 3},
+			PropertySharding:       &neo4jv1beta1.PropertyShardingSpec{Enabled: true},
+		},
+	}
+
+	if errs := NewClusterValidator(nil).validateCluster(context.Background(), cluster); len(errs) == 0 {
+		t.Error("expected errors for an unparseable image tag with sharding enabled, got none")
+	}
+}


### PR DESCRIPTION
## Summary

Resolves **Q5** from `docs/design/cli-tool.md` — raised while building the `validate` prototype in #353, and fixed here in the operator where it belongs rather than worked around in the CLI.

`validateCluster` returned early the moment image validation failed:

```go
if imageErrs := v.imageValidator.Validate(cluster); len(imageErrs) > 0 {
    allErrs = append(allErrs, imageErrs...)
    // If image is invalid, other validations are less meaningful
    return allErrs
}
```

That reasoning holds for the **deployment** but not for the **feedback**. This operator has no admission webhook by invariant, so the `ErrorList` this function returns is a user's *only* channel — through status and events, and now also through `kubectl neo4j validate`, which calls the same code directly.

The effect was a fix-one-rerun loop, where each pass revealed problems the previous one had hidden. Observed directly while building the CLI: a manifest with a malformed image **and** two rejected `spec.config` keys reported only the image and topology errors. Correcting the image surfaced the config errors on the next run.

## Is it safe to remove?

Every validator after the image check is independent of the image. The one exception is `validatePropertySharding`, which:

- only runs when `spec.propertySharding.enabled` is true, and
- returns a `field.Invalid` rather than assuming a parseable tag.

So the worst case for a sharded cluster with a broken image is two errors on `spec.image.tag` — redundant, but correct, and better than silence.

## Testing

- [x] `make test-unit` — all packages green, controller tests included (62s run, nothing depended on the short-circuit)
- [x] `make lint` 0 issues, `go vet` clean
- [x] `internal/validation` coverage 76.6% → 77.3%

Two new tests:

- **`TestValidateCluster_ReportsAllErrors`** — asserts image, storage and `spec.config` errors all appear together. **Verified to FAIL when the early return is reinstated**, so it pins the behaviour rather than passing incidentally:

  ```
  --- FAIL: TestValidateCluster_ReportsAllErrors
      missing "dbms.default_database": a spec.config error must be reported ALONGSIDE the image error
      got: [spec.image.repo: Required value..., spec.image.tag: Required value...]
  ```

- **`TestValidateCluster_ShardingWithInvalidImageDoesNotPanic`** — covers the one validator that now sees specs it never used to reach.

## Type of change

- [x] Bug fix

## Note on sequencing

`docs/design/cli-tool.md`'s Q5 entry lands in #353 and is not on `main` yet, so this PR does not edit it. Once both merge, that entry should be marked resolved — worth doing in whichever lands second.

## Worth knowing

Users with several independent problems will now see a longer aggregate error in `status` and events than before. That is the intended trade — one complete list beats several sequential partial ones — but it is a visible change in output length for anyone parsing those messages.