### PR TITLE
feat(cli): install ergonomics — go install, install script, Helm pointer

### DIFF
--- a/charts/neo4j-operator/templates/NOTES.txt
+++ b/charts/neo4j-operator/templates/NOTES.txt
@@ -91,6 +91,25 @@ ServiceMonitor has been created for Prometheus Operator integration.
 {{- end }}
 {{- end }}
 
+## Optional: the kubectl-neo4j CLI
+
+Helm cannot install it — it runs on YOUR machine, not in the cluster — but the
+chart knows which version you need. Validate manifests against this operator's
+own rules BEFORE you apply them:
+
+  go install github.com/priyolahiri/neo4j-kubernetes-operator/cmd/kubectl-neo4j@v{{ .Chart.AppVersion }}
+
+or, without Go:
+
+  curl -sSL https://raw.githubusercontent.com/priyolahiri/neo4j-kubernetes-operator/main/hack/install-cli.sh | VERSION={{ .Chart.AppVersion }} sh
+
+Then:
+
+  kubectl neo4j validate -f your-manifests/
+
+Keep it on the same version as the operator ({{ .Chart.AppVersion }}) — it carries
+that release's validation rules.
+
 ## Documentation
 
 For more information, visit:

--- a/docs/design/cli-tool.md
+++ b/docs/design/cli-tool.md
@@ -469,16 +469,20 @@ make the operator legible; one to humans, one to agents. If `explain` and the
 MCP server end up encoding the same troubleshooting knowledge in two places,
 that is B3 in a new costume. Worth checking before §8 item 6, not before item 1.
 
-**Q5 — Should the operator batch validation errors instead of short-circuiting?**
-Raised by the prototype (§6.1). The early return in `validateCluster` predates
-any CLI and is reasonable for a reconciler, where the user re-reads status after
-each fix anyway. For a linter it means a fix-one-rerun loop.
+**Q5 — ANSWERED and fixed in the operator.** Raised by the prototype (§6.1):
+`validateCluster`'s early return on image failure meant a fix-one-rerun loop.
 
-The fix belongs in the **operator**, not the CLI: remove the early return so
-every validator contributes, and let callers decide what to show. That is an
-operator behaviour change with test impact and its own review, so it is filed
-here rather than smuggled into a CLI change. Until then the CLI's help text
-should say that a clean run after fixes may reveal further errors.
+Fixed where it belonged — the operator, not the CLI — by removing the early
+return so every validator contributes. Two tests pin it, one of which was
+verified to fail when the early return is reinstated rather than merely passing
+today. The same broken manifest that previously reported 6 errors now reports
+9, with the `spec.config` and `spec.storage` problems no longer hidden behind
+the image check.
+
+The CLI needed no change: it renders whatever the validators return, which is
+precisely why not diverging (§3 B3) was the right call. The caveat in its help
+text stays, because the operator still short-circuits in *other* validators and
+the general warning remains true.
 
 **Q4 — Version skew: mostly resolved by Q2, with one thing left to build.**
 Lockstep release means `kubectl-neo4j vX.Y.Z` encodes operator `vX.Y.Z`'s rules

--- a/docs/user_guide/guides/cli.md
+++ b/docs/user_guide/guides/cli.md
@@ -19,6 +19,42 @@ Across 26 resource kinds and 234 top-level spec fields, that loop is slow.
 
 ## Install
 
