### PR TITLE
feat(cli): validate --connect — cross-reference checks against a cluster

### DIFF
--- a/cmd/kubectl-neo4j/validate.go
+++ b/cmd/kubectl-neo4j/validate.go
@@ -28,9 +28,14 @@ import (
 	"sort"
 	"strings"
 
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
 	neo4jv1beta1 "github.com/priyolahiri/neo4j-kubernetes-operator/api/v1beta1"
@@ -45,73 +50,141 @@ const (
 	exitUsage   = 2 // bad flags, unreadable input, undecodable YAML
 )
 
-// validators maps a Kind to an offline validation function.
+// validatorFn runs one kind's validator. The client is nil unless the user
+// asked to connect (--connect / --context / --kubeconfig).
+// validatorFn runs one kind's validator. The client is nil unless the user
+// asked to connect. The third return is PENDING: transient dependency gaps
+// (a password Secret not applied yet) that the operator routes to phase
+// Pending rather than failing on. They are neither errors nor warnings, and
+// dropping them would hide the difference between "wrong" and "not yet".
+type validatorFn func(doc []byte, c client.Client) (errs field.ErrorList, warnings, pending []string, err error)
+
+// kindValidator pairs a validator with whether it can run without a cluster.
+type kindValidator struct {
+	fn validatorFn
+	// needsClient marks validators that resolve cross-references (a clusterRef,
+	// a Secret, a role) through the API server. Run offline they would report
+	// "not found" for things that merely are not reachable — a false error,
+	// which is worse than not checking — so they are skipped unless connected.
+	needsClient bool
+}
+
+// validators is the full set of kinds this operator has a Go validator for.
 //
-// Membership here is a claim that the kind's validator is SAFE WITH A NIL
-// KUBERNETES CLIENT, established per kind rather than assumed:
+// It is NOT every CRD. Of the operator's 26 kinds only these 12 have
+// operator-side validation at all; the rest (the Aura suite, Neo4jRestore,
+// Neo4jReplicaPromotion) are governed by their CRD schema alone, which
+// `kubectl apply --dry-run=server` already enforces. Saying so precisely
+// matters: an earlier version of this command told users those kinds needed a
+// cluster connection, which implied --context would validate them. It will not.
 //
-//   - Neo4jEnterpriseStandalone, Neo4jBackup, Neo4jPlugin — their constructors
-//     take no client at all.
-//   - Neo4jDatabaseAlias, Neo4jReplicaDatabase — their constructors accept a
-//     client and store it, but no code path dereferences it.
-//   - Neo4jEnterpriseCluster — its single client use is
-//     ValidateAdminSecretPassword, which returns early when the client is nil.
-//
-// TestOfflineValidatorsAreNilClientSafe pins every one of those claims, so a
-// future client call added to any of these validators fails a test here rather
-// than panicking in a user's terminal.
-//
-// Kinds NOT listed resolve cross-references (clusterRef, Secrets, roles)
-// through the API server. Running them with no cluster would report "not
-// found" as a validation failure — a false error, which is worse than not
-// checking — so they are reported as skipped until a --context path exists.
-var validators = map[string]func([]byte) (field.ErrorList, []string, error){
-	"Neo4jEnterpriseCluster": func(doc []byte) (field.ErrorList, []string, error) {
+// needsClient:false is a claim that the validator tolerates a nil client,
+// established per kind and pinned by TestOfflineValidatorsAreNilClientSafe:
+//   - Standalone, Backup, Plugin — constructor takes no client.
+//   - DatabaseAlias, ReplicaDatabase — accept a client and never dereference it.
+//   - EnterpriseCluster — its one client call returns early on nil.
+var validators = map[string]kindValidator{
+	"Neo4jEnterpriseCluster": {fn: func(doc []byte, c client.Client) (field.ErrorList, []string, []string, error) {
 		var obj neo4jv1beta1.Neo4jEnterpriseCluster
 		if err := yaml.Unmarshal(doc, &obj); err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
-		out := validation.NewClusterValidator(nil).ValidateCreateWithWarnings(context.Background(), &obj)
-		return out.Errors, out.Warnings, nil
-	},
-	"Neo4jEnterpriseStandalone": func(doc []byte) (field.ErrorList, []string, error) {
+		out := validation.NewClusterValidator(c).ValidateCreateWithWarnings(context.Background(), &obj)
+		return out.Errors, out.Warnings, nil, nil
+	}},
+	"Neo4jEnterpriseStandalone": {fn: func(doc []byte, _ client.Client) (field.ErrorList, []string, []string, error) {
 		var obj neo4jv1beta1.Neo4jEnterpriseStandalone
 		if err := yaml.Unmarshal(doc, &obj); err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
-		return validation.NewStandaloneValidator().ValidateCreate(&obj), nil, nil
-	},
-	"Neo4jBackup": func(doc []byte) (field.ErrorList, []string, error) {
+		return validation.NewStandaloneValidator().ValidateCreate(&obj), nil, nil, nil
+	}},
+	"Neo4jBackup": {fn: func(doc []byte, _ client.Client) (field.ErrorList, []string, []string, error) {
 		var obj neo4jv1beta1.Neo4jBackup
 		if err := yaml.Unmarshal(doc, &obj); err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
-		return validation.NewBackupValidator().Validate(&obj), nil, nil
-	},
-	"Neo4jPlugin": func(doc []byte) (field.ErrorList, []string, error) {
+		return validation.NewBackupValidator().Validate(&obj), nil, nil, nil
+	}},
+	"Neo4jPlugin": {fn: func(doc []byte, _ client.Client) (field.ErrorList, []string, []string, error) {
 		var obj neo4jv1beta1.Neo4jPlugin
 		if err := yaml.Unmarshal(doc, &obj); err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 		out := validation.NewPluginValidator().Validate(&obj)
-		return out.Errors, out.Warnings, nil
-	},
-	"Neo4jDatabaseAlias": func(doc []byte) (field.ErrorList, []string, error) {
+		return out.Errors, out.Warnings, nil, nil
+	}},
+	"Neo4jDatabaseAlias": {fn: func(doc []byte, c client.Client) (field.ErrorList, []string, []string, error) {
 		var obj neo4jv1beta1.Neo4jDatabaseAlias
 		if err := yaml.Unmarshal(doc, &obj); err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
-		out := validation.NewAliasValidator(nil).Validate(context.Background(), &obj)
-		return out.Errors, out.Warnings, nil
-	},
-	"Neo4jReplicaDatabase": func(doc []byte) (field.ErrorList, []string, error) {
+		out := validation.NewAliasValidator(c).Validate(context.Background(), &obj)
+		return out.Errors, out.Warnings, nil, nil
+	}},
+	"Neo4jReplicaDatabase": {fn: func(doc []byte, c client.Client) (field.ErrorList, []string, []string, error) {
 		var obj neo4jv1beta1.Neo4jReplicaDatabase
 		if err := yaml.Unmarshal(doc, &obj); err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
-		out := validation.NewReplicaValidator(nil).Validate(context.Background(), &obj)
-		return out.Errors, out.Warnings, nil
-	},
+		out := validation.NewReplicaValidator(c).Validate(context.Background(), &obj)
+		return out.Errors, out.Warnings, nil, nil
+	}},
+
+	// --- require a cluster connection ---------------------------------
+	"Neo4jDatabase": {needsClient: true, fn: func(doc []byte, c client.Client) (field.ErrorList, []string, []string, error) {
+		var obj neo4jv1beta1.Neo4jDatabase
+		if err := yaml.Unmarshal(doc, &obj); err != nil {
+			return nil, nil, nil, err
+		}
+		out := validation.NewDatabaseValidator(c).Validate(context.Background(), &obj)
+		return out.Errors, out.Warnings, nil, nil
+	}},
+	"Neo4jUser": {needsClient: true, fn: func(doc []byte, c client.Client) (field.ErrorList, []string, []string, error) {
+		var obj neo4jv1beta1.Neo4jUser
+		if err := yaml.Unmarshal(doc, &obj); err != nil {
+			return nil, nil, nil, err
+		}
+		out := validation.NewUserValidator(c).Validate(context.Background(), &obj)
+		return out.Errors, out.Warnings, out.Pending, nil
+	}},
+	"Neo4jRole": {needsClient: true, fn: func(doc []byte, c client.Client) (field.ErrorList, []string, []string, error) {
+		var obj neo4jv1beta1.Neo4jRole
+		if err := yaml.Unmarshal(doc, &obj); err != nil {
+			return nil, nil, nil, err
+		}
+		out := validation.NewRoleValidator(c).Validate(context.Background(), &obj)
+		return out.Errors, out.Warnings, nil, nil
+	}},
+	"Neo4jRoleBinding": {needsClient: true, fn: func(doc []byte, c client.Client) (field.ErrorList, []string, []string, error) {
+		var obj neo4jv1beta1.Neo4jRoleBinding
+		if err := yaml.Unmarshal(doc, &obj); err != nil {
+			return nil, nil, nil, err
+		}
+		out := validation.NewRoleBindingValidator(c).Validate(context.Background(), &obj)
+		return out.Errors, out.Warnings, nil, nil
+	}},
+	"Neo4jAuthRule": {needsClient: true, fn: func(doc []byte, c client.Client) (field.ErrorList, []string, []string, error) {
+		var obj neo4jv1beta1.Neo4jAuthRule
+		if err := yaml.Unmarshal(doc, &obj); err != nil {
+			return nil, nil, nil, err
+		}
+		out := validation.NewAuthRuleValidator(c).Validate(context.Background(), &obj)
+		return out.Errors, out.Warnings, nil, nil
+	}},
+	// ShardedDatabase is the odd one out: its entrypoint returns a plain error
+	// rather than an errors-plus-warnings result, so it is adapted here rather
+	// than changing the operator's signature for the CLI's convenience.
+	"Neo4jShardedDatabase": {needsClient: true, fn: func(doc []byte, c client.Client) (field.ErrorList, []string, []string, error) {
+		var obj neo4jv1beta1.Neo4jShardedDatabase
+		if err := yaml.Unmarshal(doc, &obj); err != nil {
+			return nil, nil, nil, err
+		}
+		if vErr := validation.NewShardedDatabaseValidator(c).ValidateShardedDatabase(context.Background(), &obj); vErr != nil {
+			return field.ErrorList{field.Invalid(field.NewPath("spec"), obj.Spec.Name, vErr.Error())}, nil, nil, nil
+		}
+		return nil, nil, nil, nil
+	}},
 }
 
 // finding is one rendered line of output, decoupled from field.Error so that
@@ -131,17 +204,24 @@ type docResult struct {
 	findings []finding
 }
 
-func (d docResult) errorCount() int {
+func (d docResult) errorCount() int { return d.countOf("error") }
+
+func (d docResult) warningCount() int { return d.countOf("warning") }
+
+// pendingCount are transient dependency gaps — not yet satisfiable, not wrong.
+// They never affect the exit code, including under --strict: failing CI because
+// a Secret has not been applied yet would punish correct manifests.
+func (d docResult) pendingCount() int { return d.countOf("pending") }
+
+func (d docResult) countOf(sev string) int {
 	n := 0
 	for _, f := range d.findings {
-		if f.severity == "error" {
+		if f.severity == sev {
 			n++
 		}
 	}
 	return n
 }
-
-func (d docResult) warningCount() int { return len(d.findings) - d.errorCount() }
 
 func runValidate(args []string, stdout, stderr *os.File) int {
 	fs := flag.NewFlagSet("validate", flag.ContinueOnError)
@@ -150,19 +230,26 @@ func runValidate(args []string, stdout, stderr *os.File) int {
 	fs.Var(&files, "f", "Manifest file, directory, or - for stdin. Repeatable.")
 	strict := fs.Bool("strict", false, "Treat warnings as errors (exit non-zero on warnings)")
 	quiet := fs.Bool("quiet", false, "Print findings only; suppress the summary and banner")
+	connect := fs.Bool("connect", false, "Connect to the cluster in the current kubeconfig context to run cross-reference checks")
+	kubeContext := fs.String("context", "", "Kubeconfig context to use (implies --connect)")
+	kubeconfig := fs.String("kubeconfig", "", "Path to the kubeconfig file (implies --connect)")
+	namespace := fs.String("namespace", "", "Namespace for objects whose manifest omits one")
 	fs.Usage = func() {
 		fmt.Fprint(stderr, `Validate Neo4j CR manifests against the operator's own validators.
 
 Usage:
-  kubectl neo4j validate -f <file|dir|-> [-f ...] [--strict] [--quiet]
+  kubectl neo4j validate -f <file|dir|-> [-f ...] [--connect] [--strict] [--quiet]
 
-Runs offline. No cluster connection is made, so checks that resolve
-cross-references (clusterRef, Secrets) are reported as skipped.
+Runs OFFLINE by default: no cluster connection is made, and kinds whose
+validators resolve cross-references (clusterRef, Secrets, roles) are reported
+as skipped. Pass --connect (or --context/--kubeconfig) to check those too.
 
-Note: the operator stops validating a resource after certain critical errors
-(an invalid image, for example), so fixing the reported errors and re-running
-may surface further ones. A clean run means nothing further is reachable, not
-that nothing was ever wrong.
+Note: the operator stops validating a resource after certain critical errors,
+so fixing the reported errors and re-running may surface further ones. A clean
+run means nothing further is reachable, not that nothing was ever wrong.
+
+Not every kind has an operator-side validator. Those that do not are governed
+by their CRD schema alone — use kubectl apply --dry-run=server for that.
 
 Exit codes: 0 clean, 1 validation errors (or warnings with --strict), 2 usage.
 
@@ -178,6 +265,21 @@ Flags:
 		return exitUsage
 	}
 
+	// Connecting is opt-in. Defaulting to the current context would make a
+	// command that is documented as offline fail in CI, where a kubeconfig
+	// usually does not exist — so the user has to ask, either directly or by
+	// naming a context/kubeconfig.
+	var c client.Client
+	wantCluster := *connect || *kubeContext != "" || *kubeconfig != ""
+	if wantCluster {
+		var err error
+		c, err = newClusterClient(*kubeconfig, *kubeContext)
+		if err != nil {
+			fmt.Fprintf(stderr, "error: could not connect to the cluster: %v\n", err)
+			return exitUsage
+		}
+	}
+
 	inputs, err := expandInputs(files)
 	if err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)
@@ -186,7 +288,7 @@ Flags:
 
 	var results []docResult
 	for _, in := range inputs {
-		rs, err := validateSource(in)
+		rs, err := validateSource(in, c, *namespace)
 		if err != nil {
 			fmt.Fprintf(stderr, "error: %s: %v\n", in, err)
 			return exitUsage
@@ -194,12 +296,75 @@ Flags:
 		results = append(results, rs...)
 	}
 
-	return report(results, stdout, *strict, *quiet)
+	if wantCluster && !*quiet {
+		warnOnVersionSkew(c, stdout)
+	}
+	return report(results, stdout, *strict, *quiet, wantCluster)
+}
+
+// newClusterClient builds a direct (uncached) client from the user's kubeconfig.
+// Uncached is deliberate: a CLI makes a handful of reads and exits, so an
+// informer cache would cost more than it saves and would need list/watch
+// permissions the user may not have.
+func newClusterClient(kubeconfigPath, contextName string) (client.Client, error) {
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if kubeconfigPath != "" {
+		rules.ExplicitPath = kubeconfigPath
+	}
+	cfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		rules, &clientcmd.ConfigOverrides{CurrentContext: contextName},
+	).ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	if err := neo4jv1beta1.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	return client.New(cfg, client.Options{Scheme: scheme})
+}
+
+// warnOnVersionSkew compares this binary's version with the operator running in
+// the cluster. Q4 of the design: a CLI carries the validation rules of the
+// release it was built from, so a mismatch means rules silently added or
+// removed relative to what will actually reconcile the manifest.
+//
+// Advisory only, and silent when it cannot tell: the operator may be in a
+// namespace the user cannot list, which is not an error worth failing over.
+func warnOnVersionSkew(c client.Client, stdout *os.File) {
+	if c == nil || version == "dev" {
+		return
+	}
+	var deployments appsv1.DeploymentList
+	if err := c.List(context.Background(), &deployments,
+		client.MatchingLabels{"app.kubernetes.io/name": "neo4j-operator"}); err != nil {
+		return
+	}
+	for _, d := range deployments.Items {
+		for _, ctr := range d.Spec.Template.Spec.Containers {
+			for _, env := range ctr.Env {
+				if env.Name != "OPERATOR_VERSION" || env.Value == "" || env.Value == "latest" {
+					continue
+				}
+				if strings.TrimPrefix(env.Value, "v") != strings.TrimPrefix(version, "v") {
+					fmt.Fprintf(stdout,
+						"⚠ version skew: this CLI carries %s rules, but the operator in %s/%s is %s.\n"+
+							"  Rules added or removed between those releases are checked incorrectly here.\n",
+						version, d.Namespace, d.Name, env.Value)
+				}
+				return
+			}
+		}
+	}
 }
 
 // validateSource reads one input (a path, or "-" for stdin) and validates every
 // YAML document it contains.
-func validateSource(source string) ([]docResult, error) {
+func validateSource(source string, c client.Client, defaultNamespace string) ([]docResult, error) {
 	var r io.Reader
 	if source == "-" {
 		r = os.Stdin
@@ -227,7 +392,7 @@ func validateSource(source string) ([]docResult, error) {
 		if isEmptyDoc(doc) {
 			continue
 		}
-		res, err := validateDoc(doc, source)
+		res, err := validateDoc(doc, source, c, defaultNamespace)
 		if err != nil {
 			return nil, err
 		}
@@ -257,7 +422,7 @@ func isEmptyDoc(doc []byte) bool {
 
 // validateDoc decodes one document far enough to learn its Kind, then hands it
 // to the operator's validator for that Kind.
-func validateDoc(doc []byte, source string) (docResult, error) {
+func validateDoc(doc []byte, source string, c client.Client, defaultNamespace string) (docResult, error) {
 	var meta struct {
 		metav1.TypeMeta   `json:",inline"`
 		metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -277,13 +442,30 @@ func validateDoc(doc []byte, source string) (docResult, error) {
 		return res, nil
 	}
 
-	fn, ok := validators[meta.Kind]
+	kv, ok := validators[meta.Kind]
 	if !ok {
-		res.skipped = fmt.Sprintf("%s validation resolves cross-references and needs a cluster connection; not yet supported offline", meta.Kind)
+		// Precisely worded on purpose. These kinds have NO operator-side
+		// validator, so no amount of connecting will check them — telling a
+		// user to pass --context here would send them after something that
+		// does not exist.
+		res.skipped = fmt.Sprintf(
+			"no operator-side validator for %s; its CRD schema still applies (kubectl apply --dry-run=server)", meta.Kind)
+		return res, nil
+	}
+	if kv.needsClient && c == nil {
+		res.skipped = fmt.Sprintf(
+			"%s validation resolves cross-references; re-run with --connect to check it", meta.Kind)
 		return res, nil
 	}
 
-	errs, warns, err := fn(doc)
+	// A manifest may omit metadata.namespace and rely on the apply-time
+	// default. Cross-reference lookups need one, so mirror kubectl: the
+	// object's own namespace wins, else --namespace, else "default".
+	if defaultNamespace != "" {
+		doc = withDefaultNamespace(doc, meta.Namespace, defaultNamespace)
+	}
+
+	errs, warns, pending, err := kv.fn(doc, c)
 	if err != nil {
 		return docResult{}, fmt.Errorf("cannot decode %s: %w", meta.Kind, err)
 	}
@@ -293,18 +475,23 @@ func validateDoc(doc []byte, source string) (docResult, error) {
 	for _, w := range warns {
 		res.findings = append(res.findings, finding{"warning", "", w})
 	}
+	for _, pnd := range pending {
+		res.findings = append(res.findings, finding{"pending", "", pnd})
+	}
 
+	severityRank := map[string]int{"error": 0, "warning": 1, "pending": 2}
 	sort.SliceStable(res.findings, func(i, j int) bool {
-		if res.findings[i].severity != res.findings[j].severity {
-			return res.findings[i].severity == "error"
+		ri, rj := severityRank[res.findings[i].severity], severityRank[res.findings[j].severity]
+		if ri != rj {
+			return ri < rj
 		}
 		return res.findings[i].path < res.findings[j].path
 	})
 	return res, nil
 }
 
-func report(results []docResult, stdout *os.File, strict, quiet bool) int {
-	totalErr, totalWarn, validated, skipped := 0, 0, 0, 0
+func report(results []docResult, stdout *os.File, strict, quiet, connected bool) int {
+	totalErr, totalWarn, totalPending, validated, skipped := 0, 0, 0, 0, 0
 
 	for _, r := range results {
 		if r.skipped != "" {
@@ -317,6 +504,7 @@ func report(results []docResult, stdout *os.File, strict, quiet bool) int {
 		validated++
 		totalErr += r.errorCount()
 		totalWarn += r.warningCount()
+		totalPending += r.pendingCount()
 
 		if len(r.findings) == 0 {
 			if !quiet {
@@ -327,8 +515,11 @@ func report(results []docResult, stdout *os.File, strict, quiet bool) int {
 		fmt.Fprintf(stdout, "%s:\n", describe(r))
 		for _, f := range r.findings {
 			mark := "✗"
-			if f.severity == "warning" {
+			switch f.severity {
+			case "warning":
 				mark = "⚠"
+			case "pending":
+				mark = "…"
 			}
 			if f.path != "" {
 				fmt.Fprintf(stdout, "  %s %s: %s\n", mark, f.path, f.detail)
@@ -339,8 +530,15 @@ func report(results []docResult, stdout *os.File, strict, quiet bool) int {
 	}
 
 	if !quiet {
-		fmt.Fprintf(stdout, "\n%d validated, %d skipped — %d error(s), %d warning(s)\n",
+		summary := fmt.Sprintf("\n%d validated, %d skipped — %d error(s), %d warning(s)",
 			validated, skipped, totalErr, totalWarn)
+		if totalPending > 0 {
+			summary += fmt.Sprintf(", %d pending", totalPending)
+		}
+		fmt.Fprintln(stdout, summary)
+		if !connected && skipped > 0 {
+			fmt.Fprintln(stdout, "run with --connect to also check kinds that resolve cross-references")
+		}
 		// Offline output is only authoritative for the release it was built
 		// from. Saying so is the cheap half of the version-skew answer.
 		fmt.Fprintf(stdout, "validated against operator rules %s\n", version)
@@ -350,6 +548,29 @@ func report(results []docResult, stdout *os.File, strict, quiet bool) int {
 		return exitInvalid
 	}
 	return exitOK
+}
+
+// withDefaultNamespace injects metadata.namespace into a document that omits
+// one, so cross-reference lookups resolve against the namespace the user would
+// actually apply into. Returns the document unchanged if it already has one.
+func withDefaultNamespace(doc []byte, existing, fallback string) []byte {
+	if existing != "" {
+		return doc
+	}
+	var obj map[string]interface{}
+	if err := yaml.Unmarshal(doc, &obj); err != nil {
+		return doc
+	}
+	md, ok := obj["metadata"].(map[string]interface{})
+	if !ok {
+		return doc
+	}
+	md["namespace"] = fallback
+	patched, err := yaml.Marshal(obj)
+	if err != nil {
+		return doc
+	}
+	return patched
 }
 
 func describe(r docResult) string {

--- a/cmd/kubectl-neo4j/validate_test.go
+++ b/cmd/kubectl-neo4j/validate_test.go
@@ -8,6 +8,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	neo4jv1beta1 "github.com/priyolahiri/neo4j-kubernetes-operator/api/v1beta1"
 )
 
 // writeManifest writes content to a temp file and returns its path.
@@ -42,8 +50,9 @@ spec:
 // a user's terminal with no warning. This test converts that into a build-time
 // failure here.
 func TestOfflineValidatorsAreNilClientSafe(t *testing.T) {
-	// A minimal document per kind — enough to decode and reach the validator.
-	// Correctness of the RESULT is not asserted here; absence of a panic is.
+	// A minimal document per offline kind — enough to decode and reach the
+	// validator. Correctness of the RESULT is not asserted here; absence of a
+	// panic is.
 	docs := map[string]string{
 		"Neo4jEnterpriseCluster":    "apiVersion: neo4j.neo4j.com/v1beta1\nkind: Neo4jEnterpriseCluster\nmetadata: {name: c}\nspec: {}\n",
 		"Neo4jEnterpriseStandalone": "apiVersion: neo4j.neo4j.com/v1beta1\nkind: Neo4jEnterpriseStandalone\nmetadata: {name: s}\nspec: {}\n",
@@ -53,24 +62,99 @@ func TestOfflineValidatorsAreNilClientSafe(t *testing.T) {
 		"Neo4jReplicaDatabase":      "apiVersion: neo4j.neo4j.com/v1beta1\nkind: Neo4jReplicaDatabase\nmetadata: {name: r}\nspec: {}\n",
 	}
 
-	require.Len(t, docs, len(validators),
-		"every kind in the validators map needs a nil-client probe here — a new kind was added without one")
+	offline := map[string]kindValidator{}
+	for kind, kv := range validators {
+		if !kv.needsClient {
+			offline[kind] = kv
+		}
+	}
+	require.Len(t, docs, len(offline),
+		"every offline kind needs a nil-client probe here — one was added without one")
 
-	for kind, fn := range validators {
+	for kind, kv := range offline {
 		doc, ok := docs[kind]
-		require.True(t, ok, "no nil-client probe for kind %q", kind)
+		require.True(t, ok, "no nil-client probe for offline kind %q", kind)
 		t.Run(kind, func(t *testing.T) {
 			require.NotPanics(t, func() {
-				_, _, err := fn([]byte(doc))
+				_, _, _, err := kv.fn([]byte(doc), nil)
 				assert.NoError(t, err)
 			}, "%s validator dereferenced a nil Kubernetes client", kind)
 		})
 	}
 }
 
+// The set of kinds with operator-side validation is a fact about
+// internal/validation, not about this command. If a validator is added there
+// and not wired here, users silently get "no operator-side validator" for a
+// kind that has one — a wrong answer that looks like a correct one.
+func TestValidatorsCoverEveryKindWithAValidator(t *testing.T) {
+	want := []string{
+		// offline
+		"Neo4jEnterpriseCluster", "Neo4jEnterpriseStandalone", "Neo4jBackup",
+		"Neo4jPlugin", "Neo4jDatabaseAlias", "Neo4jReplicaDatabase",
+		// need a cluster
+		"Neo4jDatabase", "Neo4jUser", "Neo4jRole", "Neo4jRoleBinding",
+		"Neo4jAuthRule", "Neo4jShardedDatabase",
+	}
+	assert.Len(t, validators, len(want),
+		"validators map size changed — add or remove the kind in this list too, and check the count in the map's doc comment")
+	for _, kind := range want {
+		assert.Contains(t, validators, kind, "%s has a validator in internal/validation but is not wired here", kind)
+	}
+}
+
+// Kinds needing a cluster must be SKIPPED offline, never reported as failing:
+// "not found" for something merely unreachable is a false error.
+func TestValidate_CrossReferenceKindsSkippedOffline(t *testing.T) {
+	path := writeManifest(t, `
+apiVersion: neo4j.neo4j.com/v1beta1
+kind: Neo4jUser
+metadata: {name: analytics}
+spec: {clusterRef: {name: prod}, username: analytics}
+`)
+	results, err := validateSource(path, nil, "")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	assert.Empty(t, results[0].findings, "an unreachable cross-reference must not become an error")
+	assert.Contains(t, results[0].skipped, "--connect",
+		"the skip message must tell the user how to actually check this kind")
+}
+
+// A kind with NO operator-side validator must say so, and must NOT imply that
+// connecting would help — an earlier version told users to connect for kinds
+// that have no validator at all, sending them after something nonexistent.
+func TestValidate_KindsWithoutValidatorsSayThatPlainly(t *testing.T) {
+	path := writeManifest(t, `
+apiVersion: neo4j.neo4j.com/v1beta1
+kind: Neo4jRestore
+metadata: {name: restore-1}
+spec: {}
+`)
+	results, err := validateSource(path, nil, "")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	assert.Contains(t, results[0].skipped, "no operator-side validator")
+	assert.Contains(t, results[0].skipped, "--dry-run=server",
+		"users need pointing at the thing that DOES check these")
+	assert.NotContains(t, results[0].skipped, "--connect",
+		"connecting cannot help a kind with no validator; saying so would mislead")
+}
+
+func TestWithDefaultNamespace(t *testing.T) {
+	doc := []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: x\n")
+	patched := withDefaultNamespace(doc, "", "team-a")
+	assert.Contains(t, string(patched), "team-a")
+
+	// An explicit namespace in the manifest always wins.
+	unchanged := withDefaultNamespace(doc, "already-set", "team-a")
+	assert.Equal(t, string(doc), string(unchanged))
+}
+
 func TestValidate_CleanManifestExitsZero(t *testing.T) {
 	path := writeManifest(t, validCluster)
-	results, err := validateSource(path)
+	results, err := validateSource(path, nil, "")
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	assert.Empty(t, results[0].findings, "expected no findings, got %+v", results[0].findings)
@@ -92,7 +176,7 @@ spec:
     serverRoles:
       - {serverIndex: 7, modeConstraint: "PRIMARY"}
 `)
-	results, err := validateSource(path)
+	results, err := validateSource(path, nil, "")
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 
@@ -122,7 +206,7 @@ spec:
     dbms.default_database: "mydb"
     server.cluster.advertised_address: "foo:6000"
 `)
-	results, err := validateSource(path)
+	results, err := validateSource(path, nil, "")
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 
@@ -145,20 +229,20 @@ apiVersion: v1
 kind: ConfigMap
 metadata: {name: unrelated}
 `)
-	results, err := validateSource(path)
+	results, err := validateSource(path, nil, "")
 	require.NoError(t, err)
 	require.Len(t, results, 3)
 
 	assert.Empty(t, results[0].skipped, "the cluster should be validated")
-	assert.Contains(t, results[1].skipped, "cluster connection",
-		"a cross-referencing kind must be skipped, not reported as failing")
+	assert.Contains(t, results[1].skipped, "--connect",
+		"a cross-referencing kind must be skipped with a pointer to --connect, not reported as failing")
 	assert.Contains(t, results[2].skipped, "not a Neo4j operator resource",
 		"non-Neo4j objects must pass through untouched")
 }
 
 func TestValidate_EmptyAndCommentOnlyDocumentsAreIgnored(t *testing.T) {
 	path := writeManifest(t, "---\n# just a comment\n---\n"+validCluster)
-	results, err := validateSource(path)
+	results, err := validateSource(path, nil, "")
 	require.NoError(t, err)
 	require.Len(t, results, 1, "blank and comment-only documents must not produce results")
 }
@@ -177,4 +261,111 @@ func TestExpandInputs_DirectoryWalk(t *testing.T) {
 func TestExpandInputs_MissingPathIsAUsageError(t *testing.T) {
 	_, err := expandInputs([]string{filepath.Join(t.TempDir(), "nope.yaml")})
 	assert.Error(t, err)
+}
+
+// testClient builds a fake cluster containing the given objects, with the same
+// scheme newClusterClient uses. Cross-reference behaviour is testable without
+// Kind or envtest, which keeps this command out of the integration lane and off
+// the one-Enterprise-deployment-at-a-time budget entirely.
+func testClient(t *testing.T, objs ...client.Object) client.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, neo4jv1beta1.AddToScheme(scheme))
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+}
+
+const userManifest = `
+apiVersion: neo4j.neo4j.com/v1beta1
+kind: Neo4jUser
+metadata: {name: analytics, namespace: neo4j}
+spec:
+  clusterRef: prod
+  username: analytics
+  passwordSecretRef: {name: analytics-password, key: password}
+`
+
+// The whole point of --connect: a clusterRef that resolves must not be flagged.
+func TestValidate_Connected_ResolvesClusterRef(t *testing.T) {
+	c := testClient(t,
+		&neo4jv1beta1.Neo4jEnterpriseCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "prod", Namespace: "neo4j"},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "analytics-password", Namespace: "neo4j"},
+			Data:       map[string][]byte{"password": []byte("s3cret")},
+		},
+	)
+
+	results, err := validateSource(writeManifest(t, userManifest), c, "")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	assert.Empty(t, results[0].skipped, "with a client the kind must be validated, not skipped")
+	assert.Equal(t, 0, results[0].errorCount(),
+		"a resolvable clusterRef and an existing Secret must produce no errors, got %+v", results[0].findings)
+}
+
+// A missing cross-reference is only reportable WITH a connection — which is
+// exactly why reporting it offline would have been a false error.
+func TestValidate_Connected_FlagsMissingClusterRef(t *testing.T) {
+	c := testClient(t) // empty cluster: no Neo4jEnterpriseCluster named "prod"
+
+	results, err := validateSource(writeManifest(t, userManifest), c, "")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Empty(t, results[0].skipped)
+	assert.NotEmpty(t, results[0].findings,
+		"a clusterRef pointing at a cluster that does not exist must be reported once we can actually tell")
+}
+
+// Pending is a THIRD outcome the operator models deliberately: a Secret that
+// has not been applied yet is "not yet", not "wrong". It must not be rendered
+// as an error, and must not affect the exit code.
+func TestValidate_Connected_PendingIsNeitherErrorNorWarning(t *testing.T) {
+	c := testClient(t, &neo4jv1beta1.Neo4jEnterpriseCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "prod", Namespace: "neo4j"},
+	}) // cluster exists, password Secret deliberately does not
+
+	results, err := validateSource(writeManifest(t, userManifest), c, "")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	assert.Equal(t, 1, results[0].pendingCount(),
+		"a not-yet-created password Secret must be reported as pending, got %+v", results[0].findings)
+	assert.Equal(t, 0, results[0].errorCount(),
+		"pending must not be counted as an error")
+
+	// Even under --strict, pending must not fail the run.
+	if code := report(results, os.Stdout, true /*strict*/, true /*quiet*/, true); code != exitOK {
+		t.Errorf("pending findings must not fail the run even with --strict, got exit %d", code)
+	}
+}
+
+// --namespace supplies the namespace for manifests that omit one, so
+// cross-reference lookups resolve where the user would actually apply.
+func TestValidate_Connected_DefaultNamespaceIsUsedForLookups(t *testing.T) {
+	c := testClient(t, &neo4jv1beta1.Neo4jEnterpriseCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "prod", Namespace: "team-a"},
+	})
+
+	noNamespace := `
+apiVersion: neo4j.neo4j.com/v1beta1
+kind: Neo4jUser
+metadata: {name: analytics}
+spec:
+  clusterRef: prod
+  username: analytics
+  passwordSecretRef: {name: pw, key: password}
+`
+	withNs, err := validateSource(writeManifest(t, noNamespace), c, "team-a")
+	require.NoError(t, err)
+	require.Len(t, withNs, 1)
+
+	joined := ""
+	for _, f := range withNs[0].findings {
+		joined += f.detail + "\n"
+	}
+	assert.NotContains(t, joined, "clusterRef",
+		"with --namespace team-a the clusterRef must resolve; findings were: %s", joined)
 }

