### PR TITLE
fix(cli): register -n, which every command's help already promised

### DIFF
--- a/cmd/kubectl-neo4j/bundle.go
+++ b/cmd/kubectl-neo4j/bundle.go
@@ -56,7 +56,7 @@ type bundleFile struct {
 func runSupportBundle(args []string, stdout, stderr *os.File) int {
 	fs := flag.NewFlagSet("support-bundle", flag.ContinueOnError)
 	fs.SetOutput(stderr)
-	namespace := fs.String("namespace", "", "Namespace to collect from")
+	namespace := namespaceFlag(fs, "Namespace to collect from")
 	kubeContext := fs.String("context", "", "Kubeconfig context to use")
 	kubeconfig := fs.String("kubeconfig", "", "Path to the kubeconfig file")
 	out := fs.String("o", "", "Output file (default: neo4j-support-bundle-<timestamp>.tar.gz)")

--- a/cmd/kubectl-neo4j/connect.go
+++ b/cmd/kubectl-neo4j/connect.go
@@ -74,7 +74,7 @@ func (t target) cypherShellArgs(query string) string {
 func runCypher(args []string, stdout, stderr *os.File) int {
 	fs := flag.NewFlagSet("cypher", flag.ContinueOnError)
 	fs.SetOutput(stderr)
-	namespace := fs.String("namespace", "", "Namespace of the deployment")
+	namespace := namespaceFlag(fs, "Namespace of the deployment")
 	kubeContext := fs.String("context", "", "Kubeconfig context to use")
 	kubeconfig := fs.String("kubeconfig", "", "Path to the kubeconfig file")
 	query := fs.String("c", "", "Run a single query and exit, instead of opening an interactive session")
@@ -159,7 +159,7 @@ Flags:
 func runConnect(args []string, stdout, stderr *os.File) int {
 	fs := flag.NewFlagSet("connect", flag.ContinueOnError)
 	fs.SetOutput(stderr)
-	namespace := fs.String("namespace", "", "Namespace of the deployment")
+	namespace := namespaceFlag(fs, "Namespace of the deployment")
 	kubeContext := fs.String("context", "", "Kubeconfig context to use")
 	kubeconfig := fs.String("kubeconfig", "", "Path to the kubeconfig file")
 	fs.Usage = func() {

--- a/cmd/kubectl-neo4j/diagnose.go
+++ b/cmd/kubectl-neo4j/diagnose.go
@@ -124,7 +124,7 @@ func (d diagnosis) problems() bool {
 func runDiagnose(args []string, stdout, stderr *os.File) int {
 	fs := flag.NewFlagSet("diagnose", flag.ContinueOnError)
 	fs.SetOutput(stderr)
-	namespace := fs.String("namespace", "", "Namespace to inspect (default: the kubeconfig context's namespace)")
+	namespace := namespaceFlag(fs, "Namespace to inspect (default: the kubeconfig context's namespace)")
 	kubeContext := fs.String("context", "", "Kubeconfig context to use")
 	kubeconfig := fs.String("kubeconfig", "", "Path to the kubeconfig file")
 	quiet := fs.Bool("quiet", false, "Print only resources that have something to report")

--- a/cmd/kubectl-neo4j/explain.go
+++ b/cmd/kubectl-neo4j/explain.go
@@ -148,7 +148,7 @@ var phaseGuidance = map[string]guidance{
 func runExplain(args []string, stdout, stderr *os.File) int {
 	fs := flag.NewFlagSet("explain", flag.ContinueOnError)
 	fs.SetOutput(stderr)
-	namespace := fs.String("namespace", "", "Namespace of the resource")
+	namespace := namespaceFlag(fs, "Namespace of the resource")
 	kubeContext := fs.String("context", "", "Kubeconfig context to use")
 	kubeconfig := fs.String("kubeconfig", "", "Path to the kubeconfig file")
 	fs.Usage = func() {

--- a/cmd/kubectl-neo4j/export.go
+++ b/cmd/kubectl-neo4j/export.go
@@ -102,7 +102,7 @@ func runExportReplicaDatabase(args []string, stdout, stderr *os.File) int {
 	upstreamDatabase := fs.String("upstream-database", "", "Database name on the upstream (required)")
 	downstreamNamespace := fs.String("downstream-namespace", "", "Namespace to write into the manifest (default: the source namespace)")
 	seedFromLatest := fs.Bool("seed-from-latest", false, "Also set source.seedURI from the newest successful backup run")
-	namespace := fs.String("namespace", "", "Namespace of the upstream resource")
+	namespace := namespaceFlag(fs, "Namespace of the upstream resource")
 	kubeContext := fs.String("context", "", "Kubeconfig context to use")
 	kubeconfig := fs.String("kubeconfig", "", "Path to the kubeconfig file")
 	fs.Usage = func() {

--- a/cmd/kubectl-neo4j/flags.go
+++ b/cmd/kubectl-neo4j/flags.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2025 Priyo Lahiri.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "flag"
+
+// namespaceFlag registers --namespace together with -n, the short form every
+// kubectl user reaches for first.
+//
+// The standard library's flag package has no concept of a short alias, so the
+// two names are registered separately against one variable. Before this
+// existed, every command's usage text read "-n <namespace>" while only the long
+// form actually parsed — the command printed its own help in response to the
+// documented invocation, which is a particularly annoying way to be wrong.
+func namespaceFlag(fs *flag.FlagSet, usage string) *string {
+	var ns string
+	fs.StringVar(&ns, "namespace", "", usage)
+	fs.StringVar(&ns, "n", "", "Short form of --namespace")
+	return &ns
+}

--- a/cmd/kubectl-neo4j/flags_test.go
+++ b/cmd/kubectl-neo4j/flags_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2025 Priyo Lahiri.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNamespaceFlag_BothFormsBindTheSameVariable(t *testing.T) {
+	for _, arg := range []string{"-n", "--namespace", "-namespace"} {
+		fs := flag.NewFlagSet("t", flag.ContinueOnError)
+		fs.SetOutput(io.Discard)
+		ns := namespaceFlag(fs, "usage")
+		require.NoError(t, fs.Parse([]string{arg, "neo4j"}), arg)
+		assert.Equal(t, "neo4j", *ns, "%s must set the namespace", arg)
+	}
+}
+
+// Regression guard. Every command's usage text has always read "-n <namespace>",
+// but the short form was never registered, so the documented invocation was
+// answered with "flag provided but not defined: -n" and a help dump. The check
+// is per command because each builds its own FlagSet.
+func TestEveryCommandAcceptsShortNamespaceFlag(t *testing.T) {
+	commands := map[string]func([]string, *os.File, *os.File) int{
+		"status":         runStatus,
+		"diagnose":       runDiagnose,
+		"preflight":      runPreflight,
+		"explain":        runExplain,
+		"connect":        runConnect,
+		"cypher":         runCypher,
+		"support-bundle": runSupportBundle,
+		"validate":       runValidate,
+	}
+
+	for name, run := range commands {
+		t.Run(name, func(t *testing.T) {
+			stderr := captureStderr(t, func(f *os.File) {
+				// The command will fail on something else — no cluster, no
+				// input file — and that is fine. All this asserts is that it
+				// got PAST flag parsing.
+				run([]string{"-n", "neo4j"}, f, f)
+			})
+			assert.NotContains(t, stderr, "flag provided but not defined",
+				"%s does not accept -n", name)
+		})
+	}
+}
+
+func TestExportAcceptsShortNamespaceFlag(t *testing.T) {
+	stderr := captureStderr(t, func(f *os.File) {
+		runExport([]string{"replica-database", "dr", "-n", "neo4j"}, f, f)
+	})
+	assert.NotContains(t, stderr, "flag provided but not defined")
+}
+
+func captureStderr(t *testing.T, fn func(*os.File)) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "err")
+	require.NoError(t, err)
+	fn(f)
+	require.NoError(t, f.Close())
+	b, err := os.ReadFile(f.Name())
+	require.NoError(t, err)
+	return strings.ToLower(string(b))
+}

--- a/cmd/kubectl-neo4j/preflight.go
+++ b/cmd/kubectl-neo4j/preflight.go
@@ -90,7 +90,7 @@ func runPreflight(args []string, stdout, stderr *os.File) int {
 	fs.SetOutput(stderr)
 	var files multiFlag
 	fs.Var(&files, "f", "Manifest to check before applying (repeatable, '-' for stdin)")
-	namespace := fs.String("namespace", "", "Namespace the resources live in, or will be applied to")
+	namespace := namespaceFlag(fs, "Namespace the resources live in, or will be applied to")
 	kubeContext := fs.String("context", "", "Kubeconfig context to use")
 	kubeconfig := fs.String("kubeconfig", "", "Path to the kubeconfig file")
 	fs.Usage = func() {

--- a/cmd/kubectl-neo4j/status.go
+++ b/cmd/kubectl-neo4j/status.go
@@ -63,7 +63,7 @@ func (r resourceStatus) healthy() bool {
 func runStatus(args []string, stdout, stderr *os.File) int {
 	fs := flag.NewFlagSet("status", flag.ContinueOnError)
 	fs.SetOutput(stderr)
-	namespace := fs.String("namespace", "", "Namespace to inspect (default: the kubeconfig context's namespace)")
+	namespace := namespaceFlag(fs, "Namespace to inspect (default: the kubeconfig context's namespace)")
 	allNamespaces := fs.Bool("all-namespaces", false, "Inspect every namespace")
 	kubeContext := fs.String("context", "", "Kubeconfig context to use")
 	kubeconfig := fs.String("kubeconfig", "", "Path to the kubeconfig file")

--- a/cmd/kubectl-neo4j/validate.go
+++ b/cmd/kubectl-neo4j/validate.go
@@ -234,7 +234,7 @@ func runValidate(args []string, stdout, stderr *os.File) int {
 	connect := fs.Bool("connect", false, "Connect to the cluster in the current kubeconfig context to run cross-reference checks")
 	kubeContext := fs.String("context", "", "Kubeconfig context to use (implies --connect)")
 	kubeconfig := fs.String("kubeconfig", "", "Path to the kubeconfig file (implies --connect)")
-	namespace := fs.String("namespace", "", "Namespace for objects whose manifest omits one")
+	namespace := namespaceFlag(fs, "Namespace for objects whose manifest omits one")
 	fs.Usage = func() {
 		fmt.Fprint(stderr, `Validate Neo4j CR manifests against the operator's own validators.
 


### PR DESCRIPTION
## The bug

Every command's usage text has read `-n <namespace>` since the CLI shipped, but only `--namespace` was ever registered. The standard library's `flag` package has no concept of a short alias, and nothing bound one — so the **documented invocation** was answered with:

```
$ kubectl neo4j status -n default
flag provided but not defined: -n
Show the state of every Neo4j resource in a namespace.
...
```

The command printing its own usage in response to the usage it printed. `-n` is the first thing any kubectl user reaches for.

Affects every pre-existing command — `status`, `explain`, `connect`, `cypher`, `support-bundle`, `validate` — as well as the three just added.

## How it surfaced, which is the interesting part

Not by any test. By running the built binary.

Every existing test calls the collect/render functions directly (`collectStatus`, `renderStatus`, `diagnoseNamespace`), and **none went through argument parsing** — so the entire flag surface was untested. That gap is now covered.

## The fix

`namespaceFlag` registers both names against one variable, and is used by all nine flag sets. A per-command test asserts each one gets past flag parsing with `-n`, so a command added later that hand-rolls its own namespace flag fails here rather than in a user's terminal.

## Test plan

- [x] `TestNamespaceFlag_BothFormsBindTheSameVariable` — `-n`, `--namespace` and `-namespace` all bind
- [x] `TestEveryCommandAcceptsShortNamespaceFlag` — per-command, asserts no "flag provided but not defined"
- [x] Verified against the built binary: `./bin/kubectl-neo4j status -n default` now reaches the connection stage instead of dumping help
- [x] `make test-unit` and `make lint` green

Follows #367, #368, #369.

🤖 Generated with [Claude Code](https://claude.com/claude-code)