### PR TITLE
feat(cli): connect and cypher — resolve the deployment, hand over the session

### DIFF
--- a/cmd/kubectl-neo4j/connect.go
+++ b/cmd/kubectl-neo4j/connect.go
@@ -1,0 +1,300 @@
+/*
+Copyright 2025 Priyo Lahiri.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	neo4jv1beta1 "github.com/priyolahiri/neo4j-kubernetes-operator/api/v1beta1"
+	"github.com/priyolahiri/neo4j-kubernetes-operator/internal/resources"
+)
+
+// target is a resolved Neo4j deployment: which pod to talk to, in which
+// container, over which scheme. Working this out is the entire value of these
+// commands — the terminal plumbing is not.
+type target struct {
+	kind      string // Neo4jEnterpriseCluster | Neo4jEnterpriseStandalone
+	name      string
+	namespace string
+	pod       string
+	container string
+	tls       bool
+}
+
+func (t target) scheme() string {
+	if t.tls {
+		return "bolt+s"
+	}
+	return "bolt"
+}
+
+// cypherShellArgs builds the in-container command.
+//
+// The password is referenced BY NAME, never by value. DB_USERNAME and
+// DB_PASSWORD are already in the container's environment via secretKeyRef
+// (internal/resources/cluster.go), so the shell expands them inside the pod and
+// the secret never leaves it. Passing `-p <value>` instead would put the
+// password in this process's argv, in the pod's argv, and — the one people
+// forget — verbatim in the Kubernetes API audit log, which records an exec
+// request's command array.
+func (t target) cypherShellArgs(query string) string {
+	cmd := fmt.Sprintf(`cypher-shell -a %s://localhost:7687 -u "$DB_USERNAME" -p "$DB_PASSWORD"`, t.scheme())
+	if query != "" {
+		// Single-quote the user's query for the container shell, escaping any
+		// embedded single quotes. The CLI never composes Cypher of its own —
+		// it passes the user's text through unchanged.
+		cmd += fmt.Sprintf(" '%s'", strings.ReplaceAll(query, "'", `'\''`))
+	}
+	return cmd
+}
+
+func runCypher(args []string, stdout, stderr *os.File) int {
+	fs := flag.NewFlagSet("cypher", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	namespace := fs.String("namespace", "", "Namespace of the deployment")
+	kubeContext := fs.String("context", "", "Kubeconfig context to use")
+	kubeconfig := fs.String("kubeconfig", "", "Path to the kubeconfig file")
+	query := fs.String("c", "", "Run a single query and exit, instead of opening an interactive session")
+	fs.Usage = func() {
+		fmt.Fprint(stderr, `Open a cypher-shell session against a Neo4j deployment.
+
+Usage:
+  kubectl neo4j cypher [name] [-n <namespace>] [-c "<query>"]
+
+Resolves the deployment, picks a ready pod, chooses bolt:// or bolt+s:// from
+its TLS settings, and hands you an interactive session. With no name, the only
+deployment in the namespace is used.
+
+The admin password is never read by this command or placed on your command
+line: it is already inside the pod, and is referenced there by variable name.
+
+Flags:
+`)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+
+	if _, err := exec.LookPath("kubectl"); err != nil {
+		fmt.Fprintln(stderr, "error: kubectl was not found on your PATH.")
+		fmt.Fprintln(stderr, "  This command hands the interactive session to `kubectl exec`, which handles")
+		fmt.Fprintln(stderr, "  terminal sizing, signals and cluster authentication. Install kubectl, or use")
+		fmt.Fprintln(stderr, "  `kubectl neo4j connect` to print the command to run yourself.")
+		return exitUsage
+	}
+
+	c, err := newClusterClient(*kubeconfig, *kubeContext)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: could not connect to the cluster: %v\n", err)
+		return exitUsage
+	}
+	ns := *namespace
+	if ns == "" {
+		ns = currentNamespace(*kubeconfig, *kubeContext)
+	}
+
+	tgt, err := resolveTarget(context.Background(), c, ns, fs.Arg(0))
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return exitUsage
+	}
+
+	kargs := []string{"exec", "-n", tgt.namespace, tgt.pod, "-c", tgt.container}
+	if *query == "" {
+		kargs = append(kargs, "-it")
+	} else {
+		kargs = append(kargs, "-i")
+	}
+	kargs = append(kargs, "--", "sh", "-c", tgt.cypherShellArgs(*query))
+
+	if *kubeContext != "" {
+		kargs = append([]string{"--context", *kubeContext}, kargs...)
+	}
+	if *kubeconfig != "" {
+		kargs = append([]string{"--kubeconfig", *kubeconfig}, kargs...)
+	}
+
+	// context.Background deliberately: this is an interactive session, and a
+	// cancellable context would let us kill the user's shell out from under
+	// them. Ctrl-C belongs to cypher-shell, and `kubectl exec -it` forwards it.
+	cmd := exec.CommandContext(context.Background(), "kubectl", kargs...)
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, stdout, stderr
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			// cypher-shell's own exit code is the useful one — a failed query
+			// should not be reported as a CLI usage error.
+			return exitErr.ExitCode()
+		}
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return exitUsage
+	}
+	return exitOK
+}
+
+func runConnect(args []string, stdout, stderr *os.File) int {
+	fs := flag.NewFlagSet("connect", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	namespace := fs.String("namespace", "", "Namespace of the deployment")
+	kubeContext := fs.String("context", "", "Kubeconfig context to use")
+	kubeconfig := fs.String("kubeconfig", "", "Path to the kubeconfig file")
+	fs.Usage = func() {
+		fmt.Fprint(stderr, `Print how to reach a Neo4j deployment.
+
+Usage:
+  kubectl neo4j connect [name] [-n <namespace>]
+
+Shows the in-cluster address, the port-forward command for reaching it from
+your machine, where the credentials live, and the correct Bolt scheme for its
+TLS settings. Executes nothing.
+
+Flags:
+`)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+
+	c, err := newClusterClient(*kubeconfig, *kubeContext)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: could not connect to the cluster: %v\n", err)
+		return exitUsage
+	}
+	ns := *namespace
+	if ns == "" {
+		ns = currentNamespace(*kubeconfig, *kubeContext)
+	}
+
+	tgt, err := resolveTarget(context.Background(), c, ns, fs.Arg(0))
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return exitUsage
+	}
+
+	svc := fmt.Sprintf("%s-client", tgt.name)
+	fmt.Fprintf(stdout, "%s/%s in namespace %s\n\n", tgt.kind, tgt.name, tgt.namespace)
+	fmt.Fprintf(stdout, "In-cluster Bolt:\n  %s://%s.%s.svc.cluster.local:7687\n\n", tgt.scheme(), svc, tgt.namespace)
+	fmt.Fprintf(stdout, "From your machine:\n  kubectl port-forward -n %s svc/%s 7687:7687 7474:7474\n", tgt.namespace, svc)
+	fmt.Fprintf(stdout, "  then connect to %s://localhost:7687\n\n", tgt.scheme())
+	fmt.Fprintf(stdout, "Interactive session (no local port-forward needed):\n  kubectl neo4j cypher %s -n %s\n\n", tgt.name, tgt.namespace)
+	fmt.Fprintf(stdout, "Credentials live in the admin Secret for this deployment; they are already\n")
+	fmt.Fprintf(stdout, "present inside the pod, so `kubectl neo4j cypher` never needs to read them.\n")
+	if tgt.tls {
+		fmt.Fprintf(stdout, "\nTLS is enabled: plain bolt:// is rejected by this deployment — use %s://.\n", tgt.scheme())
+	}
+	return exitOK
+}
+
+// resolveTarget finds the deployment to talk to and a pod that can serve the
+// session. With no name it accepts exactly one deployment in the namespace,
+// and otherwise asks rather than guessing.
+func resolveTarget(ctx context.Context, c client.Client, namespace, name string) (target, error) {
+	var clusters neo4jv1beta1.Neo4jEnterpriseClusterList
+	var standalones neo4jv1beta1.Neo4jEnterpriseStandaloneList
+	_ = c.List(ctx, &clusters, client.InNamespace(namespace))
+	_ = c.List(ctx, &standalones, client.InNamespace(namespace))
+
+	type candidate struct {
+		kind, name string
+		tls        bool
+		selector   client.MatchingLabels
+	}
+	var found []candidate
+	for i := range clusters.Items {
+		cl := &clusters.Items[i]
+		if name != "" && cl.Name != name {
+			continue
+		}
+		found = append(found, candidate{
+			kind: "Neo4jEnterpriseCluster", name: cl.Name,
+			tls:      cl.Spec.TLS != nil && cl.Spec.TLS.Mode == "cert-manager",
+			selector: client.MatchingLabels{"neo4j.com/cluster": cl.Name},
+		})
+	}
+	for i := range standalones.Items {
+		st := &standalones.Items[i]
+		if name != "" && st.Name != name {
+			continue
+		}
+		found = append(found, candidate{
+			kind: "Neo4jEnterpriseStandalone", name: st.Name,
+			tls:      st.Spec.TLS != nil && st.Spec.TLS.Mode == "cert-manager",
+			selector: client.MatchingLabels{"app": st.Name},
+		})
+	}
+
+	switch {
+	case len(found) == 0 && name != "":
+		return target{}, fmt.Errorf("no Neo4j deployment named %q in namespace %q", name, namespace)
+	case len(found) == 0:
+		return target{}, fmt.Errorf("no Neo4j deployment found in namespace %q", namespace)
+	case len(found) > 1:
+		var names []string
+		for _, f := range found {
+			names = append(names, f.name)
+		}
+		return target{}, fmt.Errorf(
+			"namespace %q has %d Neo4j deployments (%s) — name the one you want",
+			namespace, len(found), strings.Join(names, ", "))
+	}
+
+	f := found[0]
+	pod, err := readyPod(ctx, c, namespace, f.selector)
+	if err != nil {
+		return target{}, err
+	}
+	return target{
+		kind: f.kind, name: f.name, namespace: namespace,
+		pod: pod, container: resources.Neo4jContainer, tls: f.tls,
+	}, nil
+}
+
+// readyPod prefers a Ready pod and says so plainly when none is — "connection
+// refused" from a pod that was never going to answer is a worse error than
+// naming the actual problem.
+func readyPod(ctx context.Context, c client.Client, namespace string, sel client.MatchingLabels) (string, error) {
+	var pods corev1.PodList
+	if err := c.List(ctx, &pods, client.InNamespace(namespace), sel); err != nil {
+		return "", fmt.Errorf("could not list pods: %w", err)
+	}
+	if len(pods.Items) == 0 {
+		return "", fmt.Errorf("no pods found for this deployment in namespace %q", namespace)
+	}
+	for i := range pods.Items {
+		p := &pods.Items[i]
+		if p.Status.Phase != corev1.PodRunning {
+			continue
+		}
+		for _, cond := range p.Status.Conditions {
+			if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+				return p.Name, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("no ready pod for this deployment (%d pod(s) exist but none are Ready) — try `kubectl neo4j status`", len(pods.Items))
+}

--- a/cmd/kubectl-neo4j/connect_test.go
+++ b/cmd/kubectl-neo4j/connect_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	neo4jv1beta1 "github.com/priyolahiri/neo4j-kubernetes-operator/api/v1beta1"
+)
+
+func readyPodObj(name, namespace string, labels map[string]string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Labels: labels},
+		Status: corev1.PodStatus{
+			Phase:      corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+		},
+	}
+}
+
+// THE security property of this command: the admin password is referenced by
+// variable name so the shell expands it inside the pod. Passing -p <value>
+// would put the secret in this process's argv, in the pod's argv, and verbatim
+// in the Kubernetes audit log, which records an exec request's command array.
+func TestCypherShellArgs_NeverCarriesThePasswordValue(t *testing.T) {
+	tgt := target{tls: false}
+	cmd := tgt.cypherShellArgs("")
+
+	assert.Contains(t, cmd, `-p "$DB_PASSWORD"`,
+		"the password must be referenced by variable name, expanded inside the pod")
+	assert.Contains(t, cmd, `-u "$DB_USERNAME"`)
+	assert.NotContains(t, cmd, "secret")
+	assert.NotContains(t, cmd, "password=")
+}
+
+func TestCypherShellArgs_SchemeFollowsTLS(t *testing.T) {
+	assert.Contains(t, target{tls: false}.cypherShellArgs(""), "bolt://localhost:7687")
+	// With TLS on, the operator rejects plain bolt:// — guessing wrong fails
+	// opaquely, which is the whole reason this command resolves it.
+	assert.Contains(t, target{tls: true}.cypherShellArgs(""), "bolt+s://localhost:7687")
+}
+
+// The CLI never composes Cypher of its own; it passes the user's text through.
+// Quoting is therefore the only thing it must get right.
+func TestCypherShellArgs_QueryPassthroughEscapesQuotes(t *testing.T) {
+	cmd := target{}.cypherShellArgs(`RETURN 'it''s fine'`)
+	assert.Contains(t, cmd, `'\''`, "embedded single quotes must be escaped for the container shell")
+	assert.True(t, strings.HasPrefix(strings.TrimSpace(cmd), "cypher-shell"))
+}
+
+func TestResolveTarget_PicksTheOnlyDeployment(t *testing.T) {
+	c := testClient(t,
+		&neo4jv1beta1.Neo4jEnterpriseCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "prod", Namespace: "neo4j"},
+			Spec:       neo4jv1beta1.Neo4jEnterpriseClusterSpec{TLS: &neo4jv1beta1.TLSSpec{Mode: "cert-manager"}},
+		},
+		readyPodObj("prod-server-0", "neo4j", map[string]string{"neo4j.com/cluster": "prod"}),
+	)
+
+	tgt, err := resolveTarget(context.Background(), c, "neo4j", "")
+	require.NoError(t, err)
+	assert.Equal(t, "prod", tgt.name)
+	assert.Equal(t, "prod-server-0", tgt.pod)
+	assert.Equal(t, "neo4j", tgt.container)
+	assert.True(t, tgt.tls, "TLS must be read from spec, not guessed")
+	assert.Equal(t, "bolt+s", tgt.scheme())
+}
+
+// Ambiguity must be an error that names the options, not a silent guess.
+func TestResolveTarget_AmbiguousNamespaceAsksRatherThanGuessing(t *testing.T) {
+	c := testClient(t,
+		&neo4jv1beta1.Neo4jEnterpriseCluster{ObjectMeta: metav1.ObjectMeta{Name: "prod", Namespace: "neo4j"}},
+		&neo4jv1beta1.Neo4jEnterpriseStandalone{ObjectMeta: metav1.ObjectMeta{Name: "dev", Namespace: "neo4j"}},
+	)
+
+	_, err := resolveTarget(context.Background(), c, "neo4j", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "prod")
+	assert.Contains(t, err.Error(), "dev", "the error must name the candidates so the user can pick")
+}
+
+func TestResolveTarget_StandaloneUsesItsOwnPodSelector(t *testing.T) {
+	c := testClient(t,
+		&neo4jv1beta1.Neo4jEnterpriseStandalone{ObjectMeta: metav1.ObjectMeta{Name: "dev", Namespace: "neo4j"}},
+		readyPodObj("dev-0", "neo4j", map[string]string{"app": "dev"}),
+	)
+
+	tgt, err := resolveTarget(context.Background(), c, "neo4j", "dev")
+	require.NoError(t, err)
+	assert.Equal(t, "Neo4jEnterpriseStandalone", tgt.kind)
+	assert.Equal(t, "dev-0", tgt.pod)
+	assert.False(t, tgt.tls)
+}
+
+// "connection refused" from a pod that was never going to answer is a worse
+// error than naming the actual problem.
+func TestResolveTarget_NoReadyPodSaysSoAndPointsSomewhere(t *testing.T) {
+	notReady := readyPodObj("prod-server-0", "neo4j", map[string]string{"neo4j.com/cluster": "prod"})
+	notReady.Status.Conditions[0].Status = corev1.ConditionFalse
+
+	c := testClient(t,
+		&neo4jv1beta1.Neo4jEnterpriseCluster{ObjectMeta: metav1.ObjectMeta{Name: "prod", Namespace: "neo4j"}},
+		notReady,
+	)
+
+	_, err := resolveTarget(context.Background(), c, "neo4j", "prod")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "none are Ready")
+	assert.Contains(t, err.Error(), "status", "point the user at the command that explains why")
+}
+
+func TestResolveTarget_UnknownNameIsAClearError(t *testing.T) {
+	c := testClient(t, &neo4jv1beta1.Neo4jEnterpriseCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "prod", Namespace: "neo4j"},
+	})
+	_, err := resolveTarget(context.Background(), c, "neo4j", "typo")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"typo"`)
+}

--- a/cmd/kubectl-neo4j/main.go
+++ b/cmd/kubectl-neo4j/main.go
@@ -48,6 +48,8 @@ Usage:
 Commands:
   validate    Validate Neo4j CR manifests against the operator's own validators
   status      Show the state of every Neo4j resource in a namespace
+  connect     Print how to reach a deployment (address, port-forward, scheme)
+  cypher      Open a cypher-shell session against a deployment
   version     Print the version
 
 Run "kubectl neo4j <command> -h" for command flags.
@@ -69,6 +71,10 @@ func run(args []string, stdout, stderr *os.File) int {
 		return runValidate(args[1:], stdout, stderr)
 	case "status":
 		return runStatus(args[1:], stdout, stderr)
+	case "connect":
+		return runConnect(args[1:], stdout, stderr)
+	case "cypher":
+		return runCypher(args[1:], stdout, stderr)
 	case "version":
 		fmt.Fprintln(stdout, version)
 		return exitOK

--- a/docs/design/cli-tool.md
+++ b/docs/design/cli-tool.md
@@ -314,6 +314,24 @@ a parsing surface, breaks under partial RBAC in ways that are hard to report
 well, and forfeits the shared-package property in §2 that is the whole reason
 to build this here.
 
+**Scope of that rejection, clarified when `cypher` was built.** What is rejected
+is shelling out to `kubectl` *as a data source* — parsing its output instead of
+using the API. Handing it an **interactive session** parses nothing and forfeits
+nothing, and `cypher` does exactly that: client-go resolves the pod, container
+and Bolt scheme, then `kubectl exec -it` runs the session. Terminal raw mode,
+window resize, signal forwarding and every kubeconfig auth plugin are already
+solved there; reimplementing them via SPDY would be a few hundred lines of
+fragile code for no capability we want. The cost — `kubectl` must be on PATH —
+is definitional for a kubectl plugin and is reported plainly when it is not.
+
+**The security argument that would have favoured SPDY does not apply**, because
+neither approach needs to handle the password. `DB_USERNAME` / `DB_PASSWORD`
+are already in the container via `secretKeyRef`, so the command references them
+by name and the shell expands them inside the pod. The secret never reaches
+this process, the user's shell history, or the Kubernetes audit log — which
+records an exec request's command array verbatim, and is where a `-p <value>`
+implementation would leak it.
+
 ### (d) Decline — improve the docs instead
 
 The status quo, and the honest baseline. It is what the 98-line troubleshooting
@@ -443,7 +461,7 @@ honest options are recorded in §9 Q5 rather than papered over.
    renders distinctly and never affects the exit code, including under
    `--strict`. Dropping it, as the first implementation did, hid the difference
    between "wrong" and "not yet".
-4. **`status`** (§4.2) → **done**, then **`connect` / `cypher`** (§4.3).
+4. **`status`** (§4.2) → **done**. **`connect` / `cypher`** (§4.3) → **done**.
 
    `status` reads every kind generically — phase, ready, message — rather than
    through 26 typed switches, and takes its kind list from the registered

--- a/docs/user_guide/guides/cli.md
+++ b/docs/user_guide/guides/cli.md
@@ -283,6 +283,54 @@ The kind list comes from the operator's registered API scheme rather than a hard
 
 Exit code is `0` on a successful query even when resources are unhealthy — mirroring `kubectl get`. Use `--problems` and check for empty output if you want a health gate.
 
+## `connect` and `cypher`
+
+The most-repeated sequence in the troubleshooting guide is: find the pod, extract the password from a Secret, remember the container name, guess the right Bolt scheme. These two commands do the resolution for you.
+
+```bash
+kubectl neo4j cypher                    # the only deployment in the namespace
+kubectl neo4j cypher prod -n neo4j      # a specific one
+kubectl neo4j cypher prod -c "SHOW DATABASES"
+```
+
+`connect` prints the same resolution without executing anything — useful when you want the port-forward command, or to hand someone the details:
+
+```
+$ kubectl neo4j connect prod
+Neo4jEnterpriseCluster/prod in namespace neo4j
+
+In-cluster Bolt:
+  bolt+s://prod-client.neo4j.svc.cluster.local:7687
+
+From your machine:
+  kubectl port-forward -n neo4j svc/prod-client 7687:7687 7474:7474
+  then connect to bolt+s://localhost:7687
+...
+TLS is enabled: plain bolt:// is rejected by this deployment — use bolt+s://.
+```
+
+### Your password is never read, moved, or logged
+
+This is worth stating precisely, because the obvious implementation gets it wrong.
+
+The admin credentials are **already inside the pod** — the operator injects them via `secretKeyRef` as `DB_USERNAME` and `DB_PASSWORD`. So the command references them *by variable name* and lets the shell expand them in the container:
+
+```bash
+kubectl exec -n neo4j prod-server-0 -c neo4j -it --   sh -c 'cypher-shell -a bolt+s://localhost:7687 -u "$DB_USERNAME" -p "$DB_PASSWORD"'
+```
+
+The secret never leaves the pod. It is not in your shell history, not in `ps` output on either side, and — the one people forget — **not in the Kubernetes API audit log**, which records an exec request's command array verbatim. A version that read the Secret and passed `-p <value>` would leak it into all three.
+
+### It hands the session to `kubectl`
+
+`cypher` resolves the target itself, then execs `kubectl` for the interactive part. That is deliberate: terminal raw mode, window resize, signal forwarding and every kubeconfig authentication plugin are already solved there, and reimplementing them would add a large amount of fragile code for no capability you want.
+
+Consequence: **`kubectl` must be on your `PATH`.** Invoked as `kubectl neo4j cypher` it always is. If you run the binary standalone without kubectl installed, the command says so and points you at `connect` instead of failing obscurely.
+
+### What it will not do
+
+`cypher` passes *your* query through unchanged; the CLI never composes Cypher of its own. Operations the operator models as resources — creating a database, promoting a replica — belong in a CR, not in a shell command, so that they are declarative, auditable and reversible. `kubectl neo4j cypher -c "..."` is you running your own query, which is a different thing from the CLI deciding to mutate your database.
+
 ## See also
 
 - [Troubleshooting](troubleshooting.md) — diagnosing a deployment that is already running


### PR DESCRIPTION
## Summary

Delivery item 4b. **Stacked on #361** (which is stacked on #360) — base is `feat/cli-status`, so the diff shows only this work.

```bash
kubectl neo4j cypher                 # the only deployment in the namespace
kubectl neo4j cypher prod -n neo4j
kubectl neo4j cypher prod -c "SHOW DATABASES"
kubectl neo4j connect prod           # print the resolution, execute nothing
```

## The password is never read, moved, or logged

The obvious implementation gets this wrong, so it is worth being explicit.

`DB_USERNAME` and `DB_PASSWORD` are **already inside the container** via `secretKeyRef` (`internal/resources/cluster.go:1181`). The command references them *by name* and lets the shell expand them in the pod:

```bash
kubectl exec -n neo4j prod-server-0 -c neo4j -it -- \
  sh -c 'cypher-shell -a bolt+s://localhost:7687 -u "$DB_USERNAME" -p "$DB_PASSWORD"'
```

The secret never reaches this process, your shell history, `ps` on either side, or — the one people forget — **the Kubernetes API audit log**, which records an exec request's command array verbatim. A version that read the Secret and passed `-p <value>` would leak it into all of those. Pinned by `TestCypherShellArgs_NeverCarriesThePasswordValue`.

## Why `kubectl exec`, not SPDY

Terminal raw mode, window resize, signal forwarding and every kubeconfig auth plugin (EKS/GKE/AKS exec credentials, impersonation, proxies) are already solved in kubectl. Reimplementing them over SPDY is a few hundred lines of fragile code for no capability we want.

**The security argument that would have favoured SPDY does not apply** — I expected it to, and it dissolved once I checked how credentials reach the pod. Neither approach needs to handle the password.

**This does not contradict the design's rejection of option (c).** What was rejected there is shelling out to kubectl *as a data source* — parsing its output instead of using the API. Handing it an interactive session parses nothing, and client-go still does all the resolution. The design doc now records that distinction explicitly so a later reader doesn't think we drifted.

Cost: `kubectl` must be on `PATH`. Definitional when invoked as `kubectl neo4j cypher`, and reported plainly rather than failing as `exec: "kubectl": not found`:

```
error: kubectl was not found on your PATH.
  This command hands the interactive session to `kubectl exec`, which handles
  terminal sizing, signals and cluster authentication. Install kubectl, or use
  `kubectl neo4j connect` to print the command to run yourself.
```

## Resolution refuses to guess

- An **ambiguous namespace** errors and *names the candidates* rather than picking one.
- A deployment with **no Ready pod** says so and points at `kubectl neo4j status` — "connection refused" from a pod that was never going to answer is a worse error than naming the actual problem.
- The **Bolt scheme comes from `spec.tls`**, not a guess. With TLS on, the operator rejects plain `bolt://` and the failure is opaque; that resolution is a large part of the value here.

## Scope boundary held

`cypher` passes *your* query through unchanged; the CLI never composes Cypher of its own. Operations the operator models as resources — creating a database, promoting a replica — stay in CRs, where they are declarative, auditable and reversible. `-c "..."` is you running your own query, which is a different thing from the CLI deciding to mutate your database. That distinction is written into the guide, not just the commit.

## Type of change

- [x] New feature

## Testing

- [x] `make lint` 0 issues, `go vet` clean, cross-compile targets build
- [x] `go test ./cmd/...` green; drift/catalogue gates OK

Fake-client tests cover the password-never-in-argv property, scheme selection from TLS, query passthrough quoting (including embedded single quotes), single-deployment resolution, the ambiguous-namespace error naming its candidates, standalone's different pod selector, the no-Ready-pod message, and an unknown name. The missing-`kubectl` path was verified by hand with a stripped `PATH`.

## Next

`support-bundle`, then `explain` last — highest drift risk, and the design says to check the MCP-server overlap (Q3) before building it.