--- a/docs/design/cli-tool.md
+++ b/docs/design/cli-tool.md
@@ -405,9 +405,8 @@ honest options are recorded in §9 Q5 rather than papered over.
 
 ## 8. Delivery order
 
-1. **`validate`, offline only** (§6). One command, no cluster, no release
-   pipeline yet — buildable and reviewable as a normal PR, with `go run` and
-   `make` targets for local use.
+1. ~~**`validate`, offline only** (§6)~~ → **done.** Six kinds, no cluster
+   required, `make build-cli` for local use.
 2. ~~**Cross-compile matrix in `release.yml`** (revised B1)~~ → **done.** A
    `GOOS`/`GOARCH` matrix writing into `release-artifacts/`, which the existing
    release step already globs — no new workflow, as the revised B1 predicted.
@@ -426,7 +425,24 @@ honest options are recorded in §9 Q5 rather than papered over.
    A CI cross-compile step (`ci.yml`) builds all five targets on every PR, so a
    unix-only import reaching `cmd/` fails a pull request rather than a tagged
    release.
-3. **`validate --context`** — the 8 cross-reference validators.
+3. ~~**`validate --context`** — the 8 cross-reference validators~~ → **done**,
+   as `--connect` / `--context` / `--kubeconfig` / `--namespace`.
+
+   Two corrections the work forced. First, it is **6** cross-reference
+   validators, not 8: `resource` and `cluster` are sub-validators, not per-CRD
+   entrypoints. Second, and more important, this document and the command's own
+   output implied every unsupported kind merely needed a connection. **Of 26
+   CRD kinds only 12 have operator-side validators at all** — the 12 Aura kinds,
+   `Neo4jRestore` and `Neo4jReplicaPromotion` have none, and no amount of
+   connecting will check them. The skip taxonomy now distinguishes "needs
+   --connect" from "no validator exists; use --dry-run=server", because telling
+   a user to connect for a check that does not exist sends them after nothing.
+
+   Also surfaced `UserValidationResult.Pending` — the operator's own third
+   outcome for a dependency that is not satisfiable *yet* rather than wrong. It
+   renders distinctly and never affects the exit code, including under
+   `--strict`. Dropping it, as the first implementation did, hid the difference
+   between "wrong" and "not yet".
 4. **`status`** (§4.2), then **`connect` / `cypher`** (§4.3).
 5. **krew index submission** (B6), once the command set is stable enough that
    users installing it will not immediately want a newer one.

