### PR TITLE
feat(cli): export replica-database — the paste the operator cannot do for you

### DIFF
--- a/cmd/kubectl-neo4j/export.go
+++ b/cmd/kubectl-neo4j/export.go
@@ -1,0 +1,341 @@
+/*
+Copyright 2025 Priyo Lahiri.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+// export authors the downstream CR whose input lives in an upstream CR's
+// status, on a DIFFERENT Kubernetes cluster.
+//
+// # Why this exists, and why it is narrow
+//
+// Several status fields on this operator's CRs exist purely to be pasted into
+// another resource's spec — Neo4jBackup.status.replicationPullURI is declared
+// with the comment that assembling it by hand "is the single most likely thing
+// for a user to get wrong, so the operator publishes it instead".
+//
+// Within ONE Kubernetes cluster the operator has already closed that loop
+// itself: Neo4jReplicaDatabase.spec.source.upstreamBackupRef resolves the pull
+// URI live, and upstreamClusterRef resolves network addresses live. Rebuilding
+// either here would be redundant, and worse than redundant — a generated
+// literal goes stale the moment the upstream changes, where a ref does not.
+//
+// What neither ref can do is cross a cluster boundary. Both resolve through a
+// Get against their own API server, and the CRD says so in as many words: for
+// an upstream on a different Kubernetes cluster, "paste it from that CR's own
+// status by hand". That paste is what this command replaces, and it is the
+// whole of its scope.
+//
+// The manifest goes to stdout and nothing else does, so it can be redirected
+// into a file or piped into `kubectl apply --context other-cluster` without
+// stripping anything. Notes and warnings go to stderr.
+//
+// Every manifest is run through the operator's OWN ReplicaValidator before it
+// is printed. A command that emitted something `validate` would then reject
+// would be worse than no command.
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+
+	neo4jv1beta1 "github.com/priyolahiri/neo4j-kubernetes-operator/api/v1beta1"
+	"github.com/priyolahiri/neo4j-kubernetes-operator/internal/validation"
+)
+
+func runExport(args []string, stdout, stderr *os.File) int {
+	if len(args) == 0 {
+		fmt.Fprint(stderr, exportUsage)
+		return exitUsage
+	}
+	switch args[0] {
+	case "replica-database":
+		return runExportReplicaDatabase(args[1:], stdout, stderr)
+	case "-h", "--help", "help":
+		fmt.Fprint(stdout, exportUsage)
+		return exitOK
+	default:
+		fmt.Fprintf(stderr, "unknown export target %q\n\n%s", args[0], exportUsage)
+		return exitUsage
+	}
+}
+
+const exportUsage = `Author a downstream manifest from an upstream resource's status.
+
+Usage:
+  kubectl neo4j export replica-database <name> --from-backup <backup> [flags]
+  kubectl neo4j export replica-database <name> --from-cluster <cluster> [flags]
+
+For a downstream on a DIFFERENT Kubernetes cluster, where the operator's own
+upstreamBackupRef / upstreamClusterRef cannot resolve. On the same cluster,
+prefer those refs — they stay correct when the upstream changes.
+
+Run "kubectl neo4j export replica-database -h" for flags.
+`
+
+func runExportReplicaDatabase(args []string, stdout, stderr *os.File) int {
+	fs := flag.NewFlagSet("export replica-database", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fromBackup := fs.String("from-backup", "", "Upstream Neo4jBackup to read status.replicationPullURI from (backup mode)")
+	fromCluster := fs.String("from-cluster", "", "Upstream Neo4jEnterpriseCluster to read replication addresses from (network mode)")
+	clusterRef := fs.String("cluster-ref", "", "Downstream cluster or standalone that will host the replica (required)")
+	upstreamDatabase := fs.String("upstream-database", "", "Database name on the upstream (required)")
+	downstreamNamespace := fs.String("downstream-namespace", "", "Namespace to write into the manifest (default: the source namespace)")
+	seedFromLatest := fs.Bool("seed-from-latest", false, "Also set source.seedURI from the newest successful backup run")
+	namespace := fs.String("namespace", "", "Namespace of the upstream resource")
+	kubeContext := fs.String("context", "", "Kubeconfig context to use")
+	kubeconfig := fs.String("kubeconfig", "", "Path to the kubeconfig file")
+	fs.Usage = func() {
+		fmt.Fprint(stderr, `Author a Neo4jReplicaDatabase for a downstream on another Kubernetes cluster.
+
+Usage:
+  kubectl neo4j export replica-database <name> --from-backup <backup> \
+      --cluster-ref <downstream> --upstream-database <db> [-n <namespace>]
+
+Reads the upstream's status in THIS cluster and writes the manifest to stdout,
+ready to redirect to a file or pipe into kubectl against the other cluster:
+
+  kubectl neo4j export replica-database dr-copy --from-backup nightly \
+      --cluster-ref dr --upstream-database neo4j > replica.yaml
+
+Only stdout carries the manifest; notes and warnings go to stderr.
+
+The result is checked against the operator's own ReplicaValidator before it is
+printed, so it cannot emit something "kubectl neo4j validate" would reject.
+
+Flags:
+`)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+
+	name := fs.Arg(0)
+	switch {
+	case name == "":
+		fmt.Fprint(stderr, "error: a name for the replica database is required\n\n")
+		fs.Usage()
+		return exitUsage
+	case *fromBackup == "" && *fromCluster == "":
+		fmt.Fprintln(stderr, "error: one of --from-backup or --from-cluster is required")
+		return exitUsage
+	case *fromBackup != "" && *fromCluster != "":
+		fmt.Fprintln(stderr, "error: --from-backup and --from-cluster are mutually exclusive —")
+		fmt.Fprintln(stderr, "  backup mode pulls from object storage, network mode connects to the upstream.")
+		return exitUsage
+	case *clusterRef == "":
+		fmt.Fprintln(stderr, "error: --cluster-ref is required — it names the downstream cluster that will host the replica")
+		return exitUsage
+	case *upstreamDatabase == "":
+		fmt.Fprintln(stderr, "error: --upstream-database is required — it names the database on the upstream")
+		return exitUsage
+	}
+
+	c, err := newClusterClient(*kubeconfig, *kubeContext)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: could not connect to the cluster: %v\n", err)
+		return exitUsage
+	}
+	ns := *namespace
+	if ns == "" {
+		ns = currentNamespace(*kubeconfig, *kubeContext)
+	}
+	outNS := *downstreamNamespace
+	if outNS == "" {
+		outNS = ns
+	}
+
+	ctx := context.Background()
+	var replica *neo4jv1beta1.Neo4jReplicaDatabase
+	var notes []string
+
+	if *fromBackup != "" {
+		replica, notes, err = replicaFromBackup(ctx, c, ns, outNS, name, *fromBackup, *clusterRef, *upstreamDatabase, *seedFromLatest)
+	} else {
+		replica, notes, err = replicaFromCluster(ctx, c, ns, outNS, name, *fromCluster, *clusterRef, *upstreamDatabase)
+	}
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return exitUsage
+	}
+
+	// Validated with the operator's own validator, against the SAME client, so
+	// the manifest this prints is one the operator would accept.
+	result := validation.NewReplicaValidator(c).Validate(ctx, replica)
+	for _, w := range result.Warnings {
+		notes = append(notes, "warning: "+w)
+	}
+	if len(result.Errors) > 0 {
+		fmt.Fprintln(stderr, "error: the manifest this would produce does not validate:")
+		for _, e := range result.Errors {
+			fmt.Fprintf(stderr, "  ✗ %s: %s\n", e.Field, e.ErrorBody())
+		}
+		fmt.Fprintln(stderr, "  Nothing was written. This is a bug in the CLI or a gap in the upstream's status —")
+		fmt.Fprintln(stderr, "  please report it with the upstream resource's status attached.")
+		return exitInvalid
+	}
+
+	body, err := yaml.Marshal(replica)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return exitUsage
+	}
+	fmt.Fprint(stdout, string(body))
+
+	for _, n := range notes {
+		fmt.Fprintln(stderr, n)
+	}
+	return exitOK
+}
+
+// replicaFromBackup builds a backup-mode replica from an upstream Neo4jBackup's
+// published pull URI.
+func replicaFromBackup(ctx context.Context, c client.Client, ns, outNS, name, backupName, clusterRef, upstreamDatabase string, seedFromLatest bool) (*neo4jv1beta1.Neo4jReplicaDatabase, []string, error) {
+	var backup neo4jv1beta1.Neo4jBackup
+	if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: backupName}, &backup); err != nil {
+		return nil, nil, fmt.Errorf("reading Neo4jBackup %s/%s: %w", ns, backupName, err)
+	}
+
+	pullURI := backup.Status.ReplicationPullURI
+	if pullURI == "" {
+		return nil, nil, fmt.Errorf(
+			"Neo4jBackup %s/%s has not published status.replicationPullURI.\n"+
+				"  That field is populated only when spec.mode is \"replication-source\", and only\n"+
+				"  after a run has completed. Check the backup's mode and that it has run at least once",
+			ns, backupName)
+	}
+
+	replica := newReplicaSkeleton(name, outNS, clusterRef, upstreamDatabase)
+	replica.Spec.Source.Mode = "backup"
+	replica.Spec.Source.PullURI = pullURI
+
+	notes := []string{
+		fmt.Sprintf("source.pullURI taken from Neo4jBackup %s/%s status.replicationPullURI", ns, backupName),
+	}
+	if cloud := backup.Spec.Storage.Cloud; cloud != nil && cloud.CredentialsSecretRef != "" {
+		notes = append(notes, fmt.Sprintf(
+			"note: the upstream reads its bucket with Secret %q. The DOWNSTREAM cluster needs its own\n"+
+				"      credentials for the same bucket — set source.credentialsSecretRef there, or bind a\n"+
+				"      workload identity. This command cannot copy a Secret between clusters.",
+			cloud.CredentialsSecretRef))
+	}
+
+	if seedFromLatest {
+		artifact, err := latestArtifact(&backup)
+		if err != nil {
+			return nil, nil, err
+		}
+		replica.Spec.Source.SeedURI = strings.TrimSuffix(pullURI, "/") + "/" + artifact
+		notes = append(notes, fmt.Sprintf(
+			"source.seedURI built from the newest successful run's artifact %q, joined onto the pull URI", artifact))
+	}
+	return replica, notes, nil
+}
+
+// latestArtifact finds the newest successful run's artifact filename. It never
+// guesses: a run whose filename was not captured (the operator parses it out of
+// the Job's pod log, which can fail) is skipped rather than reconstructed, and
+// running out of candidates is an error.
+func latestArtifact(backup *neo4jv1beta1.Neo4jBackup) (string, error) {
+	runs := make([]neo4jv1beta1.BackupRun, 0, len(backup.Status.History))
+	for _, r := range backup.Status.History {
+		if strings.EqualFold(r.Status, "Completed") || strings.EqualFold(r.Status, "Succeeded") {
+			runs = append(runs, r)
+		}
+	}
+	sort.Slice(runs, func(i, j int) bool { return runs[j].StartTime.Before(&runs[i].StartTime) })
+
+	for _, r := range runs {
+		if r.ArtifactFilename != "" {
+			return r.ArtifactFilename, nil
+		}
+	}
+	return "", fmt.Errorf(
+		"--seed-from-latest: no successful run in status.history carries an artifactFilename.\n" +
+			"  The operator parses that name out of the backup Job's pod log, so it can be empty\n" +
+			"  even for a run that succeeded. Set source.seedURI by hand, or omit the flag —\n" +
+			"  a replica can seed from the chain in pullURI alone")
+}
+
+// replicaFromCluster builds a network-mode replica from an upstream cluster's
+// published addresses.
+func replicaFromCluster(ctx context.Context, c client.Client, ns, outNS, name, clusterName, clusterRef, upstreamDatabase string) (*neo4jv1beta1.Neo4jReplicaDatabase, []string, error) {
+	var upstream neo4jv1beta1.Neo4jEnterpriseCluster
+	if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: clusterName}, &upstream); err != nil {
+		return nil, nil, fmt.Errorf("reading Neo4jEnterpriseCluster %s/%s: %w", ns, clusterName, err)
+	}
+
+	replica := newReplicaSkeleton(name, outNS, clusterRef, upstreamDatabase)
+	replica.Spec.Source.Mode = "network"
+
+	ccr := upstream.Status.CrossClusterReplication
+	switch {
+	case ccr != nil && len(ccr.Addresses) > 0:
+		replica.Spec.Source.Addresses = ccr.Addresses
+		notes := []string{fmt.Sprintf(
+			"source.addresses taken from %s/%s status.crossClusterReplication.addresses", ns, clusterName)}
+		if !ccr.Ready {
+			notes = append(notes, "warning: the upstream's cross-cluster proxy does not report Ready yet.\n"+
+				"         These addresses may not route until it does.")
+		}
+		return replica, notes, nil
+
+	case len(upstream.Status.InternalAddresses) > 0:
+		// Emitting these is still useful — a downstream in another NAMESPACE on
+		// the same cluster can use them — but they are in-cluster DNS names, so
+		// saying nothing here would hand someone an manifest that silently
+		// cannot connect from a genuinely separate cluster.
+		replica.Spec.Source.Addresses = upstream.Status.InternalAddresses
+		return replica, []string{
+			fmt.Sprintf("source.addresses taken from %s/%s status.internalAddresses", ns, clusterName),
+			"warning: these are IN-CLUSTER addresses. They resolve across namespaces on this\n" +
+				"         Kubernetes cluster, but NOT from a separate one.\n" +
+				"         For a genuinely separate cluster, set spec.crossClusterReplication.enabled\n" +
+				"         on the upstream and re-run this once its proxy reports Ready.\n" +
+				"         For a downstream on THIS cluster, prefer source.upstreamClusterRef, which\n" +
+				"         stays correct when the upstream's addresses change.",
+		}, nil
+
+	default:
+		return nil, nil, fmt.Errorf(
+			"Neo4jEnterpriseCluster %s/%s publishes no replication addresses.\n"+
+				"  status.internalAddresses is populated once the cluster is running;\n"+
+				"  status.crossClusterReplication.addresses needs spec.crossClusterReplication.enabled",
+			ns, clusterName)
+	}
+}
+
+func newReplicaSkeleton(name, ns, clusterRef, upstreamDatabase string) *neo4jv1beta1.Neo4jReplicaDatabase {
+	return &neo4jv1beta1.Neo4jReplicaDatabase{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: neo4jv1beta1.GroupVersion.String(),
+			Kind:       "Neo4jReplicaDatabase",
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: neo4jv1beta1.Neo4jReplicaDatabaseSpec{
+			ClusterRef:       clusterRef,
+			UpstreamDatabase: upstreamDatabase,
+		},
+	}
+}

--- a/cmd/kubectl-neo4j/export_test.go
+++ b/cmd/kubectl-neo4j/export_test.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2025 Priyo Lahiri.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	neo4jv1beta1 "github.com/priyolahiri/neo4j-kubernetes-operator/api/v1beta1"
+	"github.com/priyolahiri/neo4j-kubernetes-operator/internal/validation"
+)
+
+func replicationBackup(name string, runs ...neo4jv1beta1.BackupRun) *neo4jv1beta1.Neo4jBackup {
+	return &neo4jv1beta1.Neo4jBackup{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "neo4j"},
+		Spec: neo4jv1beta1.Neo4jBackupSpec{
+			InstanceRef: "prod",
+			Storage: neo4jv1beta1.StorageLocation{
+				Type: "s3", Bucket: "prod-backups",
+				Cloud: &neo4jv1beta1.CloudBlock{Provider: "aws", CredentialsSecretRef: "cloud-creds"},
+			},
+		},
+		Status: neo4jv1beta1.Neo4jBackupStatus{
+			ReplicationPullURI: "s3://prod-backups/nightly-chain/",
+			History:            runs,
+		},
+	}
+}
+
+// The whole point: the pull URI comes out of the upstream's status, not out of
+// the user's head. The CRD says assembling it by hand is the single most likely
+// thing to get wrong.
+func TestExport_ReplicaFromBackupTakesPullURIFromStatus(t *testing.T) {
+	c := testClient(t, replicationBackup("nightly"))
+
+	replica, notes, err := replicaFromBackup(context.Background(), c, "neo4j", "neo4j",
+		"dr-copy", "nightly", "dr", "neo4j", false)
+	require.NoError(t, err)
+
+	assert.Equal(t, "s3://prod-backups/nightly-chain/", replica.Spec.Source.PullURI)
+	assert.Equal(t, "backup", replica.Spec.Source.Mode)
+	assert.Equal(t, "dr", replica.Spec.ClusterRef)
+	assert.Equal(t, "neo4j", replica.Spec.UpstreamDatabase)
+	assert.Empty(t, replica.Spec.Source.SeedURI, "seedURI is opt-in")
+
+	joined := strings.Join(notes, "\n")
+	assert.Contains(t, joined, "status.replicationPullURI")
+	// Credentials cannot cross a cluster boundary, and silently emitting a
+	// manifest that references a Secret which does not exist there would be a
+	// trap.
+	assert.Contains(t, joined, "cloud-creds")
+	assert.Contains(t, joined, "DOWNSTREAM")
+}
+
+// A backup that is not a replication source has nothing to publish, and the
+// error has to say why rather than emitting an empty pullURI.
+func TestExport_BackupWithoutPullURIIsAClearError(t *testing.T) {
+	c := testClient(t, &neo4jv1beta1.Neo4jBackup{
+		ObjectMeta: metav1.ObjectMeta{Name: "nightly", Namespace: "neo4j"},
+		Spec:       neo4jv1beta1.Neo4jBackupSpec{InstanceRef: "prod"},
+	})
+
+	_, _, err := replicaFromBackup(context.Background(), c, "neo4j", "neo4j",
+		"dr-copy", "nightly", "dr", "neo4j", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "replication-source")
+}
+
+func TestExport_SeedFromLatestPicksNewestSuccessfulRun(t *testing.T) {
+	older := neo4jv1beta1.BackupRun{
+		RunID: "1", Status: "Completed", ArtifactFilename: "neo4j-2026-08-01T01-00-00.backup",
+		StartTime: metav1.NewTime(time.Now().Add(-48 * time.Hour)),
+	}
+	newer := neo4jv1beta1.BackupRun{
+		RunID: "2", Status: "Completed", ArtifactFilename: "neo4j-2026-08-02T01-00-00.backup",
+		StartTime: metav1.NewTime(time.Now().Add(-24 * time.Hour)),
+	}
+	failed := neo4jv1beta1.BackupRun{
+		RunID: "3", Status: "Failed", ArtifactFilename: "neo4j-2026-08-03T01-00-00.backup",
+		StartTime: metav1.NewTime(time.Now()),
+	}
+
+	c := testClient(t, replicationBackup("nightly", older, newer, failed))
+	replica, notes, err := replicaFromBackup(context.Background(), c, "neo4j", "neo4j",
+		"dr-copy", "nightly", "dr", "neo4j", true)
+	require.NoError(t, err)
+
+	assert.Equal(t, "s3://prod-backups/nightly-chain/neo4j-2026-08-02T01-00-00.backup",
+		replica.Spec.Source.SeedURI, "the newest SUCCESSFUL run wins, and the URI is joined once")
+	assert.Contains(t, strings.Join(notes, "\n"), "newest successful run")
+}
+
+// The operator parses the artifact name out of a pod log, so it can be missing
+// on a run that genuinely succeeded. Reconstructing it would be a guess.
+func TestExport_SeedFromLatestRefusesToGuessAMissingArtifact(t *testing.T) {
+	run := neo4jv1beta1.BackupRun{
+		RunID: "1", Status: "Completed", StartTime: metav1.NewTime(time.Now()),
+	}
+	c := testClient(t, replicationBackup("nightly", run))
+
+	_, _, err := replicaFromBackup(context.Background(), c, "neo4j", "neo4j",
+		"dr-copy", "nightly", "dr", "neo4j", true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "artifactFilename")
+	assert.Contains(t, err.Error(), "by hand")
+}
+
+func TestExport_ReplicaFromClusterPrefersCrossClusterAddresses(t *testing.T) {
+	c := testClient(t, &neo4jv1beta1.Neo4jEnterpriseCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "prod", Namespace: "neo4j"},
+		Status: neo4jv1beta1.Neo4jEnterpriseClusterStatus{
+			InternalAddresses: []string{"prod-server-0.prod-headless.neo4j.svc.cluster.local:6000"},
+			CrossClusterReplication: &neo4jv1beta1.CrossClusterReplicationStatus{
+				Ready:     true,
+				Addresses: []string{"ccr.example.com:6000"},
+			},
+		},
+	})
+
+	replica, notes, err := replicaFromCluster(context.Background(), c, "neo4j", "neo4j",
+		"dr-copy", "prod", "dr", "neo4j")
+	require.NoError(t, err)
+
+	assert.Equal(t, "network", replica.Spec.Source.Mode)
+	assert.Equal(t, []string{"ccr.example.com:6000"}, replica.Spec.Source.Addresses)
+	assert.Contains(t, strings.Join(notes, "\n"), "crossClusterReplication.addresses")
+}
+
+// The trap this command must not set: in-cluster DNS names handed to someone
+// building a genuinely separate cluster.
+func TestExport_InternalAddressesCarryAnUnmissableWarning(t *testing.T) {
+	c := testClient(t, &neo4jv1beta1.Neo4jEnterpriseCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "prod", Namespace: "neo4j"},
+		Status: neo4jv1beta1.Neo4jEnterpriseClusterStatus{
+			InternalAddresses: []string{"prod-server-0.prod-headless.neo4j.svc.cluster.local:6000"},
+		},
+	})
+
+	replica, notes, err := replicaFromCluster(context.Background(), c, "neo4j", "neo4j",
+		"dr-copy", "prod", "dr", "neo4j")
+	require.NoError(t, err)
+
+	assert.Len(t, replica.Spec.Source.Addresses, 1)
+	joined := strings.Join(notes, "\n")
+	assert.Contains(t, joined, "IN-CLUSTER addresses")
+	assert.Contains(t, joined, "NOT from a separate one")
+	// And it must point at the better same-cluster answer rather than leaving
+	// the user with a literal that goes stale.
+	assert.Contains(t, joined, "upstreamClusterRef")
+}
+
+func TestExport_ClusterWithNoAddressesIsAClearError(t *testing.T) {
+	c := testClient(t, &neo4jv1beta1.Neo4jEnterpriseCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "prod", Namespace: "neo4j"},
+	})
+	_, _, err := replicaFromCluster(context.Background(), c, "neo4j", "neo4j",
+		"dr-copy", "prod", "dr", "neo4j")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "crossClusterReplication.enabled")
+}
+
+// The property that makes generation safe: what it emits is what the operator
+// accepts. Asserted by running the operator's own validator over the result.
+func TestExport_OutputPassesTheOperatorsOwnValidator(t *testing.T) {
+	c := testClient(t, replicationBackup("nightly"))
+
+	replica, _, err := replicaFromBackup(context.Background(), c, "neo4j", "neo4j",
+		"dr-copy", "nightly", "dr", "neo4j", false)
+	require.NoError(t, err)
+
+	res := validation.NewReplicaValidator(c).Validate(context.Background(), replica)
+	assert.Empty(t, res.Errors, "generated manifests must pass kubectl neo4j validate")
+}
+
+// Cross-namespace targeting: the manifest is for another cluster, so its
+// namespace need not match the source's.
+func TestExport_DownstreamNamespaceIsIndependentOfTheSource(t *testing.T) {
+	c := testClient(t, replicationBackup("nightly"))
+	replica, _, err := replicaFromBackup(context.Background(), c, "neo4j", "dr-namespace",
+		"dr-copy", "nightly", "dr", "neo4j", false)
+	require.NoError(t, err)
+	assert.Equal(t, "dr-namespace", replica.Namespace)
+}
+
+// TypeMeta must be set: a manifest without apiVersion/kind cannot be applied,
+// and objects read back from a typed client do not carry it.
+func TestExport_ManifestCarriesAPIVersionAndKind(t *testing.T) {
+	r := newReplicaSkeleton("dr-copy", "neo4j", "dr", "neo4j")
+	assert.Equal(t, "Neo4jReplicaDatabase", r.Kind)
+	assert.Equal(t, neo4jv1beta1.GroupVersion.String(), r.APIVersion)
+}

--- a/cmd/kubectl-neo4j/main.go
+++ b/cmd/kubectl-neo4j/main.go
@@ -54,6 +54,7 @@ Commands:
   cypher      Open a cypher-shell session against a deployment
   support-bundle  Collect a redacted diagnostic archive
   explain     Explain a status condition or phase, and what to do about it
+  export      Author a downstream manifest from an upstream resource's status
   version     Print the version
 
 Run "kubectl neo4j <command> -h" for command flags.
@@ -87,6 +88,8 @@ func run(args []string, stdout, stderr *os.File) int {
 		return runSupportBundle(args[1:], stdout, stderr)
 	case "explain":
 		return runExplain(args[1:], stdout, stderr)
+	case "export":
+		return runExport(args[1:], stdout, stderr)
 	case "version":
 		fmt.Fprintln(stdout, version)
 		return exitOK

--- a/docs/user_guide/cli/export.md
+++ b/docs/user_guide/cli/export.md
@@ -1,0 +1,71 @@
+# `export`
+
+Authors a downstream manifest whose input lives in an **upstream resource's status** — for a downstream on a *different* Kubernetes cluster.
+
+```bash
+kubectl neo4j export replica-database dr-copy \
+    --from-backup nightly --cluster-ref dr --upstream-database neo4j > replica.yaml
+
+kubectl neo4j export replica-database dr-copy \
+    --from-cluster prod --cluster-ref dr --upstream-database neo4j > replica.yaml
+```
+
+## Why it is this narrow
+
+Several status fields on this operator's CRs exist purely to be pasted into another resource's spec. `Neo4jBackup.status.replicationPullURI` is declared with the comment that assembling it by hand *"is the single most likely thing for a user to get wrong, so the operator publishes it instead."*
+
+Within **one** Kubernetes cluster the operator already closes that loop itself:
+
+- `Neo4jReplicaDatabase.spec.source.upstreamBackupRef` resolves the pull URI live from the upstream `Neo4jBackup`
+- `spec.source.upstreamClusterRef` resolves network addresses live from the upstream cluster's `status.internalAddresses`
+
+**Prefer those refs on the same cluster.** They stay correct when the upstream changes; a generated literal does not.
+
+What neither can do is cross a cluster boundary — both resolve through a `Get` against their own API server, and the CRD says so in as many words: for an upstream on a different Kubernetes cluster, *"paste it from that CR's own status by hand."* That paste is what this command replaces, and it is the whole of its scope.
+
+## What it emits
+
+A `Neo4jReplicaDatabase` manifest on **stdout**, and nothing else — so it can be redirected to a file or piped into `kubectl apply --context other-cluster` without stripping anything. Notes and warnings go to stderr.
+
+```
+$ kubectl neo4j export replica-database dr-copy --from-backup nightly \
+      --cluster-ref dr --upstream-database neo4j
+apiVersion: neo4j.neo4j.com/v1beta1
+kind: Neo4jReplicaDatabase
+metadata:
+  name: dr-copy
+  namespace: neo4j
+spec:
+  clusterRef: dr
+  upstreamDatabase: neo4j
+  source:
+    mode: backup
+    pullURI: s3://prod-backups/nightly-chain/
+```
+
+with, on stderr:
+
+```
+source.pullURI taken from Neo4jBackup neo4j/nightly status.replicationPullURI
+note: the upstream reads its bucket with Secret "cloud-creds". The DOWNSTREAM cluster
+      needs its own credentials for the same bucket — set source.credentialsSecretRef
+      there, or bind a workload identity. This command cannot copy a Secret between
+      clusters.
+```
+
+### `--seed-from-latest`
+
+Off by default. When set, `source.seedURI` is built by joining the newest **successful** run's `artifactFilename` onto the pull URI. If no successful run carries one — the operator parses that name out of the Job's pod log, so it can be missing even on a run that worked — the command **fails rather than reconstructs it**. A replica can seed from the chain in `pullURI` alone.
+
+### Network mode and the in-cluster trap
+
+`--from-cluster` prefers `status.crossClusterReplication.addresses`, which are routable off-cluster. If only `status.internalAddresses` exist, it emits them **with a warning**: those are in-cluster DNS names that resolve across namespaces on one Kubernetes cluster and not from a separate one. The warning names both fixes — enable `spec.crossClusterReplication` on the upstream for a real second cluster, or use `upstreamClusterRef` if the downstream is on this one after all.
+
+## Validated by construction
+
+Every manifest is run through the operator's **own `ReplicaValidator`** before it is printed. A command that emitted something [`validate`](validate.md) would then reject would be worse than no command — so if validation fails, nothing is written and the failure is reported as a bug worth filing.
+
+## See also
+
+- [`validate`](validate.md) — the same validators, run against manifests you wrote
+- [Cross-Cluster Replication](../guides/cross_cluster_replication.md) — when you need the proxy, and why

--- a/docs/user_guide/cli/index.md
+++ b/docs/user_guide/cli/index.md
@@ -28,6 +28,7 @@ The second reason is volume. The troubleshooting guide documents 98 separate `ku
 | [`connect` and `cypher`](connect.md) | Reach a deployment, or open a `cypher-shell` session |
 | [`support-bundle`](support-bundle.md) | Collect a redacted diagnostic archive |
 | [`explain`](explain.md) | Decode a status condition or phase, and what to do about it |
+| [`export`](export.md) | Author a downstream manifest from an upstream resource's status |
 
 Start with [Installing the CLI](install.md).
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -148,6 +148,7 @@ nav:
       - connect & cypher: user_guide/cli/connect.md
       - support-bundle: user_guide/cli/support-bundle.md
       - explain: user_guide/cli/explain.md
+      - export: user_guide/cli/export.md
 
   - Operate:
       - Backup & Restore: user_guide/guides/backup_restore.md


### PR DESCRIPTION
## Why, and why it is much narrower than the design assumed

§1.1 counted **five status fields that exist solely to be pasted into another resource's spec** and read that as a CLI-shaped gap. `Neo4jBackup.status.replicationPullURI` even says so in its own doc comment — assembling it by hand is *"the single most likely thing for a user to get wrong, so the operator publishes it instead."*

Re-reading the CRDs while building this showed the operator had **already closed most of that gap itself**:

- `source.upstreamBackupRef` resolves the pull URI live from the upstream `Neo4jBackup`
- `source.upstreamClusterRef` resolves network addresses live from the upstream cluster

Generating a literal where a ref exists would be redundant — and *worse* than redundant, because the literal goes stale the moment the upstream changes, where a ref does not. **So this does not do that.** The docs point same-cluster users back at the refs.

What no ref can do is cross a cluster boundary: both resolve through a `Get` against their own API server, and the CRD says as much, telling you to *"paste it from that CR's own status by hand"* for an upstream on a different Kubernetes cluster. **That paste is the entire scope of this command.**

## What it does

```
$ kubectl neo4j export replica-database dr-copy --from-backup nightly \
      --cluster-ref dr --upstream-database neo4j
apiVersion: neo4j.neo4j.com/v1beta1
kind: Neo4jReplicaDatabase
metadata:
  name: dr-copy
  namespace: neo4j
spec:
  clusterRef: dr
  upstreamDatabase: neo4j
  source:
    mode: backup
    pullURI: s3://prod-backups/nightly-chain/
```

with, on stderr:

```
source.pullURI taken from Neo4jBackup neo4j/nightly status.replicationPullURI
note: the upstream reads its bucket with Secret "cloud-creds". The DOWNSTREAM cluster
      needs its own credentials for the same bucket — set source.credentialsSecretRef
      there, or bind a workload identity. This command cannot copy a Secret between
      clusters.
```

## Three properties worth keeping if this pattern is extended

- **The manifest is the only thing on stdout.** Notes and warnings go to stderr, so `> replica.yaml` or a pipe into `kubectl apply --context other-cluster` stays clean.
- **It is validated by construction.** Every manifest is run through the operator's own `ReplicaValidator` before printing. A generator that emitted something `validate` would then reject would be worse than no generator — so a validation failure writes nothing and reports itself as a bug worth filing.
- **It refuses to guess.** `--seed-from-latest` is opt-in, and a successful run whose `artifactFilename` the operator could not parse out of the pod log is an **error**, not a reconstructed path.

## The trap it is careful not to set

`--from-cluster` prefers `status.crossClusterReplication.addresses`, which route off-cluster. When only `status.internalAddresses` exist it still emits them — a downstream in another *namespace* can use them — but **with a warning** that they are in-cluster DNS names, naming both fixes: enable `spec.crossClusterReplication` on the upstream for a genuinely separate cluster, or use `upstreamClusterRef` if the downstream is on this one after all.

## Test plan

- [x] `make test-unit`, `make lint` (full set) and `make check-drift` green
- [x] A test asserts the output passes the operator's own `ReplicaValidator`
- [x] Tests cover the in-cluster-address warning, the refusal to guess a missing artifact, and newest-successful-run selection

Follows #367 and #368. Design rationale recorded in `docs/design/cli-tool.md` §8 item 9, including the §1.1 correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)