### PR TITLE
feat(cli): status — one view of every Neo4j resource in a namespace

### DIFF
--- a/cmd/kubectl-neo4j/main.go
+++ b/cmd/kubectl-neo4j/main.go
@@ -47,6 +47,7 @@ Usage:
 
 Commands:
   validate    Validate Neo4j CR manifests against the operator's own validators
+  status      Show the state of every Neo4j resource in a namespace
   version     Print the version
 
 Run "kubectl neo4j <command> -h" for command flags.
@@ -66,6 +67,8 @@ func run(args []string, stdout, stderr *os.File) int {
 	switch args[0] {
 	case "validate":
 		return runValidate(args[1:], stdout, stderr)
+	case "status":
+		return runStatus(args[1:], stdout, stderr)
 	case "version":
 		fmt.Fprintln(stdout, version)
 		return exitOK

--- a/cmd/kubectl-neo4j/status.go
+++ b/cmd/kubectl-neo4j/status.go
@@ -1,0 +1,304 @@
+/*
+Copyright 2025 Priyo Lahiri.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	neo4jv1beta1 "github.com/priyolahiri/neo4j-kubernetes-operator/api/v1beta1"
+)
+
+// resourceStatus is one row of output, read generically rather than through 26
+// typed switches. Every Neo4j CRD's status carries the same three fields
+// (phase, ready, message) plus conditions, so unstructured access is both
+// shorter and automatically correct for CRDs added later.
+type resourceStatus struct {
+	kind      string
+	namespace string
+	name      string
+	phase     string
+	ready     string
+	age       string
+	message   string
+}
+
+// healthy reports whether this row needs the user's attention. Deliberately
+// conservative: an unrecognised phase counts as healthy rather than alarming
+// someone about a status vocabulary this binary predates (the same reasoning
+// the project's ArgoCD health checks use for the Aura kinds).
+func (r resourceStatus) healthy() bool {
+	switch strings.ToLower(r.phase) {
+	case "failed", "error", "degraded", "unknown":
+		return false
+	}
+	return r.ready != "false"
+}
+
+func runStatus(args []string, stdout, stderr *os.File) int {
+	fs := flag.NewFlagSet("status", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	namespace := fs.String("namespace", "", "Namespace to inspect (default: the kubeconfig context's namespace)")
+	allNamespaces := fs.Bool("all-namespaces", false, "Inspect every namespace")
+	kubeContext := fs.String("context", "", "Kubeconfig context to use")
+	kubeconfig := fs.String("kubeconfig", "", "Path to the kubeconfig file")
+	problemsOnly := fs.Bool("problems", false, "Show only resources that need attention")
+	fs.Usage = func() {
+		fmt.Fprint(stderr, `Show the state of every Neo4j resource in a namespace.
+
+Usage:
+  kubectl neo4j status [-n <namespace>] [--all-namespaces] [--problems]
+
+Reports each resource's phase, readiness and age, and the status message for
+anything that is not healthy. Read-only.
+
+Exit codes: 0 on a successful query (even if resources are unhealthy — mirroring
+kubectl get), 2 on a usage or connection error.
+
+Flags:
+`)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+
+	c, err := newClusterClient(*kubeconfig, *kubeContext)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: could not connect to the cluster: %v\n", err)
+		return exitUsage
+	}
+
+	ns := *namespace
+	if *allNamespaces {
+		ns = ""
+	} else if ns == "" {
+		ns = currentNamespace(*kubeconfig, *kubeContext)
+	}
+
+	rows, err := collectStatus(context.Background(), c, ns)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return exitUsage
+	}
+	renderStatus(rows, stdout, *allNamespaces, *problemsOnly, ns)
+	return exitOK
+}
+
+// registeredNeo4jKinds returns every Kind in the operator's API group, taken
+// from the client's SCHEME rather than a hardcoded list. A CRD added to
+// api/v1beta1 therefore appears here with no change to this command — the
+// alternative is a list that silently goes stale, which is exactly the failure
+// mode this repo's catalogue checks exist to prevent.
+//
+// "List" kinds are filtered out: the scheme registers both Foo and FooList, and
+// listing FooList would ask the API server for FooListList.
+func registeredNeo4jKinds(c client.Client) []schema.GroupVersionKind {
+	var kinds []schema.GroupVersionKind
+	for gvk := range c.Scheme().AllKnownTypes() {
+		if gvk.Group != neo4jv1beta1.GroupVersion.Group {
+			continue
+		}
+		if gvk.Version != neo4jv1beta1.GroupVersion.Version {
+			continue
+		}
+		if strings.HasSuffix(gvk.Kind, "List") {
+			continue
+		}
+		// runtime.Scheme also carries meta kinds (WatchEvent, Status, …) that
+		// are not custom resources and cannot be listed.
+		switch gvk.Kind {
+		case "WatchEvent", "Status", "APIGroup", "APIResourceList",
+			"CreateOptions", "UpdateOptions", "PatchOptions", "DeleteOptions",
+			"GetOptions", "ListOptions":
+			continue
+		}
+		kinds = append(kinds, gvk)
+	}
+	sort.Slice(kinds, func(i, j int) bool { return kinds[i].Kind < kinds[j].Kind })
+	return kinds
+}
+
+// currentNamespace resolves the namespace from the kubeconfig context, the way
+// kubectl does when -n is omitted. Falls back to "default" so the command still
+// does something sensible with a minimal kubeconfig.
+func currentNamespace(kubeconfigPath, contextName string) string {
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if kubeconfigPath != "" {
+		rules.ExplicitPath = kubeconfigPath
+	}
+	ns, _, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		rules, &clientcmd.ConfigOverrides{CurrentContext: contextName},
+	).Namespace()
+	if err != nil || ns == "" {
+		return "default"
+	}
+	return ns
+}
+
+func collectStatus(ctx context.Context, c client.Client, namespace string) ([]resourceStatus, error) {
+	var rows []resourceStatus
+
+	for _, kind := range registeredNeo4jKinds(c) {
+		list := &unstructured.UnstructuredList{}
+		list.SetGroupVersionKind(kind.GroupVersion().WithKind(kind.Kind + "List"))
+
+		opts := []client.ListOption{}
+		if namespace != "" {
+			opts = append(opts, client.InNamespace(namespace))
+		}
+		if err := c.List(ctx, list, opts...); err != nil {
+			// A kind the user cannot read, or a CRD not installed, is not a
+			// reason to fail the whole command — report what IS visible.
+			continue
+		}
+		for i := range list.Items {
+			rows = append(rows, rowFrom(&list.Items[i]))
+		}
+	}
+
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].kind != rows[j].kind {
+			return rows[i].kind < rows[j].kind
+		}
+		if rows[i].namespace != rows[j].namespace {
+			return rows[i].namespace < rows[j].namespace
+		}
+		return rows[i].name < rows[j].name
+	})
+	return rows, nil
+}
+
+func rowFrom(obj *unstructured.Unstructured) resourceStatus {
+	r := resourceStatus{
+		kind:      obj.GetKind(),
+		namespace: obj.GetNamespace(),
+		name:      obj.GetName(),
+		phase:     "-",
+		ready:     "-",
+		age:       humanAge(obj.GetCreationTimestamp().Time),
+	}
+	if phase, ok, _ := unstructured.NestedString(obj.Object, "status", "phase"); ok && phase != "" {
+		r.phase = phase
+	}
+	if ready, ok, _ := unstructured.NestedBool(obj.Object, "status", "ready"); ok {
+		r.ready = fmt.Sprintf("%t", ready)
+	}
+	if msg, ok, _ := unstructured.NestedString(obj.Object, "status", "message"); ok {
+		r.message = msg
+	}
+	return r
+}
+
+func renderStatus(rows []resourceStatus, stdout *os.File, allNamespaces, problemsOnly bool, ns string) {
+	shown := rows
+	if problemsOnly {
+		shown = nil
+		for _, r := range rows {
+			if !r.healthy() {
+				shown = append(shown, r)
+			}
+		}
+	}
+
+	if len(shown) == 0 {
+		switch {
+		case problemsOnly && len(rows) > 0:
+			fmt.Fprintf(stdout, "all %d Neo4j resource(s) look healthy\n", len(rows))
+		case allNamespaces:
+			fmt.Fprintln(stdout, "no Neo4j resources found in any namespace")
+		case ns == "":
+			fmt.Fprintln(stdout, "no Neo4j resources found")
+		default:
+			fmt.Fprintf(stdout, "no Neo4j resources found in namespace %q\n", ns)
+		}
+		return
+	}
+
+	w := tabwriter.NewWriter(stdout, 0, 0, 3, ' ', 0)
+	if allNamespaces {
+		fmt.Fprintln(w, "KIND\tNAMESPACE\tNAME\tPHASE\tREADY\tAGE")
+	} else {
+		fmt.Fprintln(w, "KIND\tNAME\tPHASE\tREADY\tAGE")
+	}
+	for _, r := range shown {
+		if allNamespaces {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", r.kind, r.namespace, r.name, r.phase, r.ready, r.age)
+		} else {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", r.kind, r.name, r.phase, r.ready, r.age)
+		}
+	}
+	_ = w.Flush()
+
+	// Messages are the part people actually act on, so they are printed below
+	// the table rather than squeezed into a column that would wrap unreadably.
+	//
+	// Pending is included even though it is not unhealthy: "waiting for
+	// password Secret X" is precisely the thing a user needs to read, and
+	// hiding it because the resource is not technically broken would withhold
+	// the one line that says what to do next. It is marked "…" rather than "✗",
+	// matching how `validate` distinguishes "not yet" from "wrong".
+	var notes []string
+	for _, r := range rows {
+		if r.message == "" {
+			continue
+		}
+		switch {
+		case !r.healthy():
+			notes = append(notes, fmt.Sprintf("✗ %s/%s: %s", r.kind, r.name, r.message))
+		case strings.EqualFold(r.phase, "pending"):
+			notes = append(notes, fmt.Sprintf("… %s/%s: %s", r.kind, r.name, r.message))
+		}
+	}
+	// Collect first, then print — so a run with nothing to say does not emit a
+	// separator followed by nothing.
+	if len(notes) > 0 {
+		fmt.Fprintln(stdout)
+		for _, n := range notes {
+			fmt.Fprintln(stdout, n)
+		}
+	}
+}
+
+// humanAge renders a duration the way kubectl does, coarsest useful unit only.
+func humanAge(t time.Time) string {
+	if t.IsZero() {
+		return "-"
+	}
+	d := time.Since(t)
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	}
+}

--- a/cmd/kubectl-neo4j/status_test.go
+++ b/cmd/kubectl-neo4j/status_test.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	neo4jv1beta1 "github.com/priyolahiri/neo4j-kubernetes-operator/api/v1beta1"
+)
+
+// The kind list comes from the scheme, not a literal, so a CRD added to
+// api/v1beta1 shows up in `status` for free. This pins that wiring — and that
+// the List kinds the scheme also registers are filtered out, since listing
+// "Neo4jDatabaseList" would ask the API server for Neo4jDatabaseListList.
+func TestRegisteredNeo4jKinds_FromSchemeAndExcludesListKinds(t *testing.T) {
+	kinds := registeredNeo4jKinds(testClient(t))
+	require.NotEmpty(t, kinds)
+
+	var names []string
+	for _, k := range kinds {
+		names = append(names, k.Kind)
+		assert.False(t, strings.HasSuffix(k.Kind, "List"), "%s is a List kind and must be filtered out", k.Kind)
+		assert.Equal(t, neo4jv1beta1.GroupVersion.Group, k.Group)
+	}
+
+	joined := strings.Join(names, ",")
+	for _, want := range []string{"Neo4jEnterpriseCluster", "Neo4jDatabase", "Neo4jUser", "Neo4jBackup"} {
+		assert.Contains(t, joined, want)
+	}
+	// The Aura suite is in the same group and must be included — it was absent
+	// from docs/index.md for its whole life, which is the kind of omission a
+	// scheme-derived list cannot make.
+	assert.Contains(t, joined, "AuraInstance")
+}
+
+func TestCollectStatus_ReadsPhaseReadyAndMessageGenerically(t *testing.T) {
+	c := testClient(t,
+		&neo4jv1beta1.Neo4jEnterpriseCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "prod", Namespace: "neo4j",
+				CreationTimestamp: metav1.NewTime(time.Now().Add(-3 * time.Hour)),
+			},
+			Status: neo4jv1beta1.Neo4jEnterpriseClusterStatus{
+				Phase: "Ready", Ready: true,
+			},
+		},
+		&neo4jv1beta1.Neo4jDatabase{
+			ObjectMeta: metav1.ObjectMeta{Name: "analytics", Namespace: "neo4j"},
+			Status: neo4jv1beta1.Neo4jDatabaseStatus{
+				Phase: "Failed", Message: "topology requires 3 primaries, cluster has 2 servers",
+			},
+		},
+	)
+
+	rows, err := collectStatus(context.Background(), c, "neo4j")
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+
+	byKind := map[string]resourceStatus{}
+	for _, r := range rows {
+		byKind[r.kind] = r
+	}
+
+	cluster := byKind["Neo4jEnterpriseCluster"]
+	assert.Equal(t, "Ready", cluster.phase)
+	assert.Equal(t, "true", cluster.ready)
+	assert.Equal(t, "3h", cluster.age)
+	assert.True(t, cluster.healthy())
+
+	db := byKind["Neo4jDatabase"]
+	assert.Equal(t, "Failed", db.phase)
+	assert.False(t, db.healthy())
+	assert.Contains(t, db.message, "topology requires 3 primaries")
+}
+
+func TestCollectStatus_NamespaceScoping(t *testing.T) {
+	c := testClient(t,
+		&neo4jv1beta1.Neo4jEnterpriseCluster{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "team-a"}},
+		&neo4jv1beta1.Neo4jEnterpriseCluster{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "team-b"}},
+	)
+
+	scoped, err := collectStatus(context.Background(), c, "team-a")
+	require.NoError(t, err)
+	require.Len(t, scoped, 1)
+	assert.Equal(t, "a", scoped[0].name)
+
+	all, err := collectStatus(context.Background(), c, "")
+	require.NoError(t, err)
+	assert.Len(t, all, 2, "an empty namespace must mean all namespaces")
+}
+
+// An unrecognised phase must NOT be reported as a problem. The Aura kinds
+// mirror Aura's own status vocabulary, which Neo4j can extend without a version
+// bump — the same reasoning the project's ArgoCD health checks use.
+func TestResourceStatus_UnknownPhaseIsNotAlarming(t *testing.T) {
+	cases := []struct {
+		phase   string
+		ready   string
+		healthy bool
+	}{
+		{"Ready", "true", true},
+		{"Running", "-", true},
+		{"SomePhaseThisBinaryPredates", "-", true},
+		{"Failed", "-", false},
+		{"Degraded", "-", false},
+		{"Ready", "false", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.phase+"/"+tc.ready, func(t *testing.T) {
+			r := resourceStatus{phase: tc.phase, ready: tc.ready}
+			assert.Equal(t, tc.healthy, r.healthy())
+		})
+	}
+}
+
+func TestHumanAge(t *testing.T) {
+	now := time.Now()
+	assert.Equal(t, "30s", humanAge(now.Add(-30*time.Second)))
+	assert.Equal(t, "5m", humanAge(now.Add(-5*time.Minute)))
+	assert.Equal(t, "2h", humanAge(now.Add(-2*time.Hour)))
+	assert.Equal(t, "3d", humanAge(now.Add(-72*time.Hour)))
+	assert.Equal(t, "-", humanAge(time.Time{}))
+}
+
+// renderTo captures what the user actually sees, so the table layout and the
+// message block are asserted rather than assumed.
+func renderTo(t *testing.T, rows []resourceStatus, allNamespaces, problemsOnly bool, ns string) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "out")
+	require.NoError(t, err)
+	renderStatus(rows, f, allNamespaces, problemsOnly, ns)
+	require.NoError(t, f.Close())
+	b, err := os.ReadFile(f.Name())
+	require.NoError(t, err)
+	return string(b)
+}
+
+func TestRenderStatus_TableAndMessages(t *testing.T) {
+	rows := []resourceStatus{
+		{kind: "Neo4jEnterpriseCluster", name: "prod", phase: "Ready", ready: "true", age: "3h"},
+		{kind: "Neo4jDatabase", name: "analytics", phase: "Failed", ready: "-", age: "5m",
+			message: "topology requires 3 primaries, cluster has 2 servers"},
+	}
+
+	out := renderTo(t, rows, false, false, "neo4j")
+	assert.Contains(t, out, "KIND")
+	assert.Contains(t, out, "Neo4jEnterpriseCluster")
+	assert.Contains(t, out, "analytics")
+	// The message is what people act on, so it must appear in full below the
+	// table rather than be truncated into a column.
+	assert.Contains(t, out, "topology requires 3 primaries, cluster has 2 servers")
+	assert.NotContains(t, out, "NAMESPACE", "the namespace column is only for --all-namespaces")
+}
+
+func TestRenderStatus_ProblemsOnlyAndEmptyStates(t *testing.T) {
+	healthy := []resourceStatus{{kind: "Neo4jEnterpriseCluster", name: "prod", phase: "Ready", ready: "true"}}
+
+	out := renderTo(t, healthy, false, true, "neo4j")
+	assert.Contains(t, out, "look healthy",
+		"--problems with nothing wrong should say so, not print an empty table")
+
+	out = renderTo(t, nil, false, false, "neo4j")
+	assert.Contains(t, out, `no Neo4j resources found in namespace "neo4j"`)
+
+	out = renderTo(t, nil, true, false, "")
+	assert.Contains(t, out, "any namespace")
+}
+
+func TestRenderStatus_AllNamespacesAddsTheColumn(t *testing.T) {
+	rows := []resourceStatus{{kind: "Neo4jDatabase", namespace: "team-a", name: "db", phase: "Ready", ready: "-"}}
+	out := renderTo(t, rows, true, false, "")
+	assert.Contains(t, out, "NAMESPACE")
+	assert.Contains(t, out, "team-a")
+}
+
+// A run with nothing to report must not print a separator followed by nothing.
+func TestRenderStatus_NoTrailingBlankWhenNothingToSay(t *testing.T) {
+	rows := []resourceStatus{
+		{kind: "Neo4jEnterpriseCluster", name: "prod", phase: "Ready", ready: "true", age: "1h"},
+	}
+	out := renderTo(t, rows, false, false, "neo4j")
+	assert.False(t, strings.HasSuffix(out, "\n\n"), "unexpected trailing blank line: %q", out)
+}
+
+// Pending is not unhealthy, but its message is the one line that says what to
+// do next, so it must still be surfaced — with a marker distinct from an error.
+func TestRenderStatus_PendingMessagesAreShownDistinctly(t *testing.T) {
+	rows := []resourceStatus{
+		{kind: "Neo4jUser", name: "reporting", phase: "Pending", ready: "-", age: "2m",
+			message: `waiting for password Secret "reporting-pw"`},
+	}
+	out := renderTo(t, rows, false, false, "neo4j")
+	assert.Contains(t, out, `… Neo4jUser/reporting: waiting for password Secret "reporting-pw"`)
+	assert.NotContains(t, out, "✗ Neo4jUser/reporting", "pending must not be rendered as an error")
+}

--- a/docs/design/cli-tool.md
+++ b/docs/design/cli-tool.md
@@ -443,7 +443,16 @@ honest options are recorded in §9 Q5 rather than papered over.
    renders distinctly and never affects the exit code, including under
    `--strict`. Dropping it, as the first implementation did, hid the difference
    between "wrong" and "not yet".
-4. **`status`** (§4.2), then **`connect` / `cypher`** (§4.3).
+4. **`status`** (§4.2) → **done**, then **`connect` / `cypher`** (§4.3).
+
+   `status` reads every kind generically — phase, ready, message — rather than
+   through 26 typed switches, and takes its kind list from the registered
+   scheme rather than a literal, so a new CRD appears without touching the
+   command. Two reporting decisions carried over from `validate` deliberately:
+   an unrecognised phase is **not** treated as a problem (the Aura kinds mirror
+   an open vocabulary Neo4j can extend), and `Pending` messages are shown but
+   marked `…` rather than `✗`, because "waiting for a Secret you have not
+   created" is the line that says what to do next, not a failure.
 5. **krew index submission** (B6), once the command set is stable enough that
    users installing it will not immediately want a newer one.
 6. **`explain`** (§4.4) and **`support-bundle`** (§4.5), on evidence.

--- a/docs/user_guide/guides/cli.md
+++ b/docs/user_guide/guides/cli.md
@@ -250,6 +250,39 @@ Or as a pre-commit hook:
 
 `--strict` is the usual choice for CI: it makes advisory warnings — such as a two-server cluster that will lose quorum if one server fails — block the pipeline rather than scroll past.
 
+## `status`
+
+One view of every Neo4j resource in a namespace — what exists, what is healthy, and the message for anything that is not.
+
+```bash
+kubectl neo4j status                      # the current context's namespace
+kubectl neo4j status -n neo4j
+kubectl neo4j status --all-namespaces
+kubectl neo4j status --problems           # only what needs attention
+```
+
+```
+KIND                     NAME        PHASE     READY   AGE
+Neo4jEnterpriseCluster   prod        Ready     true    3h
+Neo4jDatabase            analytics   Failed    -       5m
+Neo4jUser                reporting   Pending   -       2m
+
+✗ Neo4jDatabase/analytics: topology requires 3 primaries, cluster has 2 servers
+… Neo4jUser/reporting: waiting for password Secret "reporting-pw"
+```
+
+Without it, this is `kubectl get` against 26 kinds followed by `describe` on whichever looks wrong.
+
+Three things worth knowing about how it reports:
+
+- **Messages appear below the table, in full.** They are the part you act on, and squeezing them into a column would wrap them into noise.
+- **`…` is not `✗`.** A `Pending` resource is not broken — it is waiting on something you have not created yet. Its message is still shown, because it is the line that tells you what to do next, but it is marked distinctly from a failure. This matches how `validate` separates "not yet" from "wrong".
+- **An unrecognised phase is not treated as a problem.** The Aura kinds mirror Aura's own status vocabulary, which Neo4j can extend without a version bump; flagging every phase this binary predates would produce false alarms. This is the same reasoning behind the project's ArgoCD health checks.
+
+The kind list comes from the operator's registered API scheme rather than a hardcoded list, so a CRD added to the operator appears here automatically. Kinds you lack permission to read, or whose CRD is not installed, are skipped rather than failing the whole command.
+
+Exit code is `0` on a successful query even when resources are unhealthy — mirroring `kubectl get`. Use `--problems` and check for empty output if you want a health gate.
+
 ## See also
 
 - [Troubleshooting](troubleshooting.md) — diagnosing a deployment that is already running


### PR DESCRIPTION
## Summary

Delivery item 4a. **Stacked on #360** — review that first; this PR's base is `feat/cli-validate-context`, so its diff shows only the `status` work.

Replaces "`kubectl get` against 26 kinds, then `describe` whichever looks wrong":

```
KIND                     NAME        PHASE     READY   AGE
Neo4jEnterpriseCluster   prod        Ready     true    3h
Neo4jDatabase            analytics   Failed    -       5m
Neo4jUser                reporting   Pending   -       2m

✗ Neo4jDatabase/analytics: topology requires 3 primaries, cluster has 2 servers
… Neo4jUser/reporting: waiting for password Secret "reporting-pw"
```

```bash
kubectl neo4j status                 # current context's namespace
kubectl neo4j status --all-namespaces
kubectl neo4j status --problems      # only what needs attention
```

## Two implementation choices worth flagging

**Generic status reading, not 26 typed switches.** Every Neo4j CRD status carries the same `phase` / `ready` / `message` contract, so unstructured access is shorter *and* automatically correct for kinds added later.

**The kind list comes from the registered scheme, not a literal.** A CRD added to `api/v1beta1` appears here with no change to this command. A hardcoded list is precisely the surface this repo's catalogue checks exist to catch going stale — the 12-CRD Aura suite was missing from `docs/index.md` for its entire life while being correct in two other places.

## Three reporting decisions

- **An unrecognised phase is not a problem.** The Aura kinds mirror Aura's own status vocabulary, which Neo4j can extend without a version bump. Enumerating "running" states would report every new one as broken — the same reasoning as the project's ArgoCD health checks.
- **`…` is not `✗`.** A `Pending` resource is not broken, but its message is the one line that says what to do next. Showing it while marking it distinctly matches how `validate` separates "not yet" from "wrong". I initially hid Pending messages entirely and caught it while eyeballing real output.
- **Messages print below the table, in full.** They are what you act on; a column would wrap them into noise.

## Type of change

- [x] New feature

## Testing

- [x] `make lint` 0 issues, `go vet` clean, cross-compile targets build
- [x] All four drift/catalogue gates OK
- [x] `go test ./cmd/...` green

Fake-client tests cover: scheme-derived enumeration (**including that `List` kinds are filtered** — listing `Neo4jDatabaseList` would ask the API server for `Neo4jDatabaseListList`), generic status reading, namespace scoping vs `--all-namespaces`, the unknown-phase rule, table rendering with and without the namespace column, the pending marker, and the absence of a stray trailing blank line when there is nothing to report.

No Kind or envtest needed, so this stays out of the integration lane.

## Next in the sequence

`connect` / `cypher` (needs a TTY/exec path), then `support-bundle`, then `explain` last — it carries the highest drift risk, and the design says to check the MCP-server overlap (Q3) before building it. krew is parked per your call.