--- a/docs/user_guide/guides/cli.md
+++ b/docs/user_guide/guides/cli.md
@@ -122,7 +122,11 @@ Errors are listed before warnings, each sorted by field path.
 | Flag | Meaning |
 |---|---|
 | `-f` | File, directory, or `-` for stdin. Repeatable. |
-| `--strict` | Treat warnings as errors (exit non-zero on warnings). |
+| `--connect` | Connect to the current kubeconfig context to check cross-references. |
+| `--context` | Kubeconfig context to use (implies `--connect`). |
+| `--kubeconfig` | Path to the kubeconfig file (implies `--connect`). |
+| `--namespace` | Namespace for manifests that omit one. |
+| `--strict` | Treat warnings as errors (exit non-zero on warnings). Pending is unaffected. |
 | `--quiet` | Print findings only — no per-file "ok" lines, no summary. |
 
 ### Exit codes
@@ -152,19 +156,56 @@ What it adds is everything that lives in the operator's validators *beyond* the 
 
 The two are complementary. In CI, run both.
 
-### Kinds validated offline
+### What gets checked, and what doesn't
 
-Six kinds validate with no cluster connection:
+The operator has **26 CRD kinds, but only 12 have operator-side validators**. The command reports three distinct outcomes, and the distinction matters:
 
