### PR TITLE
fix: untrack the 37MB binary committed into the repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,13 @@
 *.so
 *.dylib
 bin/*
+
+# Compiled binaries built into the repo root. `go build ./cmd/kubectl-neo4j`
+# writes ./kubectl-neo4j unless -o says otherwise, and a 37MB binary was once
+# committed that way. Use `make build-cli`, which writes into bin/.
+/kubectl-neo4j
+/kubectl-neo4j.exe
+/manager
 main
 # Compiled kubectl plugin binary (same name as its source dir — anchor so the
 # pattern hits only the built binary, not the cmd/kubectl-neo4j/ source).

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,8 +8,12 @@ repos:
       - id: check-yaml
         args: ['--allow-multiple-documents']
         exclude: ^(config/manager/|charts/).*\.ya?ml$
-      # - id: check-added-large-files
-      #   args: ['--maxkb=1000']  # Limit to 1MB
+      # Enabled after a 37MB compiled binary was committed: `go build ./cmd/...`
+      # writes into the repo root unless -o says otherwise, and .gitignore only
+      # covered bin/*. The largest legitimately tracked file is a ~395KB
+      # generated CRD, so 1MB leaves ample headroom.
+      - id: check-added-large-files
+        args: ['--maxkb=1000']
       - id: check-case-conflict
       - id: check-merge-conflict
       - id: debug-statements


### PR DESCRIPTION
## What happened

I committed a **37MB compiled binary** into the repo root, and it reached `main` via #360.

`go build ./cmd/kubectl-neo4j` writes `./kubectl-neo4j` unless `-o` says otherwise. `.gitignore` covered `bin/*` but not a bare binary at the root, and a later `git add -A` swept it in. It is present in all four CLI stack branches too.

## Three changes so it cannot recur

- **Untracked**, and `/kubectl-neo4j`, `/kubectl-neo4j.exe`, `/manager` added to `.gitignore` — the three names `go build` produces when run from the repo root without `-o`. `make build-cli` and `make build` both write into `bin/`, which was already ignored.
- **`check-added-large-files` enabled** in `.pre-commit-config.yaml`. It was already there, **commented out**. With it on, my commit would have been blocked at the moment I made it. Largest legitimately tracked file is a ~395KB generated CRD, so the existing `--maxkb=1000` needs no change.

## The bit I am not doing unilaterally

This removes the blob from the tip — it no longer ships in a checkout, archive, or release tarball. **The object still exists in `main`'s history**, so a full clone still pays the 37MB.

Excising it properly means rewriting `main` with `git filter-repo` and force-pushing a shared branch, invalidating every existing clone and open PR. That is your call, not mine. If you want it, say so and I will do it as a separate deliberate operation with the stack merged first.

## Type of change

- [x] Bug fix