+=== "go install"
+
+    The simplest path if you have Go, and the only one that needs no release
+    asset at all — the module is published on the Go proxy:
+
+    ```bash
+    go install github.com/priyolahiri/neo4j-kubernetes-operator/cmd/kubectl-neo4j@v1.15.0
+    ```
+
+    It installs into `$(go env GOPATH)/bin` under the name `kubectl-neo4j`,
+    which is exactly what `kubectl` needs for plugin discovery. Pin the version
+    to the operator release you deploy — `@latest` will drift.
+
+=== "Install script"
+
+    Detects your OS and architecture, downloads the matching archive, and
+    **verifies its checksum before installing** — it aborts rather than
+    installing something it could not verify:
+
+    ```bash
+    curl -sSL https://raw.githubusercontent.com/priyolahiri/neo4j-kubernetes-operator/main/hack/install-cli.sh | sh
+    ```
+
+    Pipe-to-shell means trusting the network round trip. Downloading first and
+    reading it is the better habit:
+
+    ```bash
+    curl -sSLO https://raw.githubusercontent.com/priyolahiri/neo4j-kubernetes-operator/main/hack/install-cli.sh
+    less install-cli.sh
+    sh install-cli.sh
+    ```
+
+    Two knobs: `VERSION` (default: latest release) and `INSTALL_DIR`
+    (default: `/usr/local/bin`). Windows is not covered — use the `.zip`
+    asset.
+
 === "Download a release"
 
     Binaries are attached to every [release](https://github.com/priyolahiri/neo4j-kubernetes-operator/releases). Pick your platform:

--- a/hack/install-cli.sh
+++ b/hack/install-cli.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env sh
+#
+# Install the kubectl-neo4j plugin.
+#
+#   curl -sSL https://raw.githubusercontent.com/priyolahiri/neo4j-kubernetes-operator/main/hack/install-cli.sh | sh
+#
+# Prefer downloading and reading this script before running it — piping any
+# installer straight into a shell means trusting the network round-trip.
+#
+# Environment:
+#   VERSION      release to install, without the leading "v" (default: latest)
+#   INSTALL_DIR  destination directory (default: /usr/local/bin)
+#
+# Checksum verification is MANDATORY, not best-effort: the script aborts if it
+# cannot verify, rather than installing an unverified binary. An installer that
+# silently degrades to "no integrity check" is worse than one that fails.
+set -eu
+
+REPO="priyolahiri/neo4j-kubernetes-operator"
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+
+die() { printf 'error: %s\n' "$*" >&2; exit 1; }
+info() { printf '%s\n' "$*"; }
+
+need() { command -v "$1" >/dev/null 2>&1 || die "$1 is required but not installed"; }
+need curl
+need tar
+
+# --- platform -----------------------------------------------------------
+os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+case "$os" in
+  darwin|linux) ;;
+  mingw*|msys*|cygwin*)
+    die "Windows is not supported by this script — download the .zip asset from https://github.com/${REPO}/releases" ;;
+  *) die "unsupported operating system: ${os}" ;;
+esac
+
+arch="$(uname -m)"
+case "$arch" in
+  x86_64|amd64) arch="amd64" ;;
+  arm64|aarch64) arch="arm64" ;;
+  *) die "unsupported architecture: ${arch}" ;;
+esac
+
+# --- version ------------------------------------------------------------
+if [ -z "${VERSION:-}" ]; then
+  info "resolving latest release..."
+  # Ask the API for the latest tag rather than relying on the /latest redirect,
+  # so a failure here is a clear error instead of a 404 much later.
+  VERSION="$(curl -sSL "https://api.github.com/repos/${REPO}/releases/latest" \
+    | sed -n 's/.*"tag_name" *: *"v\{0,1\}\([^"]*\)".*/\1/p' | head -n 1)"
+  [ -n "$VERSION" ] || die "could not determine the latest release — set VERSION explicitly"
+fi
+VERSION="${VERSION#v}"
+
+# This filename is a public contract shared with the release workflow, the
+# release-notes template and the CLI guide; scripts/check-cli-asset-names.sh
+# fails CI if they ever disagree. Do not change it here alone.
+ARCHIVE="kubectl-neo4j_${VERSION}_${os}_${arch}.tar.gz"
+CHECKSUMS="kubectl-neo4j_${VERSION}_checksums.txt"
+BASE="https://github.com/${REPO}/releases/download/v${VERSION}"
+
+tmp="$(mktemp -d)"
+# shellcheck disable=SC2064
+trap "rm -rf '$tmp'" EXIT INT TERM
+
+info "downloading kubectl-neo4j ${VERSION} (${os}/${arch})..."
+curl -sSLf -o "${tmp}/${ARCHIVE}" "${BASE}/${ARCHIVE}" \
+  || die "download failed — does release v${VERSION} publish ${ARCHIVE}?"
+curl -sSLf -o "${tmp}/${CHECKSUMS}" "${BASE}/${CHECKSUMS}" \
+  || die "could not fetch ${CHECKSUMS}; refusing to install an unverified binary"
+
+# --- verify -------------------------------------------------------------
+if command -v shasum >/dev/null 2>&1; then
+  SUMCMD="shasum -a 256"
+elif command -v sha256sum >/dev/null 2>&1; then
+  SUMCMD="sha256sum"
+else
+  die "neither shasum nor sha256sum found; refusing to install an unverified binary"
+fi
+
+expected="$(grep " ${ARCHIVE}\$" "${tmp}/${CHECKSUMS}" | awk '{print $1}')"
+[ -n "$expected" ] || die "${ARCHIVE} is not listed in ${CHECKSUMS}"
+actual="$(cd "$tmp" && $SUMCMD "${ARCHIVE}" | awk '{print $1}')"
+[ "$expected" = "$actual" ] || die "checksum mismatch for ${ARCHIVE} (expected ${expected}, got ${actual})"
+info "checksum verified"
+
+# --- install ------------------------------------------------------------
+tar -xzf "${tmp}/${ARCHIVE}" -C "$tmp"
+[ -f "${tmp}/kubectl-neo4j" ] || die "archive did not contain kubectl-neo4j"
+chmod +x "${tmp}/kubectl-neo4j"
+
+if [ -w "$INSTALL_DIR" ]; then
+  mv "${tmp}/kubectl-neo4j" "${INSTALL_DIR}/kubectl-neo4j"
+elif command -v sudo >/dev/null 2>&1; then
+  info "${INSTALL_DIR} is not writable; using sudo"
+  sudo mv "${tmp}/kubectl-neo4j" "${INSTALL_DIR}/kubectl-neo4j"
+else
+  die "${INSTALL_DIR} is not writable and sudo is unavailable — set INSTALL_DIR to a writable directory"
+fi
+
+info "installed ${INSTALL_DIR}/kubectl-neo4j"
+case ":${PATH}:" in
+  *":${INSTALL_DIR}:"*) info "run: kubectl neo4j validate -f your-manifests/" ;;
+  *) info "note: ${INSTALL_DIR} is not on your PATH — add it, then run: kubectl neo4j validate -f your-manifests/" ;;
+esac