-`Neo4jEnterpriseCluster` · `Neo4jEnterpriseStandalone` · `Neo4jBackup` · `Neo4jPlugin` · `Neo4jDatabaseAlias` · `Neo4jReplicaDatabase`
-
-Every other kind — `Neo4jDatabase`, `Neo4jUser`, `Neo4jRole`, `Neo4jRoleBinding`, `Neo4jAuthRule`, `Neo4jShardedDatabase` and the Aura resources — resolves cross-references (a `clusterRef`, a Secret, a role) through the Kubernetes API. Those are reported as **skipped**:
+| | Kinds | Behaviour |
+|---|---|---|
+| **Checked offline** | `Neo4jEnterpriseCluster`, `Neo4jEnterpriseStandalone`, `Neo4jBackup`, `Neo4jPlugin`, `Neo4jDatabaseAlias`, `Neo4jReplicaDatabase` | Validated with no cluster |
+| **Need `--connect`** | `Neo4jDatabase`, `Neo4jUser`, `Neo4jRole`, `Neo4jRoleBinding`, `Neo4jAuthRule`, `Neo4jShardedDatabase` | Skipped offline; validated when connected |
+| **No validator at all** | the 12 Aura kinds, `Neo4jRestore`, `Neo4jReplicaPromotion` | Only the CRD schema applies — use `kubectl apply --dry-run=server` |
 
 ```
-- Neo4jUser/analytics (users.yaml): skipped — Neo4jUser validation resolves cross-references and needs a cluster connection; not yet supported offline
+- Neo4jUser/analytics (users.yaml): skipped — Neo4jUser validation resolves cross-references; re-run with --connect to check it
+- Neo4jRestore/restore-1 (restore.yaml): skipped — no operator-side validator for Neo4jRestore; its CRD schema still applies (kubectl apply --dry-run=server)
 ```
 
