### PR TITLE
feat(cli): diagnose — cross the boundary status stops at

### DIFF
--- a/cmd/kubectl-neo4j/diagnose.go
+++ b/cmd/kubectl-neo4j/diagnose.go
@@ -1,0 +1,716 @@
+/*
+Copyright 2025 Priyo Lahiri.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+// diagnose crosses the boundary `status` stops at.
+//
+// `status` reads custom resources, and `explain` decodes the operator's own
+// condition and phase vocabulary. But the failure taxonomy in
+// docs/user_guide/guides/troubleshooting.md is dominated by things one layer
+// BELOW the CR — pods that will not schedule, containers OOMKilled at 1Gi,
+// image pulls that fail, PVCs that never bind. Today `status` reports
+// "Pending / not ready" for every one of those and the user is handed back to
+// a 98-line runbook to work out which it was.
+//
+// This command answers that question. It reads the CR, finds the workload the
+// operator built for it, and names the Kubernetes-level cause.
+//
+// # Why this does not drift the way a prose runbook does
+//
+// Every rule below is anchored to a fact the Kubernetes API defines, not to a
+// string this project made up. Where client-go exports a constant it is used —
+// corev1.PodScheduled, corev1.PodReasonUnschedulable, corev1.ClaimBound — so a
+// rename upstream fails this build rather than silently matching nothing.
+//
+// Three reasons have no exported constant because kubelet, not the API, owns
+// them: "CrashLoopBackOff", "ImagePullBackOff" and "OOMKilled". Those are
+// matched as literals, and the OOM check additionally matches exit code 137 so
+// that the single most common Neo4j Enterprise failure is not detected by a
+// string alone.
+//
+// Workloads are located through the operator's OWN exported selectors
+// (resources.ServerPodSelector and friends) rather than by rebuilding the
+// label scheme here — the same discipline that makes `validate` share the
+// operator's validators.
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/priyolahiri/neo4j-kubernetes-operator/internal/resources"
+)
+
+// exitProblems is diagnose's "I found something" code. It shares the value of
+// exitInvalid deliberately: to a CI consumer both mean "the command ran fine
+// and the answer is bad", which is the distinction the exit code exists to
+// carry. 2 stays reserved for "the command could not run at all".
+const exitProblems = exitInvalid
+
+// Severity markers reuse validate's and status's vocabulary so that the three
+// commands do not each teach the user a different alphabet:
+//
+//	✗  something is wrong and will not fix itself
+//	…  waiting on something that may still resolve on its own
+//	⚠  worth knowing, not itself a failure
+const (
+	markProblem = "✗"
+	markWaiting = "…"
+	markWarning = "⚠"
+)
+
+// noStatusGrace is how long a resource may carry no phase at all before that
+// silence is itself reported. A CR the operator has never written status to is
+// the visible symptom of the operator not running, not having RBAC for the
+// kind, or not watching this namespace — a failure mode with no other signal,
+// since nothing is broken, there is simply nothing there.
+const noStatusGrace = 2 * time.Minute
+
+type symptom struct {
+	mark    string
+	subject string // "pod prod-server-2"
+	what    string // short observation
+	detail  string // the cluster's own words, verbatim
+	action  string // what the user should do
+}
+
+type diagnosis struct {
+	kind     string
+	name     string
+	phase    string
+	ready    string
+	message  string
+	summary  string // "2/3 servers ready"
+	symptoms []symptom
+}
+
+// problems reports whether this diagnosis contains anything that will not fix
+// itself. Waiting and warning symptoms deliberately do not count: exiting
+// non-zero because a pod is 20 seconds into its readiness probe would make the
+// exit code useless in the CI loop it exists for.
+func (d diagnosis) problems() bool {
+	for _, f := range d.symptoms {
+		if f.mark == markProblem {
+			return true
+		}
+	}
+	return false
+}
+
+func runDiagnose(args []string, stdout, stderr *os.File) int {
+	fs := flag.NewFlagSet("diagnose", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	namespace := fs.String("namespace", "", "Namespace to inspect (default: the kubeconfig context's namespace)")
+	kubeContext := fs.String("context", "", "Kubeconfig context to use")
+	kubeconfig := fs.String("kubeconfig", "", "Path to the kubeconfig file")
+	quiet := fs.Bool("quiet", false, "Print only resources that have something to report")
+	fs.Usage = func() {
+		fmt.Fprint(stderr, `Explain why a Neo4j resource is not healthy, at the Kubernetes level.
+
+Usage:
+  kubectl neo4j diagnose [<Kind>/<name>] [-n <namespace>]
+
+Where "status" reports that a resource is Pending, this reports WHY: the pod
+that will not schedule, the container that was OOMKilled, the image that will
+not pull, the PVC that never bound. Read-only.
+
+Examples:
+  kubectl neo4j diagnose
+  kubectl neo4j diagnose Neo4jEnterpriseCluster/prod -n neo4j
+
+Exit codes: 0 when nothing is wrong, 1 when a problem was found, 2 on a usage
+or connection error. Things that may still resolve on their own (a readiness
+probe that has not passed yet) are reported but do not change the exit code.
+
+Flags:
+`)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+
+	c, err := newClusterClient(*kubeconfig, *kubeContext)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: could not connect to the cluster: %v\n", err)
+		return exitUsage
+	}
+
+	ns := *namespace
+	if ns == "" {
+		ns = currentNamespace(*kubeconfig, *kubeContext)
+	}
+
+	target := fs.Arg(0)
+	if target != "" && !strings.Contains(target, "/") {
+		fmt.Fprintf(stderr, "error: expected <Kind>/<name>, got %q\n", target)
+		return exitUsage
+	}
+
+	results, err := diagnoseNamespace(context.Background(), c, ns, target)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return exitUsage
+	}
+	if target != "" && len(results) == 0 {
+		fmt.Fprintf(stderr, "error: %s not found in namespace %q\n", target, ns)
+		return exitUsage
+	}
+
+	return renderDiagnosis(results, stdout, ns, *quiet)
+}
+
+// diagnoseNamespace builds a diagnosis for every Neo4j resource in a namespace,
+// or for the single <Kind>/<name> given in target.
+func diagnoseNamespace(ctx context.Context, c client.Client, ns, target string) ([]diagnosis, error) {
+	wantKind, wantName := "", ""
+	if target != "" {
+		parts := strings.SplitN(target, "/", 2)
+		wantKind, wantName = parts[0], parts[1]
+	}
+
+	// Events, pods, PVCs and workloads are each listed ONCE for the namespace
+	// rather than per resource. A namespace with a dozen CRs would otherwise
+	// issue dozens of identical LISTs, and a diagnostic command is most often
+	// run against a cluster that is already struggling.
+	env := loadNamespaceEnv(ctx, c, ns)
+
+	var out []diagnosis
+	for _, gvk := range registeredNeo4jKinds(c) {
+		if wantKind != "" && !strings.EqualFold(gvk.Kind, wantKind) {
+			continue
+		}
+		list := &unstructured.UnstructuredList{}
+		list.SetGroupVersionKind(gvk.GroupVersion().WithKind(gvk.Kind + "List"))
+		if err := c.List(ctx, list, client.InNamespace(ns)); err != nil {
+			// Not installed, or not readable by this user. Reporting what IS
+			// visible beats failing the whole command, exactly as in `status`.
+			continue
+		}
+		for i := range list.Items {
+			item := &list.Items[i]
+			if wantName != "" && item.GetName() != wantName {
+				continue
+			}
+			out = append(out, diagnoseResource(item, env))
+		}
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].kind != out[j].kind {
+			return out[i].kind < out[j].kind
+		}
+		return out[i].name < out[j].name
+	})
+	return out, nil
+}
+
+// namespaceEnv is everything below the CR layer, read once.
+type namespaceEnv struct {
+	pods         []corev1.Pod
+	pvcs         []corev1.PersistentVolumeClaim
+	statefulSets []appsv1.StatefulSet
+	jobs         []batchv1.Job
+	events       []corev1.Event
+}
+
+func loadNamespaceEnv(ctx context.Context, c client.Client, ns string) namespaceEnv {
+	var env namespaceEnv
+	// Each list is independently optional: a user with partial RBAC (able to
+	// read CRs but not Pods, say) should still get everything else rather than
+	// an error, so failures are dropped rather than propagated.
+	var pods corev1.PodList
+	if err := c.List(ctx, &pods, client.InNamespace(ns)); err == nil {
+		env.pods = pods.Items
+	}
+	var pvcs corev1.PersistentVolumeClaimList
+	if err := c.List(ctx, &pvcs, client.InNamespace(ns)); err == nil {
+		env.pvcs = pvcs.Items
+	}
+	var sts appsv1.StatefulSetList
+	if err := c.List(ctx, &sts, client.InNamespace(ns)); err == nil {
+		env.statefulSets = sts.Items
+	}
+	var jobs batchv1.JobList
+	if err := c.List(ctx, &jobs, client.InNamespace(ns)); err == nil {
+		env.jobs = jobs.Items
+	}
+	var events corev1.EventList
+	if err := c.List(ctx, &events, client.InNamespace(ns)); err == nil {
+		env.events = events.Items
+	}
+	return env
+}
+
+func diagnoseResource(obj *unstructured.Unstructured, env namespaceEnv) diagnosis {
+	row := rowFrom(obj) // same generic status read as `status`
+	d := diagnosis{
+		kind:    row.kind,
+		name:    row.name,
+		phase:   row.phase,
+		ready:   row.ready,
+		message: row.message,
+	}
+
+	switch obj.GetKind() {
+	case "Neo4jEnterpriseCluster":
+		d.summary, d.symptoms = diagnoseInstance(obj.GetName(),
+			resources.ServerPodSelector(obj.GetName()), env)
+	case "Neo4jEnterpriseStandalone":
+		d.summary, d.symptoms = diagnoseInstance(obj.GetName(),
+			resources.StandalonePodSelector(obj.GetName()), env)
+	case "Neo4jBackup":
+		d.summary, d.symptoms = diagnoseBackup(obj.GetName(), env)
+	}
+
+	d.symptoms = append(d.symptoms, warningEvents(obj, env)...)
+	d.symptoms = append(d.symptoms, missingStatusSymptom(obj, row)...)
+	return d
+}
+
+// diagnoseInstance covers the two kinds that own a StatefulSet of Neo4j pods.
+func diagnoseInstance(name string, selector map[string]string, env namespaceEnv) (string, []symptom) {
+	pods := selectPods(env.pods, selector)
+	pvcs := selectPVCs(env.pvcs, resources.PVCSelectorByInstance(name))
+
+	var symptoms []symptom
+	for i := range pods {
+		symptoms = append(symptoms, diagnosePod(&pods[i])...)
+	}
+	symptoms = append(symptoms, diagnosePVCs(pvcs)...)
+
+	summary := ""
+	if sts := findStatefulSetFor(env.statefulSets, selector); sts != nil {
+		desired := int32(1)
+		if sts.Spec.Replicas != nil {
+			desired = *sts.Spec.Replicas
+		}
+		summary = fmt.Sprintf("%d/%d pods ready", sts.Status.ReadyReplicas, desired)
+		// Zero pods for a StatefulSet that wants some is a distinct failure
+		// from pods that exist and are unhealthy: nothing was ever scheduled,
+		// so there is no pod-level evidence to read and the user would
+		// otherwise see an empty diagnosis under a "not ready" heading.
+		if len(pods) == 0 && desired > 0 {
+			symptoms = append(symptoms, symptom{
+				mark:    markProblem,
+				subject: "statefulset " + sts.Name,
+				what:    fmt.Sprintf("wants %d pod(s), none exist", desired),
+				action: "No pod was created at all. Check the StatefulSet's own events " +
+					"(kubectl describe statefulset " + sts.Name + ") — a rejected pod " +
+					"template, a missing ServiceAccount or a quota denial stops creation " +
+					"before any pod appears.",
+			})
+		}
+	} else if len(pods) == 0 {
+		symptoms = append(symptoms, symptom{
+			mark:    markProblem,
+			subject: name,
+			what:    "no StatefulSet and no pods",
+			action: "The operator has not built the workload yet. Check that it is running " +
+				"and watching this namespace: kubectl logs -n neo4j-operator " +
+				"deployment/neo4j-operator-controller-manager",
+		})
+	}
+	return summary, symptoms
+}
+
+// diagnosePod is the heart of the command: one pod's Kubernetes-level state,
+// turned into a cause and an action.
+func diagnosePod(p *corev1.Pod) []symptom {
+	var symptoms []symptom
+
+	// 1. Scheduling. PodScheduled=False with reason Unschedulable is the
+	// "Pods Stuck in Pending State" heading of the troubleshooting guide, and
+	// the scheduler's own message names the exact shortfall.
+	for _, cond := range p.Status.Conditions {
+		if cond.Type != corev1.PodScheduled || cond.Status != corev1.ConditionFalse {
+			continue
+		}
+		if cond.Reason == corev1.PodReasonUnschedulable {
+			symptoms = append(symptoms, symptom{
+				mark:    markProblem,
+				subject: "pod " + p.Name,
+				what:    "cannot be scheduled",
+				detail:  cond.Message,
+				action: "No node can satisfy the pod. Compare spec.resources.requests with " +
+					"node capacity (kubectl describe nodes), or check that the PVC's " +
+					"StorageClass can provision in the zones the nodes are in. Neo4j " +
+					"Enterprise will not start below 1.5Gi of memory, so lowering the " +
+					"request has a floor.",
+			})
+		}
+	}
+
+	// 2. Container state, current and previous.
+	for _, cs := range p.Status.ContainerStatuses {
+		if w := cs.State.Waiting; w != nil {
+			switch w.Reason {
+			case "ImagePullBackOff", "ErrImagePull", "InvalidImageName":
+				symptoms = append(symptoms, symptom{
+					mark:    markProblem,
+					subject: "container " + cs.Name + " in " + p.Name,
+					what:    "image cannot be pulled (" + w.Reason + ")",
+					detail:  w.Message,
+					action: "Check spec.image.repo and spec.image.tag. Neo4j Enterprise images " +
+						"are not public: the namespace needs an imagePullSecret unless the " +
+						"registry allows anonymous pulls.",
+				})
+			case "CrashLoopBackOff":
+				symptoms = append(symptoms, symptom{
+					mark:    markProblem,
+					subject: "container " + cs.Name + " in " + p.Name,
+					what:    fmt.Sprintf("crash-looping after %d restart(s)", cs.RestartCount),
+					detail:  w.Message,
+					action: "The reason is in the log of the run that died, not the current one: " +
+						"kubectl logs " + p.Name + " -c " + cs.Name + " --previous",
+				})
+			case "CreateContainerConfigError":
+				symptoms = append(symptoms, symptom{
+					mark:    markProblem,
+					subject: "container " + cs.Name + " in " + p.Name,
+					what:    "container config is not resolvable",
+					detail:  w.Message,
+					action: "Usually a Secret or ConfigMap referenced by env valueFrom does not " +
+						"exist yet, or lacks the key named. The message above says which.",
+				})
+			}
+		}
+
+		// OOMKilled is matched on the kubelet's reason string OR exit code 137
+		// because it is the single most common Neo4j Enterprise failure on an
+		// under-provisioned cluster, and neither signal is an API constant we
+		// can lean on alone.
+		if t := cs.LastTerminationState.Terminated; t != nil {
+			if t.Reason == "OOMKilled" || t.ExitCode == 137 {
+				symptoms = append(symptoms, symptom{
+					mark:    markProblem,
+					subject: "container " + cs.Name + " in " + p.Name,
+					what:    fmt.Sprintf("was OOMKilled (exit %d)", t.ExitCode),
+					action: "Raise spec.resources.limits.memory. Neo4j Enterprise needs at least " +
+						"1.5Gi to start at all, and the JVM heap plus page cache must fit " +
+						"inside the limit — see docs/user_guide/guides/resource_sizing.md.",
+				})
+			} else if t.ExitCode != 0 {
+				symptoms = append(symptoms, symptom{
+					mark:    markWarning,
+					subject: "container " + cs.Name + " in " + p.Name,
+					what:    fmt.Sprintf("previously exited %d (%s)", t.ExitCode, t.Reason),
+					detail:  strings.TrimSpace(t.Message),
+					action:  "kubectl logs " + p.Name + " -c " + cs.Name + " --previous",
+				})
+			}
+		}
+
+		// A container that is running but not ready is usually Neo4j still
+		// starting — reported so the user knows the pod is not stuck, but NOT
+		// as a problem, because it commonly resolves without intervention.
+		if cs.State.Running != nil && !cs.Ready {
+			symptoms = append(symptoms, symptom{
+				mark:    markWaiting,
+				subject: "container " + cs.Name + " in " + p.Name,
+				what:    "running but not ready",
+				action: "Its readiness probe has not passed yet. Neo4j Enterprise takes tens of " +
+					"seconds to open Bolt on first start; if this persists, read the log.",
+			})
+		}
+	}
+	return symptoms
+}
+
+func diagnosePVCs(pvcs []corev1.PersistentVolumeClaim) []symptom {
+	var symptoms []symptom
+	for i := range pvcs {
+		pvc := &pvcs[i]
+		if pvc.Status.Phase == corev1.ClaimBound {
+			continue
+		}
+		sc := "(cluster default)"
+		if pvc.Spec.StorageClassName != nil && *pvc.Spec.StorageClassName != "" {
+			sc = *pvc.Spec.StorageClassName
+		}
+		symptoms = append(symptoms, symptom{
+			mark:    markProblem,
+			subject: "pvc " + pvc.Name,
+			what:    fmt.Sprintf("is %s, not Bound", pvc.Status.Phase),
+			action: "The pod cannot start until this binds. StorageClass " + sc +
+				" must exist and be able to provision — kubectl get storageclass, then " +
+				"kubectl describe pvc " + pvc.Name + " for the provisioner's own reason.",
+		})
+	}
+	return symptoms
+}
+
+// diagnoseBackup covers Neo4jBackup, whose workload is a Job rather than a
+// StatefulSet. Backup failures are their own chapter of the troubleshooting
+// guide, and the useful evidence is on the Job and its pod.
+func diagnoseBackup(name string, env namespaceEnv) (string, []symptom) {
+	jobs := selectJobs(env.jobs, resources.BackupJobSelector(name))
+	if len(jobs) == 0 {
+		return "", nil
+	}
+
+	var symptoms []symptom
+	var succeeded, failed int
+	for i := range jobs {
+		j := &jobs[i]
+		switch {
+		case j.Status.Failed > 0:
+			failed++
+			f := symptom{
+				mark:    markProblem,
+				subject: "job " + j.Name,
+				what:    fmt.Sprintf("failed (%d pod failure(s))", j.Status.Failed),
+				action: "Read the Job's pod log for neo4j-admin's own error: " +
+					"kubectl logs job/" + j.Name + ". A permission error names the " +
+					"ServiceAccount; a path error names the bucket.",
+			}
+			for _, cond := range j.Status.Conditions {
+				if cond.Type == batchv1.JobFailed && cond.Status == corev1.ConditionTrue {
+					f.detail = strings.TrimSpace(cond.Reason + ": " + cond.Message)
+				}
+			}
+			symptoms = append(symptoms, f)
+		case j.Status.Succeeded > 0:
+			succeeded++
+		}
+	}
+
+	// Pods of a backup Job get the same container-level treatment as server
+	// pods: an OOMKilled or unschedulable backup pod fails for exactly the
+	// reasons a server pod does, and the user needs the same answer.
+	for i := range env.pods {
+		p := &env.pods[i]
+		if matchesLabels(p.Labels, resources.BackupJobSelector(name)) {
+			symptoms = append(symptoms, diagnosePod(p)...)
+		}
+	}
+
+	return fmt.Sprintf("%d job(s): %d succeeded, %d failed", len(jobs), succeeded, failed), symptoms
+}
+
+// warningEvents surfaces Warning events the API server recorded against this
+// exact object. Events explain far more about a stuck reconcile than status
+// does, and the operator emits structured ones (internal/controller/events.go)
+// precisely so they can be read this way.
+func warningEvents(obj *unstructured.Unstructured, env namespaceEnv) []symptom {
+	var recent []corev1.Event
+	for i := range env.events {
+		e := env.events[i]
+		if e.Type != corev1.EventTypeWarning {
+			continue
+		}
+		if e.InvolvedObject.Kind != obj.GetKind() || e.InvolvedObject.Name != obj.GetName() {
+			continue
+		}
+		recent = append(recent, e)
+	}
+	sort.Slice(recent, func(i, j int) bool {
+		return recent[i].LastTimestamp.Time.After(recent[j].LastTimestamp.Time)
+	})
+	// Only the newest few: a resource that has been failing for a day can
+	// carry hundreds of near-identical events, and printing them all buries
+	// the pod-level symptoms that are the point of this command.
+	if len(recent) > 3 {
+		recent = recent[:3]
+	}
+	var symptoms []symptom
+	for _, e := range recent {
+		symptoms = append(symptoms, symptom{
+			mark:    markWarning,
+			subject: "event " + e.Reason,
+			what:    fmt.Sprintf("%s ago", humanAge(e.LastTimestamp.Time)),
+			detail:  e.Message,
+		})
+	}
+	return symptoms
+}
+
+// missingStatusSymptom reports a resource the operator has never written status
+// to. There is no other signal for this: nothing is broken, the CR simply sits
+// there — which is what a user sees when the operator is not running, cannot
+// read the kind, or is not watching this namespace.
+func missingStatusSymptom(obj *unstructured.Unstructured, row resourceStatus) []symptom {
+	if row.phase != "-" || row.ready != "-" {
+		return nil
+	}
+	created := obj.GetCreationTimestamp().Time
+	if created.IsZero() || time.Since(created) < noStatusGrace {
+		return nil
+	}
+	return []symptom{{
+		mark:    markProblem,
+		subject: obj.GetKind() + "/" + obj.GetName(),
+		what:    "has no status after " + humanAge(created),
+		action: "Nothing has reconciled it. Check the operator is running, has RBAC for " +
+			"this kind, and is watching this namespace (a namespace-scoped install " +
+			"ignores resources outside WATCH_NAMESPACE without reporting anything): " +
+			"kubectl logs -n neo4j-operator deployment/neo4j-operator-controller-manager",
+	}}
+}
+
+func selectPods(pods []corev1.Pod, selector map[string]string) []corev1.Pod {
+	var out []corev1.Pod
+	for i := range pods {
+		if matchesLabels(pods[i].Labels, selector) {
+			out = append(out, pods[i])
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+func selectPVCs(pvcs []corev1.PersistentVolumeClaim, selector map[string]string) []corev1.PersistentVolumeClaim {
+	var out []corev1.PersistentVolumeClaim
+	for i := range pvcs {
+		if matchesLabels(pvcs[i].Labels, selector) {
+			out = append(out, pvcs[i])
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+func selectJobs(jobs []batchv1.Job, selector map[string]string) []batchv1.Job {
+	var out []batchv1.Job
+	for i := range jobs {
+		if matchesLabels(jobs[i].Labels, selector) {
+			out = append(out, jobs[i])
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+func findStatefulSetFor(sets []appsv1.StatefulSet, selector map[string]string) *appsv1.StatefulSet {
+	for i := range sets {
+		if matchesLabels(sets[i].Spec.Template.Labels, selector) {
+			return &sets[i]
+		}
+	}
+	return nil
+}
+
+// matchesLabels reports whether labels contains every key/value in selector —
+// the same subset semantics client.MatchingLabels uses server-side, kept here
+// because the lists are fetched once and filtered in memory.
+func matchesLabels(labels, selector map[string]string) bool {
+	if len(selector) == 0 {
+		return false
+	}
+	for k, v := range selector {
+		if labels[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func renderDiagnosis(results []diagnosis, stdout *os.File, ns string, quiet bool) int {
+	shown := 0
+	problems := 0
+	for _, d := range results {
+		if d.problems() {
+			problems++
+		}
+		if quiet && len(d.symptoms) == 0 {
+			continue
+		}
+		if shown > 0 {
+			fmt.Fprintln(stdout)
+		}
+		shown++
+		renderOne(d, stdout)
+	}
+
+	if shown == 0 {
+		if len(results) == 0 {
+			fmt.Fprintf(stdout, "no Neo4j resources found in namespace %q\n", ns)
+		} else {
+			fmt.Fprintf(stdout, "%d Neo4j resource(s) in %q, nothing to report\n", len(results), ns)
+		}
+		return exitOK
+	}
+
+	if problems > 0 {
+		fmt.Fprintf(stdout, "\n%d of %d resource(s) have problems.\n", problems, len(results))
+		fmt.Fprintln(stdout, "For an archive to attach to an issue: kubectl neo4j support-bundle")
+		return exitProblems
+	}
+	return exitOK
+}
+
+func renderOne(d diagnosis, stdout *os.File) {
+	head := fmt.Sprintf("%s/%s — %s", d.kind, d.name, d.phase)
+	if d.summary != "" {
+		head += " · " + d.summary
+	}
+	fmt.Fprintln(stdout, head)
+	if d.message != "" {
+		fmt.Fprintf(stdout, "  %s\n", d.message)
+	}
+	if len(d.symptoms) == 0 {
+		fmt.Fprintln(stdout, "  nothing to report below the resource level")
+		return
+	}
+	for _, f := range d.symptoms {
+		fmt.Fprintf(stdout, "  %s %s — %s\n", f.mark, f.subject, f.what)
+		if f.detail != "" {
+			fmt.Fprintf(stdout, "      %s\n", wrapIndent(f.detail, 6))
+		}
+		if f.action != "" {
+			fmt.Fprintf(stdout, "      → %s\n", wrapIndent(f.action, 8))
+		}
+	}
+}
+
+// wrapIndent soft-wraps long text at 78 columns so a scheduler message or an
+// action does not run off the terminal. Continuation lines are indented to line
+// up under the first, which is what makes a multi-line action readable at all.
+func wrapIndent(s string, indent int) string {
+	s = strings.Join(strings.Fields(s), " ")
+	const width = 78
+	if len(s)+indent <= width {
+		return s
+	}
+	pad := strings.Repeat(" ", indent)
+	var b strings.Builder
+	line := 0
+	for i, word := range strings.Fields(s) {
+		switch {
+		case i == 0:
+			b.WriteString(word)
+			line = indent + len(word)
+		case line+1+len(word) > width:
+			b.WriteString("\n" + pad + word)
+			line = indent + len(word)
+		default:
+			b.WriteString(" " + word)
+			line += 1 + len(word)
+		}
+	}
+	return b.String()
+}

--- a/cmd/kubectl-neo4j/diagnose.go
+++ b/cmd/kubectl-neo4j/diagnose.go
@@ -529,7 +529,7 @@ func warningEvents(obj *unstructured.Unstructured, env namespaceEnv) []symptom {
 		recent = append(recent, e)
 	}
 	sort.Slice(recent, func(i, j int) bool {
-		return recent[i].LastTimestamp.Time.After(recent[j].LastTimestamp.Time)
+		return recent[i].LastTimestamp.After(recent[j].LastTimestamp.Time)
 	})
 	// Only the newest few: a resource that has been failing for a day can
 	// carry hundreds of near-identical events, and printing them all buries

--- a/cmd/kubectl-neo4j/diagnose_test.go
+++ b/cmd/kubectl-neo4j/diagnose_test.go
@@ -1,0 +1,422 @@
+/*
+Copyright 2025 Priyo Lahiri.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	neo4jv1beta1 "github.com/priyolahiri/neo4j-kubernetes-operator/api/v1beta1"
+	"github.com/priyolahiri/neo4j-kubernetes-operator/internal/resources"
+)
+
+// serverPod builds a pod carrying the labels the operator actually stamps on
+// server pods — taken from the operator's own selector rather than a literal,
+// so that a label-scheme change breaks this test the way it would break the
+// command.
+func serverPod(cluster, name string) *corev1.Pod {
+	labels := map[string]string{}
+	for k, v := range resources.ServerPodSelector(cluster) {
+		labels[k] = v
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "neo4j", Labels: labels},
+	}
+}
+
+func symptomsFor(t *testing.T, d []diagnosis, kindName string) []symptom {
+	t.Helper()
+	for _, one := range d {
+		if one.kind+"/"+one.name == kindName {
+			return one.symptoms
+		}
+	}
+	t.Fatalf("no diagnosis for %s", kindName)
+	return nil
+}
+
+func joinSymptoms(ss []symptom) string {
+	var b strings.Builder
+	for _, s := range ss {
+		b.WriteString(s.mark + " " + s.subject + " " + s.what + " " + s.detail + " " + s.action + "\n")
+	}
+	return b.String()
+}
+
+// The command's reason for existing: `status` says "Pending", this says which
+// pod could not be scheduled and why.
+func TestDiagnose_UnschedulablePodIsReportedWithSchedulerMessage(t *testing.T) {
+	pod := serverPod("prod", "prod-server-2")
+	pod.Status.Conditions = []corev1.PodCondition{{
+		Type:    corev1.PodScheduled,
+		Status:  corev1.ConditionFalse,
+		Reason:  corev1.PodReasonUnschedulable,
+		Message: "0/3 nodes are available: 3 Insufficient memory.",
+	}}
+
+	c := testClient(t,
+		&neo4jv1beta1.Neo4jEnterpriseCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "prod", Namespace: "neo4j"},
+			Status:     neo4jv1beta1.Neo4jEnterpriseClusterStatus{Phase: "Pending"},
+		},
+		pod,
+	)
+
+	results, err := diagnoseNamespace(context.Background(), c, "neo4j", "")
+	require.NoError(t, err)
+
+	out := joinSymptoms(symptomsFor(t, results, "Neo4jEnterpriseCluster/prod"))
+	assert.Contains(t, out, "cannot be scheduled")
+	assert.Contains(t, out, "0/3 nodes are available")
+	assert.Contains(t, out, markProblem)
+}
+
+// OOMKilled is the most common Neo4j Enterprise failure on an under-provisioned
+// cluster. It must be caught from the exit code alone, because that is the one
+// signal that is not a kubelet string this test could be written to match.
+func TestDiagnose_OOMKilledDetectedFromExitCodeAlone(t *testing.T) {
+	pod := serverPod("prod", "prod-server-0")
+	pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+		Name: "neo4j",
+		LastTerminationState: corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{ExitCode: 137, Reason: ""},
+		},
+	}}
+
+	c := testClient(t,
+		&neo4jv1beta1.Neo4jEnterpriseCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "prod", Namespace: "neo4j"},
+		},
+		pod,
+	)
+
+	results, err := diagnoseNamespace(context.Background(), c, "neo4j", "")
+	require.NoError(t, err)
+
+	out := joinSymptoms(symptomsFor(t, results, "Neo4jEnterpriseCluster/prod"))
+	assert.Contains(t, out, "OOMKilled")
+	assert.Contains(t, out, "1.5Gi", "the action must state the Enterprise memory floor")
+}
+
+func TestDiagnose_ImagePullAndCrashLoopAreDistinguished(t *testing.T) {
+	pull := serverPod("prod", "prod-server-0")
+	pull.Status.ContainerStatuses = []corev1.ContainerStatus{{
+		Name:  "neo4j",
+		State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "ImagePullBackOff", Message: "pull access denied"}},
+	}}
+	crash := serverPod("prod", "prod-server-1")
+	crash.Status.ContainerStatuses = []corev1.ContainerStatus{{
+		Name:         "neo4j",
+		RestartCount: 7,
+		State:        corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}},
+	}}
+
+	c := testClient(t,
+		&neo4jv1beta1.Neo4jEnterpriseCluster{ObjectMeta: metav1.ObjectMeta{Name: "prod", Namespace: "neo4j"}},
+		pull, crash,
+	)
+
+	results, err := diagnoseNamespace(context.Background(), c, "neo4j", "")
+	require.NoError(t, err)
+
+	out := joinSymptoms(symptomsFor(t, results, "Neo4jEnterpriseCluster/prod"))
+	assert.Contains(t, out, "image cannot be pulled")
+	assert.Contains(t, out, "imagePullSecret")
+	assert.Contains(t, out, "crash-looping after 7 restart(s)")
+	assert.Contains(t, out, "--previous", "the crash-loop action must point at the previous log")
+}
+
+func TestDiagnose_UnboundPVCNamesItsStorageClass(t *testing.T) {
+	sc := "fast-ssd"
+	pvcLabels := map[string]string{}
+	for k, v := range resources.PVCSelectorByInstance("prod") {
+		pvcLabels[k] = v
+	}
+
+	c := testClient(t,
+		&neo4jv1beta1.Neo4jEnterpriseCluster{ObjectMeta: metav1.ObjectMeta{Name: "prod", Namespace: "neo4j"}},
+		&corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "data-prod-server-0", Namespace: "neo4j", Labels: pvcLabels},
+			Spec:       corev1.PersistentVolumeClaimSpec{StorageClassName: &sc},
+			Status:     corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimPending},
+		},
+	)
+
+	results, err := diagnoseNamespace(context.Background(), c, "neo4j", "")
+	require.NoError(t, err)
+
+	out := joinSymptoms(symptomsFor(t, results, "Neo4jEnterpriseCluster/prod"))
+	assert.Contains(t, out, "not Bound")
+	assert.Contains(t, out, "fast-ssd")
+}
+
+// A bound PVC and a ready container are not findings. Without this, the
+// command would cry wolf on every healthy deployment and stop being read.
+func TestDiagnose_HealthyDeploymentReportsNothing(t *testing.T) {
+	pod := serverPod("prod", "prod-server-0")
+	pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+		Name:  "neo4j",
+		Ready: true,
+		State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+	}}
+
+	c := testClient(t,
+		&neo4jv1beta1.Neo4jEnterpriseCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "prod", Namespace: "neo4j"},
+			Status:     neo4jv1beta1.Neo4jEnterpriseClusterStatus{Phase: "Ready", Ready: true},
+		},
+		pod,
+		&appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "prod-server", Namespace: "neo4j"},
+			Spec: appsv1.StatefulSetSpec{
+				Replicas: ptrInt32(1),
+				Template: corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{Labels: pod.Labels}},
+			},
+			Status: appsv1.StatefulSetStatus{ReadyReplicas: 1},
+		},
+	)
+
+	results, err := diagnoseNamespace(context.Background(), c, "neo4j", "")
+	require.NoError(t, err)
+
+	d := results[0]
+	assert.Empty(t, d.symptoms)
+	assert.False(t, d.problems())
+	assert.Equal(t, "1/1 pods ready", d.summary)
+}
+
+// A running-but-not-ready container is reported so the user knows where the
+// deployment is — but it must NOT set the failure exit code, because it
+// commonly resolves on its own while Neo4j starts.
+func TestDiagnose_NotReadyYetIsWaitingNotProblem(t *testing.T) {
+	pod := serverPod("prod", "prod-server-0")
+	pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+		Name:  "neo4j",
+		Ready: false,
+		State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+	}}
+
+	c := testClient(t,
+		&neo4jv1beta1.Neo4jEnterpriseCluster{ObjectMeta: metav1.ObjectMeta{Name: "prod", Namespace: "neo4j"}},
+		pod,
+	)
+
+	results, err := diagnoseNamespace(context.Background(), c, "neo4j", "")
+	require.NoError(t, err)
+
+	d := results[0]
+	require.NotEmpty(t, d.symptoms)
+	assert.Equal(t, markWaiting, d.symptoms[0].mark)
+	assert.False(t, d.problems(), "a readiness probe still settling is not a problem")
+}
+
+// The failure mode with no other signal: a CR nothing ever reconciled. This is
+// what a user sees when the operator is not running, lacks RBAC for the kind,
+// or is namespace-scoped and not watching this namespace (#282).
+func TestDiagnose_ResourceWithNoStatusAfterGraceIsReported(t *testing.T) {
+	c := testClient(t,
+		&neo4jv1beta1.Neo4jDatabase{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "analytics", Namespace: "neo4j",
+				CreationTimestamp: metav1.NewTime(time.Now().Add(-30 * time.Minute)),
+			},
+		},
+	)
+
+	results, err := diagnoseNamespace(context.Background(), c, "neo4j", "")
+	require.NoError(t, err)
+
+	out := joinSymptoms(symptomsFor(t, results, "Neo4jDatabase/analytics"))
+	assert.Contains(t, out, "has no status")
+	assert.Contains(t, out, "watching this namespace")
+}
+
+// Same resource, just created: silence is expected, so it must stay silent.
+func TestDiagnose_FreshResourceWithNoStatusIsNotReported(t *testing.T) {
+	c := testClient(t,
+		&neo4jv1beta1.Neo4jDatabase{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "analytics", Namespace: "neo4j",
+				CreationTimestamp: metav1.NewTime(time.Now()),
+			},
+		},
+	)
+
+	results, err := diagnoseNamespace(context.Background(), c, "neo4j", "")
+	require.NoError(t, err)
+	assert.Empty(t, symptomsFor(t, results, "Neo4jDatabase/analytics"))
+}
+
+func TestDiagnose_FailedBackupJobIsFoundThroughTheSharedSelector(t *testing.T) {
+	jobLabels := map[string]string{}
+	for k, v := range resources.BackupJobSelector("nightly") {
+		jobLabels[k] = v
+	}
+
+	c := testClient(t,
+		&neo4jv1beta1.Neo4jBackup{
+			ObjectMeta: metav1.ObjectMeta{Name: "nightly", Namespace: "neo4j"},
+			Spec:       neo4jv1beta1.Neo4jBackupSpec{InstanceRef: "prod"},
+		},
+		&batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: "nightly-1", Namespace: "neo4j", Labels: jobLabels},
+			Status: batchv1.JobStatus{
+				Failed: 1,
+				Conditions: []batchv1.JobCondition{{
+					Type: batchv1.JobFailed, Status: corev1.ConditionTrue,
+					Reason: "BackoffLimitExceeded", Message: "Job has reached the specified backoff limit",
+				}},
+			},
+		},
+	)
+
+	results, err := diagnoseNamespace(context.Background(), c, "neo4j", "")
+	require.NoError(t, err)
+
+	out := joinSymptoms(symptomsFor(t, results, "Neo4jBackup/nightly"))
+	assert.Contains(t, out, "job nightly-1")
+	assert.Contains(t, out, "BackoffLimitExceeded")
+	assert.Contains(t, out, "ServiceAccount")
+}
+
+// Targeting one resource must not diagnose its neighbours.
+func TestDiagnose_TargetSelectsASingleResource(t *testing.T) {
+	c := testClient(t,
+		&neo4jv1beta1.Neo4jEnterpriseCluster{ObjectMeta: metav1.ObjectMeta{Name: "prod", Namespace: "neo4j"}},
+		&neo4jv1beta1.Neo4jEnterpriseCluster{ObjectMeta: metav1.ObjectMeta{Name: "staging", Namespace: "neo4j"}},
+		&neo4jv1beta1.Neo4jDatabase{ObjectMeta: metav1.ObjectMeta{Name: "analytics", Namespace: "neo4j"}},
+	)
+
+	results, err := diagnoseNamespace(context.Background(), c, "neo4j", "Neo4jEnterpriseCluster/prod")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "prod", results[0].name)
+}
+
+// Warning events are the operator's own voice; structured events exist in
+// internal/controller/events.go precisely so they can be read back.
+func TestDiagnose_WarningEventsAreAttachedToTheirResource(t *testing.T) {
+	c := testClient(t,
+		&neo4jv1beta1.Neo4jEnterpriseCluster{ObjectMeta: metav1.ObjectMeta{Name: "prod", Namespace: "neo4j"}},
+		&corev1.Event{
+			ObjectMeta:     metav1.ObjectMeta{Name: "e1", Namespace: "neo4j"},
+			Type:           corev1.EventTypeWarning,
+			Reason:         "SplitBrainDetected",
+			Message:        "servers disagree on cluster membership",
+			LastTimestamp:  metav1.NewTime(time.Now().Add(-time.Minute)),
+			InvolvedObject: corev1.ObjectReference{Kind: "Neo4jEnterpriseCluster", Name: "prod"},
+		},
+		&corev1.Event{
+			ObjectMeta:     metav1.ObjectMeta{Name: "e2", Namespace: "neo4j"},
+			Type:           corev1.EventTypeNormal,
+			Reason:         "Reconciled",
+			Message:        "all good",
+			InvolvedObject: corev1.ObjectReference{Kind: "Neo4jEnterpriseCluster", Name: "prod"},
+		},
+	)
+
+	results, err := diagnoseNamespace(context.Background(), c, "neo4j", "")
+	require.NoError(t, err)
+
+	out := joinSymptoms(symptomsFor(t, results, "Neo4jEnterpriseCluster/prod"))
+	assert.Contains(t, out, "SplitBrainDetected")
+	assert.NotContains(t, out, "all good", "Normal events are noise here")
+}
+
+func TestWrapIndent_KeepsShortTextOnOneLine(t *testing.T) {
+	assert.Equal(t, "short message", wrapIndent("short   message", 6))
+	long := strings.Repeat("word ", 40)
+	assert.Contains(t, wrapIndent(long, 8), "\n        word")
+}
+
+func ptrInt32(i int32) *int32 { return &i }
+
+// renderDiagnoseTo captures what the user actually sees, and the exit code the
+// caller's CI will branch on.
+func renderDiagnoseTo(t *testing.T, results []diagnosis, ns string, quiet bool) (string, int) {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "out")
+	require.NoError(t, err)
+	code := renderDiagnosis(results, f, ns, quiet)
+	require.NoError(t, f.Close())
+	b, err := os.ReadFile(f.Name())
+	require.NoError(t, err)
+	return string(b), code
+}
+
+// The exit code is this command's contract with CI, in the same way validate's
+// is: 1 means "ran fine, the answer is bad", never "could not run".
+func TestRenderDiagnosis_ExitCodeReflectsProblemsOnly(t *testing.T) {
+	healthy := diagnosis{kind: "Neo4jDatabase", name: "analytics", phase: "Ready"}
+	waiting := diagnosis{kind: "Neo4jEnterpriseCluster", name: "prod", phase: "Pending",
+		symptoms: []symptom{{mark: markWaiting, subject: "container neo4j in prod-server-0", what: "running but not ready"}}}
+	broken := diagnosis{kind: "Neo4jEnterpriseCluster", name: "bad", phase: "Pending",
+		symptoms: []symptom{{mark: markProblem, subject: "pod bad-server-0", what: "cannot be scheduled"}}}
+
+	_, code := renderDiagnoseTo(t, []diagnosis{healthy}, "neo4j", false)
+	assert.Equal(t, exitOK, code)
+
+	_, code = renderDiagnoseTo(t, []diagnosis{healthy, waiting}, "neo4j", false)
+	assert.Equal(t, exitOK, code, "a resource still settling must not fail the exit code")
+
+	out, code := renderDiagnoseTo(t, []diagnosis{healthy, waiting, broken}, "neo4j", false)
+	assert.Equal(t, exitProblems, code)
+	assert.Contains(t, out, "1 of 3 resource(s) have problems")
+	assert.Contains(t, out, "support-bundle", "the escalation path is named once, at the end")
+}
+
+func TestRenderDiagnosis_ShowsSubjectDetailAndAction(t *testing.T) {
+	d := diagnosis{
+		kind: "Neo4jEnterpriseCluster", name: "prod", phase: "Pending", summary: "2/3 pods ready",
+		symptoms: []symptom{{
+			mark: markProblem, subject: "pod prod-server-2", what: "cannot be scheduled",
+			detail: "0/3 nodes are available: 3 Insufficient memory.",
+			action: "Compare spec.resources.requests with node capacity.",
+		}},
+	}
+	out, code := renderDiagnoseTo(t, []diagnosis{d}, "neo4j", false)
+
+	assert.Equal(t, exitProblems, code)
+	assert.Contains(t, out, "Neo4jEnterpriseCluster/prod — Pending · 2/3 pods ready")
+	assert.Contains(t, out, "✗ pod prod-server-2 — cannot be scheduled")
+	assert.Contains(t, out, "0/3 nodes are available")
+	assert.Contains(t, out, "→ Compare spec.resources.requests")
+}
+
+func TestRenderDiagnosis_QuietHidesResourcesWithNothingToSay(t *testing.T) {
+	healthy := diagnosis{kind: "Neo4jDatabase", name: "analytics", phase: "Ready"}
+	out, code := renderDiagnoseTo(t, []diagnosis{healthy}, "neo4j", true)
+	assert.Equal(t, exitOK, code)
+	assert.Contains(t, out, "nothing to report")
+	assert.NotContains(t, out, "analytics")
+}
+
+func TestRenderDiagnosis_EmptyNamespace(t *testing.T) {
+	out, code := renderDiagnoseTo(t, nil, "neo4j", false)
+	assert.Equal(t, exitOK, code)
+	assert.Contains(t, out, `no Neo4j resources found in namespace "neo4j"`)
+}

--- a/cmd/kubectl-neo4j/main.go
+++ b/cmd/kubectl-neo4j/main.go
@@ -48,6 +48,7 @@ Usage:
 Commands:
   validate    Validate Neo4j CR manifests against the operator's own validators
   status      Show the state of every Neo4j resource in a namespace
+  diagnose    Explain WHY a resource is unhealthy, at the Kubernetes level
   connect     Print how to reach a deployment (address, port-forward, scheme)
   cypher      Open a cypher-shell session against a deployment
   support-bundle  Collect a redacted diagnostic archive
@@ -73,6 +74,8 @@ func run(args []string, stdout, stderr *os.File) int {
 		return runValidate(args[1:], stdout, stderr)
 	case "status":
 		return runStatus(args[1:], stdout, stderr)
+	case "diagnose":
+		return runDiagnose(args[1:], stdout, stderr)
 	case "connect":
 		return runConnect(args[1:], stdout, stderr)
 	case "cypher":

--- a/docs/user_guide/cli/diagnose.md
+++ b/docs/user_guide/cli/diagnose.md
@@ -1,0 +1,65 @@
+# `diagnose`
+
+Answers the question `status` raises but cannot settle: **why** is this resource not healthy?
+
+```bash
+kubectl neo4j diagnose                                    # everything in the namespace
+kubectl neo4j diagnose Neo4jEnterpriseCluster/prod        # one resource
+kubectl neo4j diagnose --quiet                            # only what has something to say
+```
+
+`status` reads custom resources, so it can tell you a cluster is `Pending`. But most deployments fail one layer below the CR — a pod that will not schedule, a container OOMKilled at 1Gi, an image that will not pull, a PVC that never bound. `diagnose` follows the operator's own selectors from the resource down to its StatefulSet, pods, PVCs, Jobs and events, and names the Kubernetes-level cause.
+
+```
+$ kubectl neo4j diagnose -n neo4j
+Neo4jEnterpriseCluster/prod — Pending · 2/3 pods ready
+  ✗ pod prod-server-2 — cannot be scheduled
+      0/3 nodes are available: 3 Insufficient memory.
+      → No node can satisfy the pod. Compare spec.resources.requests with node
+        capacity (kubectl describe nodes), or check that the PVC's StorageClass can
+        provision in the zones the nodes are in. Neo4j Enterprise will not start
+        below 1.5Gi of memory, so lowering the request has a floor.
+
+1 of 3 resource(s) have problems.
+For an archive to attach to an issue: kubectl neo4j support-bundle
+```
+
+## What it looks at
+
+| Symptom | Where it comes from |
+|---|---|
+| Pod cannot be scheduled | `PodScheduled=False`, reason `Unschedulable` — the scheduler's own message |
+| Container OOMKilled | `lastState.terminated` reason, **or** exit code 137 |
+| Image will not pull | waiting reason `ImagePullBackOff` / `ErrImagePull` / `InvalidImageName` |
+| Crash-looping | waiting reason `CrashLoopBackOff`, with the restart count |
+| Config not resolvable | waiting reason `CreateContainerConfigError` — usually a missing Secret key |
+| PVC never bound | `pvc.status.phase != Bound`, naming the StorageClass |
+| No pods at all | a StatefulSet that wants replicas but has none |
+| Backup Job failed | the Job's `Failed` condition, plus its pods |
+| Nothing ever reconciled | a CR with no status at all after two minutes |
+| Operator warnings | the three most recent `Warning` events on the resource |
+
+That last-but-one row is worth calling out. A resource with **no status at all** has no other signal — nothing is broken, the CR simply sits there. That is what you see when the operator is not running, has no RBAC for the kind, or is namespace-scoped and not watching this namespace.
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | nothing wrong, or only things that may still resolve on their own |
+| `1` | a problem was found |
+| `2` | usage error, or the cluster could not be reached |
+
+Things marked `…` — a readiness probe that has not passed yet — are printed but **do not** change the exit code. Neo4j Enterprise takes tens of seconds to open Bolt on first start, and a command that failed during a normal startup would be useless in the loop the exit code exists for.
+
+## Why this does not go stale
+
+Every rule is anchored to a fact the Kubernetes API defines. Where client-go exports a constant it is used — `PodScheduled`, `PodReasonUnschedulable`, `ClaimBound` — so an upstream rename fails the build rather than silently matching nothing. The three kubelet-owned reasons that have no constant (`CrashLoopBackOff`, `ImagePullBackOff`, `OOMKilled`) are matched as literals, and OOM is additionally matched on exit code 137 so the most common Enterprise failure does not rest on a string alone.
+
+Workloads are found through the operator's **own exported selectors**, not a label scheme restated here — the same discipline that has `validate` call the operator's own validators.
+
+## See also
+
+- [`status`](status.md) — what is deployed and which resources need attention
+- [`explain`](explain.md) — decode the operator's own conditions and phases
+- [`support-bundle`](support-bundle.md) — package the same evidence for an issue
+- [Troubleshooting](../guides/troubleshooting.md) — the long-form knowledge

--- a/docs/user_guide/cli/index.md
+++ b/docs/user_guide/cli/index.md
@@ -23,6 +23,7 @@ The second reason is volume. The troubleshooting guide documents 98 separate `ku
 |---|---|
 | [`validate`](validate.md) | Check manifests against the operator's validators, before applying |
 | [`status`](status.md) | One view of every Neo4j resource in a namespace |
+| [`diagnose`](diagnose.md) | Why a resource is unhealthy, at the Kubernetes level |
 | [`connect` and `cypher`](connect.md) | Reach a deployment, or open a `cypher-shell` session |
 | [`support-bundle`](support-bundle.md) | Collect a redacted diagnostic archive |
 | [`explain`](explain.md) | Decode a status condition or phase, and what to do about it |

--- a/internal/controller/neo4jbackup_controller.go
+++ b/internal/controller/neo4jbackup_controller.go
@@ -801,9 +801,7 @@ func backupTargetName(backup *neo4jv1beta1.Neo4jBackup) string {
 // backupLabels returns the standard label set for a Neo4jBackup workload, ready to
 // be applied identically at the CronJob/Job level and both template levels.
 func backupLabels(backup *neo4jv1beta1.Neo4jBackup, component string) map[string]string {
-	return map[string]string{
-		"app.kubernetes.io/name":       "neo4j-backup",
-		"app.kubernetes.io/instance":   backup.Name,
+	labels := map[string]string{
 		"app.kubernetes.io/component":  component,
 		"app.kubernetes.io/managed-by": "neo4j-operator",
 		// part-of identifies the chain root — same value for every CR
@@ -813,6 +811,13 @@ func backupLabels(backup *neo4jv1beta1.Neo4jBackup, component string) map[string
 		"app.kubernetes.io/part-of": chainRoot(backup),
 		"neo4j.com/backup-target":   backupTargetName(backup),
 	}
+	// The name/instance pair is owned by resources.BackupJobSelector so that
+	// selecting these workloads from outside the reconciler cannot drift from
+	// what is stamped on them here.
+	for k, v := range resources.BackupJobSelector(backup.Name) {
+		labels[k] = v
+	}
+	return labels
 }
 
 // ensureTempStagingPVC creates a PVC for temporary staging if tempStorage is configured.

--- a/internal/controller/neo4jbackup_selector_test.go
+++ b/internal/controller/neo4jbackup_selector_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2025 Priyo Lahiri.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+// Contract test for resources.BackupJobSelector, in the same spirit as
+// internal/resources/cluster_selectors_test.go: a selector that consumers use
+// to FIND a workload must be a subset of the labels the producer STAMPS on it.
+//
+// It lives in this package rather than next to the other selector tests
+// because backupLabels is unexported here, and asserting against a copy of it
+// would test the copy rather than the contract.
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	neo4jv1beta1 "github.com/priyolahiri/neo4j-kubernetes-operator/api/v1beta1"
+	"github.com/priyolahiri/neo4j-kubernetes-operator/internal/resources"
+)
+
+func TestBackupJobSelector_IsSubsetOfBackupLabels(t *testing.T) {
+	backup := &neo4jv1beta1.Neo4jBackup{
+		ObjectMeta: metav1.ObjectMeta{Name: "nightly", Namespace: "neo4j"},
+		Spec:       neo4jv1beta1.Neo4jBackupSpec{InstanceRef: "prod"},
+	}
+
+	// Every component the controller stamps must remain selectable: the Job,
+	// its pod template, and the CronJob for a scheduled backup.
+	for _, component := range []string{"backup", "cronjob", "cleanup"} {
+		labels := backupLabels(backup, component)
+		for k, v := range resources.BackupJobSelector(backup.Name) {
+			assert.Equal(t, v, labels[k],
+				"BackupJobSelector key %q must match backupLabels(%q)", k, component)
+		}
+	}
+}
+
+// Guards the shape of the mistake that #68 made for server pods: a selector
+// keyed on a derived name rather than the CR name matches nothing, and a
+// consumer silently reports "no workload found" instead of the real failure.
+func TestBackupJobSelector_UsesCRNameNotDerivedName(t *testing.T) {
+	sel := resources.BackupJobSelector("nightly")
+	assert.Equal(t, "nightly", sel["app.kubernetes.io/instance"])
+	assert.Equal(t, "neo4j-backup", sel["app.kubernetes.io/name"])
+}

--- a/internal/resources/cluster.go
+++ b/internal/resources/cluster.go
@@ -1110,6 +1110,22 @@ func StandalonePodSelector(standaloneName string) map[string]string {
 
 // PVCSelectorByInstance returns labels that match every PVC of a given
 // Enterprise or Standalone instance. Must stay in sync with GetLabelsForPVC.
+// BackupJobSelector returns labels that match the Jobs, CronJobs and Pods a
+// Neo4jBackup owns. Must stay in sync with backupLabels in
+// internal/controller/neo4jbackup_controller.go, which builds on it; the
+// contract is asserted in cluster_selectors_test.go.
+//
+// It lives here rather than in the controller package so that consumers
+// outside the reconciler — kubectl-neo4j's `diagnose`, which correlates a
+// failed backup CR with the Job that failed — can select the workload without
+// restating the label scheme, and without importing the controller package.
+func BackupJobSelector(backupName string) map[string]string {
+	return map[string]string{
+		"app.kubernetes.io/name":     "neo4j-backup",
+		"app.kubernetes.io/instance": backupName,
+	}
+}
+
 func PVCSelectorByInstance(instanceName string) map[string]string {
 	return map[string]string{
 		"app.kubernetes.io/name":     "neo4j",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -143,6 +143,7 @@ nav:
       - Installing the CLI: user_guide/cli/install.md
       - validate: user_guide/cli/validate.md
       - status: user_guide/cli/status.md
+      - diagnose: user_guide/cli/diagnose.md
       - connect & cypher: user_guide/cli/connect.md
       - support-bundle: user_guide/cli/support-bundle.md
       - explain: user_guide/cli/explain.md


### PR DESCRIPTION
## Why

`status` reads custom resources and `explain` decodes the operator's own condition vocabulary. But the failure taxonomy in `guides/troubleshooting.md` is dominated by things one layer **below** the CR: pods that will not schedule, containers OOMKilled at 1Gi, image pulls that fail, PVCs that never bind. For all of those `status` reports "Pending / not ready" and hands the user back to a 98-line runbook to work out which it was.

`diagnose` reads the CR, follows the operator's own selectors to the workload it built, and names the Kubernetes-level cause with the action to take.

```
$ kubectl neo4j diagnose -n neo4j
Neo4jEnterpriseCluster/prod — Pending · 2/3 pods ready
  ✗ pod prod-server-2 — cannot be scheduled
      0/3 nodes are available: 3 Insufficient memory.
      → No node can satisfy the pod. Compare spec.resources.requests with node
        capacity (kubectl describe nodes), or check that the PVC's StorageClass can
        provision in the zones the nodes are in. Neo4j Enterprise will not start
        below 1.5Gi of memory, so lowering the request has a floor.

1 of 3 resource(s) have problems.
For an archive to attach to an issue: kubectl neo4j support-bundle
```

## Anchored so it cannot drift into confident wrongness

This is the command §4.4 flagged as most at risk of B3 drift, and it gets the same structural answer `explain` used, transposed to the other side:

- Where client-go **exports a constant it is used** — `PodScheduled`, `PodReasonUnschedulable`, `ClaimBound` — so an upstream rename fails this build rather than silently matching nothing.
- The three kubelet-owned reasons with no constant (`CrashLoopBackOff`, `ImagePullBackOff`, `OOMKilled`) are matched as literals, and OOM is **also** matched on exit code 137, so the most common Enterprise failure does not rest on a string alone.
- Workloads are located through the operator's **exported selectors**, not a label scheme restated in the CLI — the discipline that has `validate` call the operator's own validators.

`resources.BackupJobSelector` is added for that last point and `backupLabels` now builds on it, with a contract test pinning the subset relation the way `cluster_selectors_test.go` does for server pods.

## Two reporting decisions carried over

- A readiness probe that has not passed yet is reported (`…`) but does **not** set the failure exit code. Neo4j Enterprise takes tens of seconds to open Bolt on first start; a command that failed during normal startup would be useless in the loop the exit code exists for.
- A resource the operator has **never written status to** is reported explicitly. That silence is the only signal a user gets when the operator is not running, lacks RBAC for the kind, or is namespace-scoped and not watching this namespace (#282).

## Exit codes

`0` nothing wrong · `1` problem found · `2` could not run.

## Test plan

- [x] `make test-unit` green
- [x] `make check-drift` green
- [x] New table tests cover each rule, the exit-code contract, and the rendered output
- [x] Contract test fails if `backupLabels` and `BackupJobSelector` diverge

Part of a series adding `diagnose`, `preflight` and `export` — see `docs/design/cli-tool.md` §8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)