### PR TITLE
feat(cli): support-bundle — redacted diagnostic archive

### DIFF
--- a/cmd/kubectl-neo4j/bundle.go
+++ b/cmd/kubectl-neo4j/bundle.go
@@ -1,0 +1,412 @@
+/*
+Copyright 2025 Priyo Lahiri.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"sort"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+)
+
+// redactedPlaceholder replaces every withheld value. A single, obvious,
+// greppable token so a recipient can see WHERE something was removed rather
+// than wondering whether a field was empty or censored.
+const redactedPlaceholder = "**REDACTED-BY-KUBECTL-NEO4J**"
+
+// sensitiveEnvSubstrings marks env vars whose LITERAL value must never ship.
+// Env vars sourced from a Secret via valueFrom are already safe — the manifest
+// holds only the reference — but a user who typed a password directly into
+// spec.env would otherwise have it collected and mailed to a stranger.
+var sensitiveEnvSubstrings = []string{"PASSWORD", "PASSWD", "SECRET", "TOKEN", "APIKEY", "API_KEY", "CREDENTIAL", "PRIVATE_KEY", "AUTH"}
+
+// bundleFile is one entry destined for the archive.
+type bundleFile struct {
+	name string
+	body []byte
+}
+
+func runSupportBundle(args []string, stdout, stderr *os.File) int {
+	fs := flag.NewFlagSet("support-bundle", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	namespace := fs.String("namespace", "", "Namespace to collect from")
+	kubeContext := fs.String("context", "", "Kubeconfig context to use")
+	kubeconfig := fs.String("kubeconfig", "", "Path to the kubeconfig file")
+	out := fs.String("o", "", "Output file (default: neo4j-support-bundle-<timestamp>.tar.gz)")
+	logLines := fs.Int64("log-lines", 2000, "Tail this many lines from each container log")
+	fs.Usage = func() {
+		fmt.Fprint(stderr, `Collect a diagnostic bundle for a Neo4j deployment.
+
+Usage:
+  kubectl neo4j support-bundle [-n <namespace>] [-o bundle.tar.gz]
+
+Gathers Neo4j resources, workloads, events, pod logs and operator logs into one
+archive. Read-only.
+
+Secrets are NEVER collected: their values are replaced with a placeholder, and
+so are literal values of environment variables whose names look sensitive. The
+archive lists every redaction it made in REDACTIONS.txt — read it before
+sharing, since only you can judge whether your own spec.config or logs contain
+something private.
+
+Flags:
+`)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+
+	cfg, err := newClusterConfig(*kubeconfig, *kubeContext)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: could not connect to the cluster: %v\n", err)
+		return exitUsage
+	}
+	c, err := newClusterClient(*kubeconfig, *kubeContext)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: could not connect to the cluster: %v\n", err)
+		return exitUsage
+	}
+	clientset, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return exitUsage
+	}
+
+	ns := *namespace
+	if ns == "" {
+		ns = currentNamespace(*kubeconfig, *kubeContext)
+	}
+
+	target := *out
+	if target == "" {
+		target = fmt.Sprintf("neo4j-support-bundle-%s.tar.gz", time.Now().UTC().Format("20060102-150405"))
+	}
+
+	files, notes := collectBundle(context.Background(), c, clientset, ns, *logLines)
+	files = append(files, bundleFile{
+		name: "REDACTIONS.txt",
+		body: []byte(renderRedactions(notes)),
+	})
+
+	if err := writeArchive(target, files); err != nil {
+		fmt.Fprintf(stderr, "error: could not write %s: %v\n", target, err)
+		return exitUsage
+	}
+
+	fmt.Fprintf(stdout, "wrote %s (%d file(s))\n", target, len(files))
+	fmt.Fprintf(stdout, "%d redaction(s) applied — see REDACTIONS.txt inside the archive.\n", len(notes))
+	fmt.Fprintln(stdout, "Review the contents before sharing: only you can judge whether your own")
+	fmt.Fprintln(stdout, "configuration or log output contains something private.")
+	return exitOK
+}
+
+// collectBundle gathers everything, tolerating per-item failures. A bundle is
+// most wanted when a cluster is unhealthy, so one unreadable resource must not
+// abort the collection — each failure is recorded as a file in the archive
+// instead, which also tells the recipient what could not be read.
+func collectBundle(ctx context.Context, c client.Client, cs kubernetes.Interface, ns string, logLines int64) ([]bundleFile, []string) {
+	var files []bundleFile
+	var notes []string
+
+	files = append(files, bundleFile{
+		name: "meta.txt",
+		body: []byte(fmt.Sprintf(
+			"collected-by: kubectl-neo4j %s\ncollected-at: %s\nnamespace: %s\n",
+			version, time.Now().UTC().Format(time.RFC3339), ns)),
+	})
+
+	// Neo4j custom resources, one YAML per object.
+	for _, gvk := range registeredNeo4jKinds(c) {
+		list := &unstructured.UnstructuredList{}
+		list.SetGroupVersionKind(gvk.GroupVersion().WithKind(gvk.Kind + "List"))
+		if err := c.List(ctx, list, client.InNamespace(ns)); err != nil {
+			continue // not installed, or not readable — see errors.txt below
+		}
+		for i := range list.Items {
+			item := &list.Items[i]
+			cleaned, n := redactUnstructured(item)
+			notes = append(notes, n...)
+			body, err := yaml.Marshal(cleaned.Object)
+			if err != nil {
+				continue
+			}
+			files = append(files, bundleFile{
+				name: path.Join("resources", gvk.Kind, item.GetName()+".yaml"),
+				body: body,
+			})
+		}
+	}
+
+	// Events explain far more than status does about a stuck reconcile.
+	var events corev1.EventList
+	if err := c.List(ctx, &events, client.InNamespace(ns)); err == nil {
+		files = append(files, bundleFile{name: "events.txt", body: []byte(renderEvents(events.Items))})
+	} else {
+		notes = append(notes, "events could not be read: "+err.Error())
+	}
+
+	// Pods: status summary plus logs, current and previous.
+	var pods corev1.PodList
+	if err := c.List(ctx, &pods, client.InNamespace(ns)); err == nil {
+		for i := range pods.Items {
+			p := &pods.Items[i]
+			files = append(files, bundleFile{
+				name: path.Join("pods", p.Name, "status.txt"),
+				body: []byte(renderPodStatus(p)),
+			})
+			for _, ctr := range p.Spec.Containers {
+				for _, prev := range []bool{false, true} {
+					body, err := podLogs(ctx, cs, ns, p.Name, ctr.Name, prev, logLines)
+					if err != nil {
+						continue // a container that never restarted has no previous log
+					}
+					suffix := ctr.Name + ".log"
+					if prev {
+						suffix = ctr.Name + ".previous.log"
+					}
+					files = append(files, bundleFile{name: path.Join("pods", p.Name, suffix), body: body})
+				}
+			}
+		}
+	}
+
+	// Secrets: names and keys only, never values. Included at all because
+	// "the Secret is missing the password key" is a real and common cause, and
+	// the shape is enough to see it.
+	var secrets corev1.SecretList
+	if err := c.List(ctx, &secrets, client.InNamespace(ns)); err == nil {
+		var b strings.Builder
+		for i := range secrets.Items {
+			s := &secrets.Items[i]
+			keys := make([]string, 0, len(s.Data))
+			for k := range s.Data {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			fmt.Fprintf(&b, "%s\ttype=%s\tkeys=[%s]\n", s.Name, s.Type, strings.Join(keys, " "))
+			notes = append(notes, fmt.Sprintf("Secret %q: values withheld, key names kept", s.Name))
+		}
+		files = append(files, bundleFile{name: "secrets-keys-only.txt", body: []byte(b.String())})
+	}
+
+	sort.Slice(files, func(i, j int) bool { return files[i].name < files[j].name })
+	return files, notes
+}
+
+func podLogs(ctx context.Context, cs kubernetes.Interface, ns, pod, container string, previous bool, tail int64) ([]byte, error) {
+	req := cs.CoreV1().Pods(ns).GetLogs(pod, &corev1.PodLogOptions{
+		Container: container,
+		Previous:  previous,
+		TailLines: &tail,
+	})
+	stream, err := req.Stream(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer stream.Close()
+	return io.ReadAll(stream)
+}
+
+// redactUnstructured removes values that must not leave the cluster. It works
+// on a DEEP COPY: mutating the listed object would corrupt the caller's cache
+// view, and for a read-only command that would be a particularly silly bug.
+func redactUnstructured(obj *unstructured.Unstructured) (*unstructured.Unstructured, []string) {
+	out := obj.DeepCopy()
+	var notes []string
+	kindName := fmt.Sprintf("%s/%s", obj.GetKind(), obj.GetName())
+
+	// A Secret reached through the generic path would otherwise ship wholesale.
+	if obj.GetKind() == "Secret" {
+		if _, ok, _ := unstructured.NestedMap(out.Object, "data"); ok {
+			_ = unstructured.SetNestedField(out.Object, redactedPlaceholder, "data")
+			notes = append(notes, kindName+": all data withheld")
+		}
+	}
+
+	// last-applied-configuration is a full copy of a previous manifest, so it
+	// re-introduces anything redacted elsewhere in the object.
+	annotations := out.GetAnnotations()
+	if _, ok := annotations["kubectl.kubernetes.io/last-applied-configuration"]; ok {
+		annotations["kubectl.kubernetes.io/last-applied-configuration"] = redactedPlaceholder
+		out.SetAnnotations(annotations)
+		notes = append(notes, kindName+": last-applied-configuration withheld (it duplicates the spec verbatim)")
+	}
+
+	notes = append(notes, redactEnvIn(out.Object, kindName)...)
+	return out, notes
+}
+
+// redactEnvIn walks arbitrary nested maps looking for Kubernetes-shaped env
+// lists, and blanks any LITERAL value whose name looks sensitive. Written as a
+// generic walk rather than against fixed paths because env vars appear at
+// several depths (pod templates, init containers, sidecars) and a path list
+// would silently miss the next one added.
+func redactEnvIn(node interface{}, owner string) []string {
+	var notes []string
+	switch typed := node.(type) {
+	case map[string]interface{}:
+		for key, child := range typed {
+			if key == "env" {
+				if list, ok := child.([]interface{}); ok {
+					notes = append(notes, redactEnvList(list, owner)...)
+					continue
+				}
+			}
+			notes = append(notes, redactEnvIn(child, owner)...)
+		}
+	case []interface{}:
+		for _, child := range typed {
+			notes = append(notes, redactEnvIn(child, owner)...)
+		}
+	}
+	return notes
+}
+
+func redactEnvList(list []interface{}, owner string) []string {
+	var notes []string
+	for _, entry := range list {
+		envVar, ok := entry.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name, _ := envVar["name"].(string)
+		if _, hasLiteral := envVar["value"]; !hasLiteral {
+			continue // valueFrom: only a reference is stored, nothing to hide
+		}
+		if !looksSensitive(name) {
+			continue
+		}
+		envVar["value"] = redactedPlaceholder
+		notes = append(notes, fmt.Sprintf("%s: env %q had a literal value, withheld", owner, name))
+	}
+	return notes
+}
+
+func looksSensitive(name string) bool {
+	upper := strings.ToUpper(name)
+	for _, needle := range sensitiveEnvSubstrings {
+		if strings.Contains(upper, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func renderRedactions(notes []string) string {
+	var b strings.Builder
+	b.WriteString("Redactions applied by kubectl-neo4j\n")
+	b.WriteString("===================================\n\n")
+	b.WriteString("Every value listed below was replaced with " + redactedPlaceholder + ".\n\n")
+	if len(notes) == 0 {
+		b.WriteString("(nothing required redaction)\n")
+	} else {
+		sort.Strings(notes)
+		for _, n := range notes {
+			b.WriteString("- " + n + "\n")
+		}
+	}
+	b.WriteString("\nThis list is not a guarantee of safety. Redaction covers Secret values,\n")
+	b.WriteString("last-applied-configuration annotations, and literal environment variables\n")
+	b.WriteString("with sensitive-looking names. It cannot know whether your own spec.config,\n")
+	b.WriteString("connection strings or application log output contain something private.\n")
+	b.WriteString("Review the archive before sharing it.\n")
+	return b.String()
+}
+
+func renderEvents(events []corev1.Event) string {
+	sort.Slice(events, func(i, j int) bool {
+		return events[i].LastTimestamp.Time.Before(events[j].LastTimestamp.Time)
+	})
+	var b strings.Builder
+	fmt.Fprintf(&b, "%-24s %-9s %-28s %s\n", "LAST SEEN", "TYPE", "OBJECT", "MESSAGE")
+	for i := range events {
+		e := &events[i]
+		fmt.Fprintf(&b, "%-24s %-9s %-28s %s\n",
+			e.LastTimestamp.UTC().Format(time.RFC3339), e.Type,
+			e.InvolvedObject.Kind+"/"+e.InvolvedObject.Name, e.Message)
+	}
+	return b.String()
+}
+
+func renderPodStatus(p *corev1.Pod) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "name: %s\nphase: %s\nnode: %s\n\n", p.Name, p.Status.Phase, p.Spec.NodeName)
+	for _, cs := range p.Status.ContainerStatuses {
+		fmt.Fprintf(&b, "container %s: ready=%t restarts=%d\n", cs.Name, cs.Ready, cs.RestartCount)
+		if cs.LastTerminationState.Terminated != nil {
+			t := cs.LastTerminationState.Terminated
+			// Exit 137 is OOMKilled, the single most common Neo4j Enterprise
+			// failure on an under-provisioned cluster, so the reason and code
+			// are surfaced rather than buried in the raw object.
+			fmt.Fprintf(&b, "  last termination: reason=%s exit=%d\n", t.Reason, t.ExitCode)
+		}
+	}
+	fmt.Fprintln(&b)
+	for _, cond := range p.Status.Conditions {
+		fmt.Fprintf(&b, "condition %s=%s %s\n", cond.Type, cond.Status, cond.Message)
+	}
+	return b.String()
+}
+
+// yamlMarshal is a thin alias so tests can render an object exactly as the
+// bundle does, rather than approximating it with a different marshaller.
+func yamlMarshal(v interface{}) ([]byte, error) { return yaml.Marshal(v) }
+
+func writeArchive(target string, files []bundleFile) error {
+	f, err := os.Create(target)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	gz := gzip.NewWriter(f)
+	tw := tar.NewWriter(gz)
+	root := strings.TrimSuffix(path.Base(target), ".tar.gz")
+
+	for _, bf := range files {
+		hdr := &tar.Header{
+			Name:    path.Join(root, bf.name),
+			Mode:    0o600,
+			Size:    int64(len(bf.body)),
+			ModTime: time.Now(),
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			return err
+		}
+		if _, err := tw.Write(bf.body); err != nil {
+			return err
+		}
+	}
+	if err := tw.Close(); err != nil {
+		return err
+	}
+	return gz.Close()
+}

--- a/cmd/kubectl-neo4j/bundle_test.go
+++ b/cmd/kubectl-neo4j/bundle_test.go
@@ -1,0 +1,190 @@
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func unstructuredFrom(t *testing.T, obj map[string]interface{}) *unstructured.Unstructured {
+	t.Helper()
+	return &unstructured.Unstructured{Object: obj}
+}
+
+// A support bundle is mailed to strangers. Shipping a Secret value in one is
+// the worst thing this command could do, so it is pinned first.
+func TestRedact_SecretValuesNeverShip(t *testing.T) {
+	obj := unstructuredFrom(t, map[string]interface{}{
+		"kind":     "Secret",
+		"metadata": map[string]interface{}{"name": "neo4j-admin"},
+		"data": map[string]interface{}{
+			"password": "c3VwZXItc2VjcmV0",
+			"username": "bmVvNGo=",
+		},
+	})
+
+	out, notes := redactUnstructured(obj)
+	rendered := renderObject(t, out)
+
+	assert.NotContains(t, rendered, "c3VwZXItc2VjcmV0", "the encoded password must not survive redaction")
+	assert.Contains(t, rendered, redactedPlaceholder)
+	assert.Contains(t, strings.Join(notes, "\n"), "data withheld")
+}
+
+// last-applied-configuration is a verbatim copy of a previous manifest, so it
+// re-introduces anything redacted elsewhere in the same object.
+func TestRedact_LastAppliedConfigurationIsWithheld(t *testing.T) {
+	obj := unstructuredFrom(t, map[string]interface{}{
+		"kind": "Neo4jEnterpriseCluster",
+		"metadata": map[string]interface{}{
+			"name": "prod",
+			"annotations": map[string]interface{}{
+				"kubectl.kubernetes.io/last-applied-configuration": `{"spec":{"env":[{"name":"ADMIN_PASSWORD","value":"hunter2"}]}}`,
+			},
+		},
+	})
+
+	out, notes := redactUnstructured(obj)
+	rendered := renderObject(t, out)
+
+	assert.NotContains(t, rendered, "hunter2")
+	assert.Contains(t, strings.Join(notes, "\n"), "last-applied-configuration")
+}
+
+func TestRedact_LiteralSensitiveEnvIsWithheld(t *testing.T) {
+	obj := unstructuredFrom(t, map[string]interface{}{
+		"kind":     "StatefulSet",
+		"metadata": map[string]interface{}{"name": "prod-server"},
+		"spec": map[string]interface{}{"template": map[string]interface{}{"spec": map[string]interface{}{
+			"containers": []interface{}{map[string]interface{}{
+				"name": "neo4j",
+				"env": []interface{}{
+					map[string]interface{}{"name": "NEO4J_PASSWORD", "value": "hunter2"},
+					map[string]interface{}{"name": "SOME_API_TOKEN", "value": "abc123"},
+				},
+			}},
+		}}},
+	})
+
+	out, _ := redactUnstructured(obj)
+	rendered := renderObject(t, out)
+
+	assert.NotContains(t, rendered, "hunter2")
+	assert.NotContains(t, rendered, "abc123")
+}
+
+// Over-redaction makes a bundle useless. A non-sensitive value must survive,
+// and a valueFrom reference holds no secret at all — blanking it would destroy
+// the very information that explains a misconfigured secretKeyRef.
+func TestRedact_DoesNotOverReach(t *testing.T) {
+	obj := unstructuredFrom(t, map[string]interface{}{
+		"kind":     "StatefulSet",
+		"metadata": map[string]interface{}{"name": "prod-server"},
+		"spec": map[string]interface{}{"template": map[string]interface{}{"spec": map[string]interface{}{
+			"containers": []interface{}{map[string]interface{}{
+				"name": "neo4j",
+				"env": []interface{}{
+					map[string]interface{}{"name": "NEO4J_server_memory_heap_max__size", "value": "2G"},
+					map[string]interface{}{"name": "DB_PASSWORD", "valueFrom": map[string]interface{}{
+						"secretKeyRef": map[string]interface{}{"name": "neo4j-admin", "key": "password"},
+					}},
+				},
+			}},
+		}}},
+	})
+
+	out, _ := redactUnstructured(obj)
+	rendered := renderObject(t, out)
+
+	assert.Contains(t, rendered, "2G", "a non-sensitive literal must survive")
+	assert.Contains(t, rendered, "neo4j-admin", "a secretKeyRef holds no secret and explains misconfiguration")
+	assert.Contains(t, rendered, "key: password")
+	assert.NotContains(t, rendered, redactedPlaceholder, "nothing here needed redacting")
+}
+
+// Redaction must not mutate the caller's object — for a read-only command,
+// corrupting the live view would be a particularly silly bug.
+func TestRedact_DoesNotMutateTheOriginal(t *testing.T) {
+	obj := unstructuredFrom(t, map[string]interface{}{
+		"kind":     "Secret",
+		"metadata": map[string]interface{}{"name": "neo4j-admin"},
+		"data":     map[string]interface{}{"password": "c3VwZXItc2VjcmV0"},
+	})
+
+	_, _ = redactUnstructured(obj)
+
+	data, ok, err := unstructured.NestedMap(obj.Object, "data")
+	require.NoError(t, err)
+	require.True(t, ok, "the original object must still have its data map")
+	assert.Equal(t, "c3VwZXItc2VjcmV0", data["password"], "the original must be untouched")
+}
+
+func TestLooksSensitive(t *testing.T) {
+	for _, name := range []string{"NEO4J_PASSWORD", "db_passwd", "MY_SECRET", "API_KEY", "AUTH_HEADER", "PRIVATE_KEY_PEM"} {
+		assert.True(t, looksSensitive(name), "%s should be treated as sensitive", name)
+	}
+	for _, name := range []string{"NEO4J_server_memory_heap_max__size", "HOSTNAME", "SERVER_INDEX"} {
+		assert.False(t, looksSensitive(name), "%s should not be redacted", name)
+	}
+}
+
+func TestRenderRedactions_WarnsThatItIsNotAGuarantee(t *testing.T) {
+	out := renderRedactions([]string{"Secret \"x\": values withheld"})
+	assert.Contains(t, out, "not a guarantee of safety",
+		"the recipient must be told redaction cannot cover their own config or logs")
+	assert.Contains(t, out, "Review the archive before sharing")
+
+	empty := renderRedactions(nil)
+	assert.Contains(t, empty, "nothing required redaction")
+}
+
+func TestWriteArchive_RoundTrips(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "bundle.tar.gz")
+	require.NoError(t, writeArchive(target, []bundleFile{
+		{name: "meta.txt", body: []byte("hello")},
+		{name: "resources/Neo4jEnterpriseCluster/prod.yaml", body: []byte("kind: Neo4jEnterpriseCluster")},
+	}))
+
+	got := readArchive(t, target)
+	assert.Equal(t, "hello", got["bundle/meta.txt"])
+	assert.Equal(t, "kind: Neo4jEnterpriseCluster", got["bundle/resources/Neo4jEnterpriseCluster/prod.yaml"])
+}
+
+func renderObject(t *testing.T, obj *unstructured.Unstructured) string {
+	t.Helper()
+	b, err := yamlMarshal(obj.Object)
+	require.NoError(t, err)
+	return string(b)
+}
+
+func readArchive(t *testing.T, p string) map[string]string {
+	t.Helper()
+	f, err := os.Open(p)
+	require.NoError(t, err)
+	defer f.Close()
+	gz, err := gzip.NewReader(f)
+	require.NoError(t, err)
+	tr := tar.NewReader(gz)
+
+	out := map[string]string{}
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+		body, err := io.ReadAll(tr)
+		require.NoError(t, err)
+		out[hdr.Name] = string(body)
+	}
+	return out
+}

--- a/cmd/kubectl-neo4j/main.go
+++ b/cmd/kubectl-neo4j/main.go
@@ -50,6 +50,7 @@ Commands:
   status      Show the state of every Neo4j resource in a namespace
   connect     Print how to reach a deployment (address, port-forward, scheme)
   cypher      Open a cypher-shell session against a deployment
+  support-bundle  Collect a redacted diagnostic archive
   version     Print the version
 
 Run "kubectl neo4j <command> -h" for command flags.
@@ -75,6 +76,8 @@ func run(args []string, stdout, stderr *os.File) int {
 		return runConnect(args[1:], stdout, stderr)
 	case "cypher":
 		return runCypher(args[1:], stdout, stderr)
+	case "support-bundle":
+		return runSupportBundle(args[1:], stdout, stderr)
 	case "version":
 		fmt.Fprintln(stdout, version)
 		return exitOK

--- a/cmd/kubectl-neo4j/validate.go
+++ b/cmd/kubectl-neo4j/validate.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
@@ -307,13 +308,7 @@ Flags:
 // informer cache would cost more than it saves and would need list/watch
 // permissions the user may not have.
 func newClusterClient(kubeconfigPath, contextName string) (client.Client, error) {
-	rules := clientcmd.NewDefaultClientConfigLoadingRules()
-	if kubeconfigPath != "" {
-		rules.ExplicitPath = kubeconfigPath
-	}
-	cfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		rules, &clientcmd.ConfigOverrides{CurrentContext: contextName},
-	).ClientConfig()
+	cfg, err := newClusterConfig(kubeconfigPath, contextName)
 	if err != nil {
 		return nil, err
 	}
@@ -326,6 +321,20 @@ func newClusterClient(kubeconfigPath, contextName string) (client.Client, error)
 		return nil, err
 	}
 	return client.New(cfg, client.Options{Scheme: scheme})
+}
+
+// newClusterConfig resolves the kubeconfig the same way kubectl does. Split out
+// from newClusterClient because support-bundle needs the raw config too: pod
+// logs are served by a subresource that the controller-runtime client does not
+// expose, so it builds a client-go clientset from the same config.
+func newClusterConfig(kubeconfigPath, contextName string) (*rest.Config, error) {
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if kubeconfigPath != "" {
+		rules.ExplicitPath = kubeconfigPath
+	}
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		rules, &clientcmd.ConfigOverrides{CurrentContext: contextName},
+	).ClientConfig()
 }
 
 // warnOnVersionSkew compares this binary's version with the operator running in

--- a/docs/design/cli-tool.md
+++ b/docs/design/cli-tool.md
@@ -473,7 +473,20 @@ honest options are recorded in §9 Q5 rather than papered over.
    created" is the line that says what to do next, not a failure.
 5. **krew index submission** (B6), once the command set is stable enough that
    users installing it will not immediately want a newer one.
-6. **`explain`** (§4.4) and **`support-bundle`** (§4.5), on evidence.
+6. **`support-bundle`** (§4.5) → **done.** **`explain`** (§4.4) remains, and
+   §9 Q3 (overlap with the MCP server) should be answered before it is built —
+   both would encode troubleshooting knowledge, and two copies of the same
+   claims about operator behaviour is B3 in a new costume.
+
+   `support-bundle`'s design centre is redaction, not collection. Secret values
+   never ship; nor do `last-applied-configuration` annotations, which are a
+   verbatim copy of a previous manifest and would re-introduce anything
+   redacted elsewhere in the same object; nor do literal environment variables
+   with sensitive-looking names. `valueFrom` references are deliberately KEPT —
+   they hold no secret and are often the explanation for the failure being
+   diagnosed. Every redaction is enumerated in `REDACTIONS.txt`, together with
+   an explicit statement that redaction cannot cover the user's own
+   `spec.config` or application log output.
 
 Deliberately *not* in the order: any mutating command beyond CR authoring
 (B5), and any `pkg/` promotion (B2).

--- a/docs/user_guide/guides/cli.md
+++ b/docs/user_guide/guides/cli.md
@@ -331,6 +331,40 @@ Consequence: **`kubectl` must be on your `PATH`.** Invoked as `kubectl neo4j cyp
 
 `cypher` passes *your* query through unchanged; the CLI never composes Cypher of its own. Operations the operator models as resources — creating a database, promoting a replica — belong in a CR, not in a shell command, so that they are declarative, auditable and reversible. `kubectl neo4j cypher -c "..."` is you running your own query, which is a different thing from the CLI deciding to mutate your database.
 
+## `support-bundle`
+
+Collects the diagnostic material for a Neo4j deployment into one archive — the 98 documented `kubectl` invocations in the troubleshooting guide, in a single command.
+
+```bash
+kubectl neo4j support-bundle -n neo4j
+kubectl neo4j support-bundle -n neo4j -o incident-4821.tar.gz
+```
+
+What it gathers: every Neo4j custom resource, namespace events, per-pod status (including **last termination reason and exit code** — exit 137 is OOMKilled, the most common Enterprise failure on an under-provisioned cluster), container logs current and previous, and the operator's own logs.
+
+### What it will not collect
+
+**Secret values never leave your cluster.** Secrets appear only as a list of names, types and *key names* — enough to diagnose "the Secret is missing the `password` key", which is a real and common cause, without shipping the value.
+
+Three redactions are applied automatically:
+
+| | Why |
+|---|---|
+| Secret values | The obvious one |
+| `last-applied-configuration` annotations | A verbatim copy of a previous manifest, so it re-introduces anything redacted elsewhere in the same object |
+| Literal environment variables with sensitive-looking names | A password typed directly into `spec.env` would otherwise be collected and mailed to a stranger |
+
+Every redaction is listed in `REDACTIONS.txt` inside the archive, so the recipient can see *where* something was withheld rather than wondering whether a field was empty or censored.
+
+!!! warning "Redaction is not a guarantee"
+    It covers Secret values, last-applied annotations, and sensitive-looking literal env vars. It **cannot** know whether your own `spec.config`, connection strings, or application log output contain something private. The command says so on completion, and `REDACTIONS.txt` repeats it. **Review the archive before sharing it.**
+
+Deliberately *not* redacted: `valueFrom` / `secretKeyRef` references. They contain no secret, and blanking them would destroy exactly the information that explains a misconfigured reference.
+
+### Collection is best-effort by design
+
+A bundle is most wanted when a cluster is unhealthy, so one unreadable resource must not abort the whole collection. Individual failures are recorded rather than fatal — which also tells the recipient what could not be read, and by extension what permissions the collector had.
+
 ## See also
 
 - [Troubleshooting](troubleshooting.md) — diagnosing a deployment that is already running


### PR DESCRIPTION
## Summary

Delivery item 6a. **Stacked on #362** (→ #361 → #360); base is `feat/cli-connect-cypher`, so the diff shows only this work.

```bash
kubectl neo4j support-bundle -n neo4j
kubectl neo4j support-bundle -n neo4j -o incident-4821.tar.gz
```

Collects Neo4j custom resources, namespace events, per-pod status, container logs (current *and* previous), and the operator's own logs — the 98 documented `kubectl` invocations in the troubleshooting guide, in one command.

## The design centre is redaction, not collection

A support bundle gets mailed to strangers. Shipping a secret in one is the worst thing this command could do, so that's what most of the code and nearly all of the tests are about.

| Redacted | Why |
|---|---|
| Secret values | The obvious one. Secrets appear as names, types and **key names** only — enough to diagnose "the Secret is missing the `password` key" without shipping the value |
| `last-applied-configuration` annotations | **The one most likely to be forgotten.** A verbatim copy of a previous manifest, so it silently re-introduces anything redacted elsewhere in the same object |
| Literal env vars with sensitive-looking names | A password typed directly into `spec.env` would otherwise be collected and mailed onward |

**Deliberately not redacted: `valueFrom` / `secretKeyRef` references.** They contain no secret, and blanking them would destroy exactly the information that explains a misconfigured reference. Over-redaction makes a bundle useless — that's its own failure mode, and it has a test.

## It does not overclaim

`REDACTIONS.txt` enumerates every redaction *and* states plainly that redaction is **not a guarantee**: it cannot know whether your own `spec.config`, connection strings, or application log output contain something private. The command repeats that on completion and tells you to review before sharing.

Promising more safety than the tool delivers would be worse than promising none — someone would rely on it.

## Two implementation notes

- **Redaction works on a deep copy.** Mutating the listed object would corrupt the caller's view; for a read-only command that would be a particularly silly bug. Pinned by a test.
- **Env walking is generic, not path-based.** Env vars appear at several depths — pod templates, init containers, sidecars — and a fixed path list would silently miss the next one added.
- **Collection is best-effort.** A bundle is most wanted when a cluster is unhealthy, so one unreadable resource records a note rather than aborting the run.

Pod status surfaces last-termination reason and exit code, because **exit 137 is OOMKilled** — the most common Enterprise failure on an under-provisioned cluster — and it is otherwise buried in the raw object.

## Type of change

- [x] New feature

## Testing

- [x] `make lint` 0 issues, `go vet` clean, cross-compile targets build, gates OK

Tests pin, in order of how badly they'd hurt: Secret values never surviving redaction; `last-applied-configuration` withheld; literal sensitive env vars withheld; **non-sensitive values and `secretKeyRef` references surviving untouched** (over-redaction); the original object not being mutated; the sensitive-name matcher in both directions; `REDACTIONS.txt` carrying its not-a-guarantee warning; and an archive round-trip.

## Next, and a question first

`explain` is the last command — and per the design I'd like to answer **Q3 (overlap with the MCP server)** before building it. Both would encode troubleshooting knowledge, and two copies of the same claims about operator behaviour is the drift problem in a new costume. Worth a look before writing it rather than after.