-**Skipped is not a failure.** Reporting "cluster not found" for a cluster that simply is not reachable would be a false error, which is worse than not checking at all — so the command declines to guess.
+**Skipped is never a failure.** For the middle row, reporting "cluster not found" for a cluster that is merely unreachable would be a false error — worse than not checking — so the command declines to guess. For the bottom row, no amount of connecting will help, and the message says so rather than sending you after a check that does not exist.
+
+### Checking cross-references with `--connect`
+
+```bash
+kubectl neo4j validate -f manifests/ --connect              # current kubeconfig context
+kubectl neo4j validate -f manifests/ --context prod         # a specific context
+kubectl neo4j validate -f manifests/ --connect -n team-a    # namespace for manifests that omit one
+```
+
+Connecting is **opt-in**. Defaulting to the current context would make a command documented as offline fail in CI, where there is usually no kubeconfig at all.
+
+With a connection, the command resolves `clusterRef`s, password Secrets and role references, and adds a third finding type:
+
+```
+Neo4jUser/analytics (users.yaml):
+  … waiting for password Secret "analytics-password" in namespace "neo4j"
+
+1 validated, 0 skipped — 0 error(s), 0 warning(s), 1 pending
+```
+
+**Pending is neither an error nor a warning.** It is the operator's own category for a dependency that is not satisfiable *yet* — a Secret you have not applied — as opposed to something wrong. Pending never affects the exit code, **including under `--strict`**: failing a pipeline because a Secret has not been created yet would punish a correct manifest.
+
+The connection is also what makes version-skew detection possible. When connected, the CLI compares itself against the operator running in the cluster:
+
+```
+⚠ version skew: this CLI carries v1.15.0 rules, but the operator in neo4j-operator/neo4j-operator-controller-manager is v1.14.0.
+  Rules added or removed between those releases are checked incorrectly here.
+```
+
+It is advisory and silent when it cannot tell — the operator may be in a namespace you cannot list, which is not worth failing over.
+
+### Required permissions
+
+`--connect` reads only. It needs `get` on `Neo4jEnterpriseCluster`, `Neo4jEnterpriseStandalone`, `Neo4jRole` and `Secret` in the namespaces you are validating, plus `list` on `Deployment` for the version check (which degrades silently without it). It never writes anything.
 
 ### A clean run may not be the last word
 