--- a/scripts/check-cli-asset-names.sh
+++ b/scripts/check-cli-asset-names.sh
@@ -10,6 +10,7 @@
 #   .github/workflows/release.yml        — builds and names the archives
 #   .github/release-notes-template.md    — tells users what to download
 #   docs/user_guide/guides/cli.md        — the install instructions
+#   hack/install-cli.sh                  — downloads and verifies them
 #
 # This repo already learned that "two of three surfaces being right is the
 # shape of drift review misses" (CLAUDE.md, on the CRD catalogue). Same shape,
@@ -21,8 +22,9 @@ fail() { echo "ERROR: $*" >&2; exit 1; }
 RELEASE_WF=".github/workflows/release.yml"
 NOTES_TMPL=".github/release-notes-template.md"
 CLI_DOC="docs/user_guide/guides/cli.md"
+INSTALL_SH="hack/install-cli.sh"
 
-for f in "$RELEASE_WF" "$NOTES_TMPL" "$CLI_DOC"; do
+for f in "$RELEASE_WF" "$NOTES_TMPL" "$CLI_DOC" "$INSTALL_SH"; do
   [ -f "$f" ] || fail "$f not found"
 done
 
@@ -46,4 +48,12 @@ grep -q 'kubectl-neo4j_\${VERSION}_\${OS}_\${ARCH}\.tar\.gz' "$CLI_DOC" \
 grep -q 'kubectl-neo4j_\${VERSION}_checksums\.txt' "$CLI_DOC" \
   || fail "$CLI_DOC does not tell users how to fetch the checksums file"
 