### PR DESCRIPTION
## Summary

Delivery item 3. Adds `--connect` / `--context` / `--kubeconfig` / `--namespace` and wires the six validators that resolve cross-references through the API server — `Neo4jDatabase`, `Neo4jUser`, `Neo4jRole`, `Neo4jRoleBinding`, `Neo4jAuthRule`, `Neo4jShardedDatabase`.

**Checkable coverage goes from 6 kinds to 12.**

```bash
kubectl neo4j validate -f manifests/ --connect           # current context
kubectl neo4j validate -f manifests/ --context prod      # a specific one
```

Connecting is **opt-in**. Defaulting to the current context would make a command documented as offline fail in CI, where there is usually no kubeconfig at all.

## Two corrections to what already shipped

**1. The skip message was misleading, and I wrote it.** It told users that unsupported kinds "need a cluster connection", implying `--context` would check them. That is false for most of them: **of 26 CRD kinds only 12 have operator-side validators at all.** The 12 Aura kinds, `Neo4jRestore` and `Neo4jReplicaPromotion` have none. Sending someone after a check that does not exist is worse than saying nothing, so the taxonomy is now three-way:

```
- Neo4jUser/analytics:   skipped — resolves cross-references; re-run with --connect to check it
- Neo4jRestore/restore-1: skipped — no operator-side validator; its CRD schema still applies (kubectl apply --dry-run=server)
```