-echo "check-cli-asset-names: OK — release workflow, release notes template and CLI guide agree on the asset naming convention."
+# The install script builds the same names at runtime. If it drifts, users get
+# a 404 from a URL they never typed, which is the least debuggable failure of
+# the four surfaces.
+grep -q 'ARCHIVE="kubectl-neo4j_\${VERSION}_\${os}_\${arch}\.tar\.gz"' "$INSTALL_SH" \
+  || fail "$INSTALL_SH no longer builds kubectl-neo4j_<version>_<os>_<arch>.tar.gz"
+grep -q 'CHECKSUMS="kubectl-neo4j_\${VERSION}_checksums\.txt"' "$INSTALL_SH" \
+  || fail "$INSTALL_SH no longer fetches kubectl-neo4j_<version>_checksums.txt"
+
+echo "check-cli-asset-names: OK — release workflow, release notes template, CLI guide and install script agree on the asset naming convention."


### PR DESCRIPTION
## Summary

Follow-up to #353 on merged `main`. Three install paths, plus the guard the fourth surface needs.

### 1. `go install` — free, and it already works

The module is published on the Go proxy, so this needs **no release asset and no infrastructure**:

```bash
go install github.com/priyolahiri/neo4j-kubernetes-operator/cmd/kubectl-neo4j@v1.15.0
```

I verified the mechanism end to end against the existing `v1.14.0` tag rather than assuming it. It installs a binary named `kubectl-neo4j` — exactly what `kubectl` needs for plugin discovery.

### 2. `hack/install-cli.sh` — for people without Go

Detects OS/arch, resolves the latest release (or honours `VERSION`), downloads, and **verifies the checksum before installing**.

Verification is mandatory, not best-effort: the script aborts if it cannot verify rather than degrading to an unverified install. An installer that silently skips its integrity check is worse than one that fails.

### 3. Helm `NOTES.txt` — answering your question directly

**Helm cannot install the CLI.** Helm installs objects into a cluster; the CLI runs on the user's workstation. No chart, hook, or Job can write to someone's `PATH`. That's a category mismatch, not a missing feature.

What the chart *can* do is tell you at the one moment you're guaranteed to be paying attention — just after `helm install` — with the version already filled in from `.Chart.AppVersion`:

```
## Optional: the kubectl-neo4j CLI

Helm cannot install it — it runs on YOUR machine, not in the cluster — but the
chart knows which version you need. ...

  go install github.com/priyolahiri/neo4j-kubernetes-operator/cmd/kubectl-neo4j@v1.15.0
```

The note says plainly *why* Helm isn't doing the installing, so nobody goes hunting for a `values.yaml` flag that cannot exist.

## The guard grows a fourth surface

The asset filename is now pinned in **four** places — release workflow, release-notes template, CLI guide, and now the install script. `scripts/check-cli-asset-names.sh` covers all four.

Drift in the install script is the least debuggable of them: the user gets a 404 for a URL they never typed. Verified the guard **catches** that, not merely that it passes today:

```
ERROR: hack/install-cli.sh no longer builds kubectl-neo4j_<version>_<os>_<arch>.tar.gz
exit=1
```

## Q5 marked resolved

#354 fixed the short-circuit in the operator. The combined effect is visible: the same broken manifest that previously reported **6** errors now reports **9**, with the `spec.config` and `spec.storage` problems no longer hidden behind the image check.

The CLI needed no change for that — it renders whatever the validators return. Which is precisely why not diverging from the operator (design §3 B3) was the right call.

## Type of change

- [x] New feature
- [x] Documentation

## Testing

- [x] `install-cli.sh` — version resolution tested against the live GitHub API; missing-asset path tested against `v1.14.0` (produces a clean, actionable message, not a raw 404); checksum-match and extract paths tested against real archives built from the release logic
- [x] Archive layout confirmed correct — binary at the root, no nested directory (matters for both the script and any future krew manifest)
- [x] `helm lint` clean; `NOTES.txt` rendered via `helm install --dry-run` and inspected
- [x] `make check-cli-asset-names` extended and verified to fail on drift in the new surface
- [x] `make lint` 0 issues, `go build ./...`, `mkdocs build` clean
- [x] `check-crd-catalog` / `check-apiref-drift` / `check-knowledge-drift` OK

## Still not built

krew (`kubectl krew install neo4j`) remains the best answer for discoverability and the most work — a plugin manifest with per-platform SHA256s regenerated each release, plus an external review cycle on krew-index, structurally like the OperatorHub submission flow. Design items 3–6 (`validate --context`, `status`, `connect`, `explain`, `support-bundle`) are untouched.