This also corrects the design doc, which said "the 8 cross-reference validators" — it is 6; `resource` and `cluster` are sub-validators, not per-CRD entrypoints.

**2. `UserValidationResult.Pending` was being silently dropped.** The operator models a *third* outcome: a dependency not satisfiable **yet** (a password Secret you have not applied) as opposed to something wrong. My first implementation threw it away, collapsing "not yet" into "nothing to report".

```
Neo4jUser/analytics (users.yaml):
  … waiting for password Secret "analytics-password" in namespace "neo4j"

1 validated, 0 skipped — 0 error(s), 0 warning(s), 1 pending
```

Pending renders distinctly and **never affects the exit code, including under `--strict`** — failing a pipeline because a Secret has not been created yet would punish a correct manifest.

## Version skew (design Q4) — now closed

Q4 said the banner was the cheap half and the mismatch warning needed a cluster. With one, the CLI compares itself against the operator Deployment's `OPERATOR_VERSION`:

```
⚠ version skew: this CLI carries v1.15.0 rules, but the operator in neo4j-operator/... is v1.14.0.
  Rules added or removed between those releases are checked incorrectly here.
```

Advisory and silent when it cannot tell — the operator may be in a namespace the user cannot list, which is not worth failing over.

## A deliberate conservatism

The six client-needing validators stay strictly behind `--connect` even though two of them (`user`, `role`) happen to guard a nil client internally and would partly work offline. Their guards are **inconsistent** — `database` and `shardeddatabase` have none and would panic — and uniform, predictable behaviour beats a per-kind patchwork users cannot reason about.

## Type of change

- [x] New feature
- [x] Bug fix (skip taxonomy, dropped Pending)

## Testing

- [x] `make test-unit` all green; `cmd/kubectl-neo4j` coverage 49.3%
- [x] `make lint` 0 issues, `go vet` clean, all five cross-compile targets build
- [x] All four drift/catalogue gates OK
- [x] `go mod tidy` — I added `k8s.io/cli-runtime` early, then used `clientcmd` from `client-go` directly instead; the unused dependency is removed rather than left behind

New tests use a **fake client**, not Kind or envtest, which keeps this command out of the integration lane and off the one-Enterprise-deployment-at-a-time budget entirely: resolvable `clusterRef`, missing `clusterRef`, pending Secret (asserted not to fail even under `--strict`), and `--namespace` defaulting. Plus `TestValidatorsCoverEveryKindWithAValidator`, so a validator added in `internal/validation` and not wired here fails a test rather than silently reporting "no validator" for a kind that has one.

Connection failure paths verified by hand to produce clean messages rather than panics:

```
error: could not connect to the cluster: context "does-not-exist" does not exist
```

## Also

Marks delivery item 1 as done in the design doc — it shipped in #353 but was never struck through, so the doc read as though `validate` were still pending.

## Left after this

`status` and `connect`/`cypher` (item 4), krew (item 5), `explain` and `support-bundle` (item 6). Q1 (does `validate` earn its place against `--dry-run=server` in practice) still wants real usage evidence rather than argument.